### PR TITLE
cargo build failing (vibe-kanban)

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -67,7 +67,6 @@ async fn main() -> Result<()> {
         } else {
             tracing::info!("Starting stdio transport in stateless mode");
             let service = StatelessService::new()
-                .await
                 .serve(stdio())
                 .await
                 .inspect_err(|e| {
@@ -96,7 +95,6 @@ async fn main() -> Result<()> {
         } else {
             tracing::info!("Starting stdio transport in stateful mode");
             let service = StatefulService::new(heap_storage)
-                .await
                 .serve(stdio())
                 .await
                 .inspect_err(|e| {
@@ -115,7 +113,6 @@ async fn http_handler_stateless(req: Request<Incoming>) -> Result<hyper::Respons
     tokio::spawn(async move {
         let upgraded = hyper::upgrade::on(req).await?;
         let service = StatelessService::new()
-            .await
             .serve(TokioIo::new(upgraded))
             .await?;
         service.waiting().await?;
@@ -159,7 +156,6 @@ async fn http_handler_stateful(req: Request<Incoming>, heap_storage: AnyHeapStor
     tokio::spawn(async move {
         let upgraded = hyper::upgrade::on(req).await?;
         let service = StatefulService::new(heap_storage)
-            .await
             .serve(TokioIo::new(upgraded))
             .await?;
         service.waiting().await?;

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -156,7 +156,7 @@ impl IntoContents for RunJsStatelessResponse {
 // Stateless service implementation
 #[tool(tool_box)]
 impl StatelessService {
-    pub async fn new() -> Self {
+    pub fn new() -> Self {
         Self
     }
 
@@ -180,7 +180,7 @@ impl StatelessService {
 // Stateful service implementation
 #[tool(tool_box)]
 impl StatefulService {
-    pub async fn new(heap_storage: AnyHeapStorage) -> Self {
+    pub fn new(heap_storage: AnyHeapStorage) -> Self {
         Self { heap_storage }
     }
 


### PR DESCRIPTION
#15 [builder 6/6] RUN cd server && cargo build --release
#15 0.138     Updating crates.io index
#15 0.257     Updating git repository `https://github.com/modelcontextprotocol/rust-sdk`
#15 1.625  Downloading crates ...
#15 1.723   Downloaded atomic-waker v1.1.2
#15 1.726   Downloaded anyhow v1.0.98
#15 1.733   Downloaded anstyle-query v1.1.2
#15 1.735   Downloaded futures-task v0.3.31
#15 1.737   Downloaded anstyle v1.0.10
#15 1.739   Downloaded anstyle-parse v0.2.6
#15 1.742   Downloaded adler v1.0.2
#15 1.744   Downloaded aho-corasick v1.1.3
#15 1.752   Downloaded anstream v0.6.18
#15 1.756   Downloaded miniz_oxide v0.7.4
#15 1.762   Downloaded nu-ansi-term v0.46.0
#15 1.769   Downloaded axum-core v0.5.2
#15 1.773   Downloaded thiserror-impl v1.0.69
#15 1.776   Downloaded aws-sigv4 v0.0.26-alpha
#15 1.779   Downloaded num-integer v0.1.46
#15 1.782   Downloaded num-traits v0.2.19
#15 1.786   Downloaded mio v1.0.3
#15 1.796   Downloaded tracing-subscriber v0.3.19
#15 1.808   Downloaded aws-smithy-query v0.30.0-alpha
#15 1.810   Downloaded aws-smithy-client v0.30.0-alpha
#15 1.813   Downloaded xmlparser v0.13.3
#15 1.817   Downloaded minimal-lexical v0.2.1
#15 1.825   Downloaded itoa v1.0.15
#15 1.828   Downloaded log v0.4.27
#15 1.832   Downloaded http-body v0.4.6
#15 1.836   Downloaded md5 v0.7.0
#15 1.837   Downloaded futures-core v0.3.31
#15 1.840   Downloaded cexpr v0.6.0
#15 1.843   Downloaded tower-layer v0.3.3
#15 1.845   Downloaded itoa v0.4.8
#15 1.847   Downloaded libloading v0.8.7
#15 1.852   Downloaded memchr v2.7.4
#15 1.861   Downloaded matchit v0.8.4
#15 1.865   Downloaded http v1.3.1
#15 1.871   Downloaded serde_derive v1.0.219
#15 1.875   Downloaded indexmap v2.9.0
#15 1.881   Downloaded h2 v0.4.12
#15 1.890   Downloaded time-macros v0.2.22
#15 1.893   Downloaded hyper v0.14.32
#15 1.903   Downloaded futures-util v0.3.31
#15 1.922   Downloaded tower-service v0.3.3
#15 1.924   Downloaded quote v1.0.40
#15 1.928   Downloaded tracing-core v0.1.33
#15 1.933   Downloaded thread_local v1.1.8
#15 1.935   Downloaded rand_chacha v0.9.0
#15 1.937   Downloaded unicode-ident v1.0.18
#15 1.942   Downloaded zerocopy v0.8.27
#15 1.981   Downloaded zeroize v1.8.1
#15 1.984   Downloaded which v6.0.3
#15 1.987   Downloaded tracing-log v0.2.0
#15 1.990   Downloaded uuid v1.18.1
#15 1.995   Downloaded pin-project-internal v1.1.10
#15 1.997   Downloaded tower v0.5.2
#15 2.013   Downloaded tokio-stream v0.1.17
#15 2.020   Downloaded sharded-slab v0.1.7
#15 2.025   Downloaded tokio-util v0.6.10
#15 2.033   Downloaded sct v0.6.1
#15 2.040   Downloaded rustversion v1.0.20
#15 2.044   Downloaded syn v2.0.101
#15 2.058   Downloaded proc-macro2 v1.0.95
#15 2.062   Downloaded prettyplease v0.2.32
#15 2.067   Downloaded regex-automata v0.4.9
#15 2.087   Downloaded powerfmt v0.2.0
#15 2.089   Downloaded regex v1.11.1
#15 2.107   Downloaded rustix v0.38.44
#15 2.144   Downloaded rand v0.9.2
#15 2.149   Downloaded percent-encoding v2.3.1
#15 2.150   Downloaded overload v0.1.1
#15 2.152   Downloaded once_cell v1.21.3
#15 2.156   Downloaded regex-syntax v0.8.5
#15 2.165   Downloaded webpki v0.21.4
#15 2.173   Downloaded untrusted v0.7.1
#15 2.175   Downloaded time-core v0.1.4
#15 2.177   Downloaded thiserror-impl v2.0.12
#15 2.179   Downloaded libc v0.2.172
#15 2.213   Downloaded thiserror v2.0.12
#15 2.223   Downloaded tokio v1.45.0
#15 2.277   Downloaded sync_wrapper v1.0.2
#15 2.279   Downloaded strsim v0.11.1
#15 2.281   Downloaded smallvec v1.15.0
#15 2.284   Downloaded serde_urlencoded v0.7.1
#15 2.287   Downloaded serde_path_to_error v0.1.17
#15 2.289   Downloaded semver v1.0.26
#15 2.292   Downloaded rustc_version v0.4.1
#15 2.294   Downloaded rustc-hash v2.1.1
#15 2.296   Downloaded pin-utils v0.1.0
#15 2.298   Downloaded openssl-probe v0.1.6
#15 2.300   Downloaded want v0.3.1
#15 2.301   Downloaded utf8parse v0.2.2
#15 2.302   Downloaded urlencoding v1.3.3
#15 2.304   Downloaded try-lock v0.2.5
#15 2.305   Downloaded tracing-attributes v0.1.28
#15 2.308   Downloaded socket2 v0.5.9
#15 2.311   Downloaded shlex v1.3.0
#15 2.313   Downloaded serde_json v1.0.140
#15 2.323   Downloaded pin-project v1.1.10
#15 2.343   Downloaded tower v0.4.13
#15 2.358   Downloaded nom v7.1.3
#15 2.364   Downloaded tracing v0.1.41
#15 2.370   Downloaded tokio-util v0.7.15
#15 2.379   Downloaded tokio-rustls v0.22.0
#15 2.382   Downloaded tokio-macros v2.5.0
#15 2.383   Downloaded serde_derive_internals v0.29.1
#15 2.385   Downloaded thiserror v1.0.69
#15 2.393   Downloaded signal-hook-registry v1.4.6
#15 2.395   Downloaded schemars_derive v0.8.22
#15 2.398   Downloaded schemars v0.8.22
#15 2.418   Downloaded ryu v1.0.20
#15 2.423   Downloaded ppv-lite86 v0.2.21
#15 2.425   Downloaded chrono v0.4.41
#15 2.434   Downloaded mime v0.3.17
#15 2.436   Downloaded bindgen v0.71.1
#15 2.444   Downloaded spin v0.5.2
#15 2.446   Downloaded serde v1.0.219
#15 2.450   Downloaded paste v1.0.15
#15 2.455   Downloaded num-conv v0.1.0
#15 2.456   Downloaded h2 v0.3.26
#15 2.465   Downloaded slab v0.4.9
#15 2.467   Downloaded itertools v0.13.0
#15 2.476   Downloaded aws-config v0.0.26-alpha
#15 2.482   Downloaded clap_builder v4.5.38
#15 2.491   Downloaded base64 v0.21.7
#15 2.496   Downloaded hashbrown v0.15.3
#15 2.502   Downloaded hyper-util v0.1.11
#15 2.508   Downloaded hyper v1.6.0
#15 2.517   Downloaded cc v1.2.22
#15 2.522   Downloaded bytes v1.10.1
#15 2.527   Downloaded base64 v0.13.1
#15 2.531   Downloaded futures v0.3.31
#15 2.539   Downloaded clap v4.5.38
#15 2.552   Downloaded clang-sys v1.8.1
#15 2.555   Downloaded hyper-rustls v0.22.1
#15 2.558   Downloaded http v0.2.12
#15 2.563   Downloaded futures-executor v0.3.31
#15 2.565   Downloaded rustls-native-certs v0.5.0
#15 2.568   Downloaded fastrand v1.9.0
#15 2.570   Downloaded colorchoice v1.0.3
#15 2.571   Downloaded clap_derive v4.5.32
#15 2.574   Downloaded bytes-utils v0.1.4
#15 2.576   Downloaded bitflags v2.9.0
#15 2.582   Downloaded autocfg v1.4.0
#15 2.585   Downloaded lazy_static v1.5.0
#15 2.588   Downloaded heck v0.5.0
#15 2.590   Downloaded linux-raw-sys v0.4.15
#15 2.646   Downloaded futures-sink v0.3.31
#15 2.647   Downloaded futures-io v0.3.31
#15 2.649   Downloaded clap_lex v0.7.4
#15 2.650   Downloaded cfg-if v1.0.0
#15 2.652   Downloaded futures-macro v0.3.31
#15 2.653   Downloaded aws-endpoint v0.0.26-alpha
#15 2.655   Downloaded crc32fast v1.4.2
#15 2.657   Downloaded fnv v1.0.7
#15 2.658   Downloaded iana-time-zone v0.1.63
#15 2.662   Downloaded http-body-util v0.1.3
#15 2.665   Downloaded futures-channel v0.3.31
#15 2.667   Downloaded fslock v0.2.1
#15 2.670   Downloaded errno v0.3.11
#15 2.672   Downloaded dyn-clone v1.0.19
#15 2.675   Downloaded axum v0.8.4
#15 2.687   Downloaded aws-hyper v0.0.26-alpha
#15 2.688   Downloaded is_terminal_polyfill v1.70.1
#15 2.690   Downloaded httpdate v1.0.3
#15 2.691   Downloaded httparse v1.10.1
#15 2.695   Downloaded http-body v1.0.1
#15 2.696   Downloaded hex v0.4.3
#15 2.699   Downloaded getrandom v0.3.4
#15 2.704   Downloaded form_urlencoded v1.2.1
#15 2.705   Downloaded equivalent v1.0.2
#15 2.707   Downloaded deranged v0.4.0
#15 2.709   Downloaded ct-logs v0.8.0
#15 2.711   Downloaded aws-sdk-sts v0.0.26-alpha
#15 2.715   Downloaded home v0.5.11
#15 2.716   Downloaded gzip-header v1.0.0
#15 2.718   Downloaded glob v0.3.2
#15 2.720   Downloaded either v1.15.0
#15 2.722   Downloaded aws-smithy-types v0.30.0-alpha
#15 2.726   Downloaded aws-sdk-s3 v0.0.26-alpha
#15 2.738   Downloaded aws-smithy-http-tower v0.30.0-alpha
#15 2.740   Downloaded aws-smithy-http v0.30.0-alpha
#15 2.742   Downloaded aws-sig-auth v0.0.26-alpha
#15 2.744   Downloaded time v0.3.41
#15 2.755   Downloaded rustls v0.19.1
#15 2.767   Downloaded pin-project-lite v0.2.16
#15 2.775   Downloaded aws-types v0.0.26-alpha
#15 2.777   Downloaded aws-smithy-json v0.30.0-alpha
#15 2.779   Downloaded aws-smithy-eventstream v0.30.0-alpha
#15 2.782   Downloaded aws-smithy-async v0.30.0-alpha
#15 2.783   Downloaded aws-smithy-xml v0.30.0-alpha
#15 2.785   Downloaded aws-http v0.0.26-alpha
#15 2.786   Downloaded async-trait v0.1.88
#15 2.792   Downloaded rand_core v0.9.3
#15 2.797   Downloaded ring v0.16.20
#15 3.000   Downloaded v8 v136.0.0
#15 4.670    Compiling proc-macro2 v1.0.95
#15 4.670    Compiling unicode-ident v1.0.18
#15 4.670    Compiling libc v0.2.172
#15 4.671    Compiling autocfg v1.4.0
#15 4.739    Compiling bytes v1.10.1
#15 5.046    Compiling pin-project-lite v0.2.16
#15 5.091    Compiling once_cell v1.21.3
#15 5.268    Compiling quote v1.0.40
#15 5.447    Compiling syn v2.0.101
#15 5.487    Compiling itoa v1.0.15
#15 5.573    Compiling memchr v2.7.4
#15 5.688    Compiling futures-core v0.3.31
#15 5.710    Compiling log v0.4.27
#15 5.776    Compiling socket2 v0.5.9
#15 5.908    Compiling signal-hook-registry v1.4.6
#15 6.581    Compiling mio v1.0.3
#15 6.744    Compiling futures-sink v0.3.31
#15 6.799    Compiling slab v0.4.9
#15 6.855    Compiling fnv v1.0.7
#15 6.902    Compiling tracing-core v0.1.33
#15 7.069    Compiling futures-channel v0.3.31
#15 7.257    Compiling pin-utils v0.1.0
#15 7.295    Compiling futures-task v0.3.31
#15 7.301    Compiling futures-io v0.3.31
#15 7.409    Compiling shlex v1.3.0
#15 7.424    Compiling num-traits v0.2.19
#15 7.505    Compiling ryu v1.0.20
#15 7.532    Compiling cfg-if v1.0.0
#15 7.778    Compiling powerfmt v0.2.0
#15 7.928    Compiling tower-service v0.3.3
#15 7.965    Compiling httparse v1.10.1
#15 7.971    Compiling deranged v0.4.0
#15 8.167    Compiling cc v1.2.22
#15 8.537    Compiling time-core v0.1.4
#15 8.601    Compiling num-conv v0.1.0
#15 8.700    Compiling num-integer v0.1.46
#15 8.745    Compiling time v0.3.41
#15 9.513    Compiling ring v0.16.20
#15 9.655    Compiling itoa v0.4.8
#15 9.753    Compiling httpdate v1.0.3
#15 10.09    Compiling http v0.2.12
#15 10.20    Compiling tokio-macros v2.5.0
#15 10.68    Compiling tokio v1.45.0
#15 12.32    Compiling futures-macro v0.3.31
#15 12.93    Compiling futures-util v0.3.31
#15 14.73    Compiling tracing-attributes v0.1.28
#15 14.87    Compiling aws-smithy-types v0.30.0-alpha
#15 15.83    Compiling tracing v0.1.41
#15 15.87    Compiling spin v0.5.2
#15 15.96    Compiling untrusted v0.7.1
#15 16.03    Compiling percent-encoding v2.3.1
#15 16.21    Compiling tokio-util v0.7.15
#15 16.22    Compiling hashbrown v0.15.3
#15 16.88    Compiling equivalent v1.0.2
#15 16.92    Compiling indexmap v2.9.0
#15 17.20    Compiling try-lock v0.2.5
#15 17.26    Compiling semver v1.0.26
#15 17.42    Compiling want v0.3.1
#15 17.53    Compiling http-body v0.4.6
#15 17.69    Compiling h2 v0.3.26
#15 17.73    Compiling pin-project-internal v1.1.10
#15 18.68    Compiling crc32fast v1.4.2
#15 18.89    Compiling aws-smithy-eventstream v0.30.0-alpha
#15 19.34    Compiling pin-project v1.1.10
#15 19.62    Compiling tower-layer v0.3.3
#15 19.69    Compiling either v1.15.0
#15 19.84    Compiling bytes-utils v0.1.4
#15 19.85    Compiling rustc_version v0.4.1
#15 20.06    Compiling sct v0.6.1
#15 20.11    Compiling tokio-util v0.6.10
#15 20.22    Compiling aws-types v0.0.26-alpha
#15 20.33    Compiling webpki v0.21.4
#15 20.62    Compiling form_urlencoded v1.2.1
#15 20.82    Compiling aws-smithy-async v0.30.0-alpha
#15 20.94    Compiling aho-corasick v1.1.3
#15 21.14    Compiling serde v1.0.219
#15 21.29    Compiling regex-syntax v0.8.5
#15 25.07    Compiling hyper v0.14.32
#15 27.64    Compiling base64 v0.13.1
#15 27.69    Compiling regex-automata v0.4.9
#15 27.95    Compiling rustls v0.19.1
#15 29.53    Compiling aws-smithy-http v0.30.0-alpha
#15 31.38    Compiling serde_derive v1.0.219
#15 32.57    Compiling lazy_static v1.5.0
#15 32.61    Compiling glob v0.3.2
#15 33.10    Compiling zeroize v1.8.1
#15 33.26    Compiling thiserror v1.0.69
#15 34.31    Compiling clang-sys v1.8.1
#15 34.50    Compiling regex v1.11.1
#15 35.95    Compiling thiserror-impl v1.0.69
#15 37.03    Compiling http v1.3.1
#15 37.23    Compiling getrandom v0.3.4
#15 37.41    Compiling prettyplease v0.2.32
#15 37.51    Compiling openssl-probe v0.1.6
#15 37.72    Compiling rustls-native-certs v0.5.0
#15 38.06    Compiling http-body v1.0.1
#15 38.92    Compiling tokio-rustls v0.22.0
#15 39.05    Compiling ct-logs v0.8.0
#15 39.07    Compiling tower v0.4.13
#15 40.20    Compiling bitflags v2.9.0
#15 40.30    Compiling minimal-lexical v0.2.1
#15 40.35    Compiling zerocopy v0.8.27
#15 40.49    Compiling hex v0.4.3
#15 40.57    Compiling rustix v0.38.44
#15 40.72    Compiling nom v7.1.3
#15 40.75    Compiling aws-sigv4 v0.0.26-alpha
#15 40.90    Compiling aws-smithy-http-tower v0.30.0-alpha
#15 41.07    Compiling hyper-rustls v0.22.1
#15 41.48    Compiling libloading v0.8.7
#15 41.61    Compiling rustversion v1.0.20
#15 41.80    Compiling smallvec v1.15.0
#15 41.99    Compiling bindgen v0.71.1
#15 42.12    Compiling linux-raw-sys v0.4.15
#15 42.30    Compiling fastrand v1.9.0
#15 42.50    Compiling serde_json v1.0.140
#15 42.60    Compiling aws-smithy-client v0.30.0-alpha
#15 42.92    Compiling cexpr v0.6.0
#15 43.58    Compiling aws-sig-auth v0.0.26-alpha
#15 44.36    Compiling itertools v0.13.0
#15 45.37    Compiling aws-endpoint v0.0.26-alpha
#15 45.49    Compiling aws-http v0.0.26-alpha
#15 45.90    Compiling adler v1.0.2
#15 45.97    Compiling home v0.5.11
#15 46.16    Compiling sync_wrapper v1.0.2
#15 46.20    Compiling utf8parse v0.2.2
#15 46.26    Compiling xmlparser v0.13.3
#15 46.72    Compiling rustc-hash v2.1.1
#15 46.78    Compiling paste v1.0.15
#15 46.94    Compiling aws-smithy-xml v0.30.0-alpha
#15 47.32    Compiling anstyle-parse v0.2.6
#15 47.46    Compiling which v6.0.3
#15 47.47    Compiling miniz_oxide v0.7.4
#15 47.61    Compiling gzip-header v1.0.0
#15 47.64    Compiling aws-hyper v0.0.26-alpha
#15 47.75    Compiling ppv-lite86 v0.2.21
#15 48.39    Compiling hyper v1.6.0
#15 51.29    Compiling rand_core v0.9.3
#15 51.49    Compiling fslock v0.2.1
#15 51.63    Compiling http-body-util v0.1.3
#15 51.86    Compiling serde_derive_internals v0.29.1
#15 51.89    Compiling urlencoding v1.3.3
#15 52.05    Compiling colorchoice v1.0.3
#15 52.10    Compiling mime v0.3.17
#15 52.57    Compiling thiserror v2.0.12
#15 52.67    Compiling schemars v0.8.22
#15 52.72    Compiling anstyle-query v1.1.2
#15 52.74    Compiling anstyle v1.0.10
#15 52.76    Compiling is_terminal_polyfill v1.70.1
#15 52.80    Compiling schemars_derive v0.8.22
#15 52.82    Compiling v8 v136.0.0
#15 52.96    Compiling anstream v0.6.18
#15 53.42    Compiling axum-core v0.5.2
#15 53.43    Compiling aws-smithy-query v0.30.0-alpha
#15 53.59    Compiling rand_chacha v0.9.0
#15 53.87    Compiling hyper-util v0.1.11
#15 54.18    Compiling tower v0.5.2
#15 54.50    Compiling serde_urlencoded v0.7.1
#15 54.59    Compiling serde_path_to_error v0.1.17
#15 54.73    Compiling futures-executor v0.3.31
#15 55.03    Compiling thiserror-impl v2.0.12
#15 55.20    Compiling matchit v0.8.4
#15 55.73    Compiling clap_lex v0.7.4
#15 55.87    Compiling iana-time-zone v0.1.63
#15 56.02    Compiling dyn-clone v1.0.19
#15 56.10    Compiling anyhow v1.0.98
#15 56.13    Compiling overload v0.1.1
#15 56.17    Compiling strsim v0.11.1
#15 56.27    Compiling heck v0.5.0
#15 56.35    Compiling clap_builder v4.5.38
#15 56.42    Compiling clap_derive v4.5.32
#15 57.00    Compiling nu-ansi-term v0.46.0
#15 58.11    Compiling chrono v0.4.41
#15 62.10    Compiling axum v0.8.4
#15 63.19    Compiling futures v0.3.31
#15 63.23    Compiling rand v0.9.2
#15 63.95    Compiling aws-sdk-sts v0.0.26-alpha
#15 67.68    Compiling uuid v1.18.1
#15 68.19    Compiling sharded-slab v0.1.7
#15 68.62    Compiling tokio-stream v0.1.17
#15 68.85    Compiling aws-smithy-json v0.30.0-alpha
#15 68.94    Compiling rmcp-macros v0.1.5 (https://github.com/modelcontextprotocol/rust-sdk?branch=main#787cc015)
#15 69.05    Compiling thread_local v1.1.8
#15 69.31    Compiling tracing-log v0.2.0
#15 69.44    Compiling base64 v0.21.7
#15 69.64    Compiling md5 v0.7.0
#15 69.81    Compiling aws-sdk-s3 v0.0.26-alpha
#15 69.85    Compiling rmcp v0.1.5 (https://github.com/modelcontextprotocol/rust-sdk?branch=main#787cc015)
#15 74.58    Compiling tracing-subscriber v0.3.19
#15 78.22    Compiling aws-config v0.0.26-alpha
#15 83.81    Compiling clap v4.5.38
#15 84.54    Compiling async-trait v0.1.88
#15 102.6    Compiling server v0.1.0 (/app/server)
#15 102.8 error[E0277]: the trait bound `impl Future<Output = StatelessService>: rmcp::Service<RoleServer>` is not satisfied
#15 102.8    --> src/main.rs:229:16
#15 102.8     |
#15 102.8 229 |     sse_server.with_service(move || {
#15 102.8     |                ^^^^^^^^^^^^ the trait `ServerHandler` is not implemented for `impl Future<Output = StatelessService>`
#15 102.8     |
#15 102.8     = help: the following other types implement trait `ServerHandler`:
#15 102.8               StatefulService
#15 102.8               StatelessService
#15 102.8     = note: required for `impl Future<Output = StatelessService>` to implement `rmcp::Service<RoleServer>`
#15 102.8 note: required by a bound in `SseServer::with_service`
#15 102.8    --> /usr/local/cargo/git/checkouts/rust-sdk-773cd6d57c4837f3/787cc01/crates/rmcp/src/transport/sse_server.rs:266:12
#15 102.8     |
#15 102.8 264 |     pub fn with_service<S, F>(mut self, service_provider: F) -> CancellationToken
#15 102.8     |            ------------ required by a bound in this associated function
#15 102.8 265 |     where
#15 102.8 266 |         S: Service<RoleServer>,
#15 102.8     |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `SseServer::with_service`
#15 102.8 
#15 102.8 error[E0277]: the trait bound `impl Future<Output = StatefulService>: rmcp::Service<RoleServer>` is not satisfied
#15 102.8    --> src/main.rs:275:16
#15 102.8     |
#15 102.8 275 |     sse_server.with_service(move || {
#15 102.8     |                ^^^^^^^^^^^^ the trait `ServerHandler` is not implemented for `impl Future<Output = StatefulService>`
#15 102.8     |
#15 102.8     = help: the following other types implement trait `ServerHandler`:
#15 102.8               StatefulService
#15 102.8               StatelessService
#15 102.8     = note: required for `impl Future<Output = StatefulService>` to implement `rmcp::Service<RoleServer>`
#15 102.8 note: required by a bound in `SseServer::with_service`
#15 102.8    --> /usr/local/cargo/git/checkouts/rust-sdk-773cd6d57c4837f3/787cc01/crates/rmcp/src/transport/sse_server.rs:266:12
#15 102.8     |
#15 102.8 264 |     pub fn with_service<S, F>(mut self, service_provider: F) -> CancellationToken
#15 102.8     |            ------------ required by a bound in this associated function
#15 102.8 265 |     where
#15 102.8 266 |         S: Service<RoleServer>,
#15 102.8     |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `SseServer::with_service`
#15 102.8 
#15 103.1 For more information about this error, try `rustc --explain E0277`.
#15 103.1 error: could not compile `server` (bin "server") due to 2 previous errors
#15 ERROR: process "/bin/sh -c cd server && cargo build --release" did not complete successfully: exit code: 101
------
 > [builder 6/6] RUN cd server && cargo build --release:
102.8    --> /usr/local/cargo/git/checkouts/rust-sdk-773cd6d57c4837f3/787cc01/crates/rmcp/src/transport/sse_server.rs:266:12
102.8     |
102.8 264 |     pub fn with_service<S, F>(mut self, service_provider: F) -> CancellationToken
102.8     |            ------------ required by a bound in this associated function
102.8 265 |     where
102.8 266 |         S: Service<RoleServer>,
102.8     |            ^^^^^^^^^^^^^^^^^^^ required by this bound in `SseServer::with_service`
102.8 
103.1 For more information about this error, try `rustc --explain E0277`.
103.1 error: could not compile `server` (bin "server") due to 2 previous errors
------
Dockerfile:21
--------------------
  19 |     
  20 |     # Build the release binary
  21 | >>> RUN cd server && cargo build --release
  22 |     
  23 |     # Runtime stage
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cd server && cargo build --release" did not complete successfully: exit code: 101
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c cd server && cargo build --release" did not complete successfully: exit code: 101