### PR TITLE
Add in-memory heap storage implementation

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 mod mcp;
 use mcp::{StatelessService, StatefulService, initialize_v8};
-use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage};
+use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage, MemoryHeapStorage};
 
 /// Command line arguments for configuring heap storage
 #[derive(Parser, Debug)]
@@ -21,15 +21,19 @@ use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage};
 struct Cli {
 
     /// S3 bucket name (required if --use-s3)
-    #[arg(long, conflicts_with_all = ["directory_path", "stateless"])]
+    #[arg(long, conflicts_with_all = ["directory_path", "stateless", "memory"])]
     s3_bucket: Option<String>,
 
     /// Directory path for filesystem storage (required if --use-filesystem)
-    #[arg(long, conflicts_with_all = ["s3_bucket", "stateless"])]
+    #[arg(long, conflicts_with_all = ["s3_bucket", "stateless", "memory"])]
     directory_path: Option<String>,
 
+    /// Use in-memory heap storage (volatile - data lost when process ends)
+    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path", "stateless"])]
+    memory: bool,
+
     /// Run in stateless mode - no heap snapshots are saved or loaded
-    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path"])]
+    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path", "memory"])]
     stateless: bool,
 
     /// HTTP port to listen on (if not specified, uses stdio transport)
@@ -81,6 +85,8 @@ async fn main() -> Result<()> {
             AnyHeapStorage::S3(S3HeapStorage::new(bucket).await)
         } else if let Some(dir) = cli.directory_path {
             AnyHeapStorage::File(FileHeapStorage::new(dir))
+        } else if cli.memory {
+            AnyHeapStorage::Memory(MemoryHeapStorage::new())
         } else {
             // default to file /tmp/mcp-v8-heaps
             AnyHeapStorage::File(FileHeapStorage::new("/tmp/mcp-v8-heaps"))

--- a/server/src/mcp/heap_storage.rs
+++ b/server/src/mcp/heap_storage.rs
@@ -5,6 +5,8 @@ use aws_sdk_s3::ByteStream;
 use aws_config;
 use std::sync::Arc;
 use async_trait::async_trait;
+use std::collections::HashMap;
+use tokio::sync::RwLock;
 
 #[async_trait]
 pub trait HeapStorage: Send + Sync + 'static {
@@ -98,11 +100,50 @@ impl HeapStorage for S3HeapStorage {
     }
 }
 
+/// In-memory heap storage using a thread-safe HashMap.
+/// Useful for testing or scenarios where persistence is not required beyond runtime.
+#[derive(Clone)]
+pub struct MemoryHeapStorage {
+    store: Arc<RwLock<HashMap<String, Vec<u8>>>>,
+}
+
+impl MemoryHeapStorage {
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+impl Default for MemoryHeapStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl HeapStorage for MemoryHeapStorage {
+    async fn put(&self, name: &str, data: &[u8]) -> Result<(), String> {
+        let mut store = self.store.write().await;
+        store.insert(name.to_string(), data.to_vec());
+        Ok(())
+    }
+    
+    async fn get(&self, name: &str) -> Result<Vec<u8>, String> {
+        let store = self.store.read().await;
+        store
+            .get(name)
+            .cloned()
+            .ok_or_else(|| format!("Heap '{}' not found in memory", name))
+    }
+}
+
 #[derive(Clone)]
 pub enum AnyHeapStorage {
     #[allow(dead_code)]
     File(FileHeapStorage),
     S3(S3HeapStorage),
+    Memory(MemoryHeapStorage),
 }
 
 
@@ -114,12 +155,14 @@ impl HeapStorage for AnyHeapStorage {
         match self {
             AnyHeapStorage::File(inner) => inner.put(name, data).await,
             AnyHeapStorage::S3(inner) => inner.put(name, data).await,
+            AnyHeapStorage::Memory(inner) => inner.put(name, data).await,
         }
     }
     async fn get(&self, name: &str) -> Result<Vec<u8>, String> {
         match self {
             AnyHeapStorage::File(inner) => inner.get(name).await,
             AnyHeapStorage::S3(inner) => inner.get(name).await,
+            AnyHeapStorage::Memory(inner) => inner.get(name).await,
         }
     }
 } 


### PR DESCRIPTION
- Created MemoryHeapStorage struct using Arc<RwLock<HashMap>>
- Added --memory CLI flag for in-memory heap storage option
- Memory storage is volatile (data lost when process ends)
- Useful for testing and scenarios without persistence requirements
- Updated AnyHeapStorage enum to include Memory variant
- Thread-safe implementation using tokio::sync::RwLock