### PR TITLE
Add in-memory heap storage implementation

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 mod mcp;
 use mcp::{StatelessService, StatefulService, initialize_v8};
-use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage};
+use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage, InMemoryHeapStorage};
 
 /// Command line arguments for configuring heap storage
 #[derive(Parser, Debug)]
@@ -21,15 +21,19 @@ use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage};
 struct Cli {
 
     /// S3 bucket name (required if --use-s3)
-    #[arg(long, conflicts_with_all = ["directory_path", "stateless"])]
+    #[arg(long, conflicts_with_all = ["directory_path", "stateless", "in_memory"])]
     s3_bucket: Option<String>,
 
     /// Directory path for filesystem storage (required if --use-filesystem)
-    #[arg(long, conflicts_with_all = ["s3_bucket", "stateless"])]
+    #[arg(long, conflicts_with_all = ["s3_bucket", "stateless", "in_memory"])]
     directory_path: Option<String>,
 
+    /// Use in-memory storage for heap snapshots (non-persistent, useful for testing/development)
+    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path", "stateless"])]
+    in_memory: bool,
+
     /// Run in stateless mode - no heap snapshots are saved or loaded
-    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path"])]
+    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path", "in_memory"])]
     stateless: bool,
 
     /// HTTP port to listen on (if not specified, uses stdio transport)
@@ -81,6 +85,8 @@ async fn main() -> Result<()> {
             AnyHeapStorage::S3(S3HeapStorage::new(bucket).await)
         } else if let Some(dir) = cli.directory_path {
             AnyHeapStorage::File(FileHeapStorage::new(dir))
+        } else if cli.in_memory {
+            AnyHeapStorage::InMemory(InMemoryHeapStorage::new())
         } else {
             // default to file /tmp/mcp-v8-heaps
             AnyHeapStorage::File(FileHeapStorage::new("/tmp/mcp-v8-heaps"))

--- a/server/src/mcp/heap_storage.rs
+++ b/server/src/mcp/heap_storage.rs
@@ -5,6 +5,8 @@ use aws_sdk_s3::ByteStream;
 use aws_config;
 use std::sync::Arc;
 use async_trait::async_trait;
+use std::collections::HashMap;
+use tokio::sync::RwLock;
 
 #[async_trait]
 pub trait HeapStorage: Send + Sync + 'static {
@@ -98,11 +100,77 @@ impl HeapStorage for S3HeapStorage {
     }
 }
 
+/// In-memory heap storage using a concurrent HashMap
+/// Useful for testing, development, or scenarios where persistence is not required
+#[derive(Clone)]
+pub struct InMemoryHeapStorage {
+    store: Arc<RwLock<HashMap<String, Vec<u8>>>>,
+}
+
+impl InMemoryHeapStorage {
+    /// Creates a new in-memory heap storage instance
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Returns the number of items currently stored
+    pub async fn len(&self) -> usize {
+        self.store.read().await.len()
+    }
+
+    /// Returns true if the storage is empty
+    pub async fn is_empty(&self) -> bool {
+        self.store.read().await.is_empty()
+    }
+
+    /// Clears all stored data
+    pub async fn clear(&self) {
+        self.store.write().await.clear();
+    }
+
+    /// Lists all keys currently stored
+    pub async fn keys(&self) -> Vec<String> {
+        self.store.read().await.keys().cloned().collect()
+    }
+
+    /// Removes a specific key from storage
+    pub async fn remove(&self, name: &str) -> Result<(), String> {
+        self.store.write().await.remove(name);
+        Ok(())
+    }
+}
+
+impl Default for InMemoryHeapStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl HeapStorage for InMemoryHeapStorage {
+    async fn put(&self, name: &str, data: &[u8]) -> Result<(), String> {
+        let mut store = self.store.write().await;
+        store.insert(name.to_string(), data.to_vec());
+        Ok(())
+    }
+
+    async fn get(&self, name: &str) -> Result<Vec<u8>, String> {
+        let store = self.store.read().await;
+        store
+            .get(name)
+            .cloned()
+            .ok_or_else(|| format!("Heap '{}' not found in memory", name))
+    }
+}
+
 #[derive(Clone)]
 pub enum AnyHeapStorage {
     #[allow(dead_code)]
     File(FileHeapStorage),
     S3(S3HeapStorage),
+    InMemory(InMemoryHeapStorage),
 }
 
 
@@ -114,12 +182,14 @@ impl HeapStorage for AnyHeapStorage {
         match self {
             AnyHeapStorage::File(inner) => inner.put(name, data).await,
             AnyHeapStorage::S3(inner) => inner.put(name, data).await,
+            AnyHeapStorage::InMemory(inner) => inner.put(name, data).await,
         }
     }
     async fn get(&self, name: &str) -> Result<Vec<u8>, String> {
         match self {
             AnyHeapStorage::File(inner) => inner.get(name).await,
             AnyHeapStorage::S3(inner) => inner.get(name).await,
+            AnyHeapStorage::InMemory(inner) => inner.get(name).await,
         }
     }
 } 


### PR DESCRIPTION
## Summary
This PR adds an in-memory heap storage implementation to the mcp-v8 project, providing a fast, non-persistent storage option for V8 heap snapshots.

## Changes
- **New `InMemoryHeapStorage` struct**: Implemented using `Arc<RwLock<HashMap<String, Vec<u8>>>>` for concurrent-safe operations
- **Helper methods**: Added `len()`, `is_empty()`, `clear()`, `keys()`, and `remove()` for better usability
- **CLI integration**: Added `--in-memory` flag to `main.rs` for easy activation
- **Updated `AnyHeapStorage` enum**: Included `InMemory` variant alongside existing `File` and `S3` options
- **Full trait integration**: Properly implements the `HeapStorage` trait with async methods

## Use Cases
- **Development and testing**: Quick setup without filesystem or S3 dependencies
- **Non-persistent scenarios**: When heap state doesn't need to survive process restarts
- **Prototyping**: Rapid iteration without external infrastructure

## Technical Details
- Uses `tokio::sync::RwLock` for async-compatible concurrent access
- Cloneable through `Arc` sharing for use across multiple connections
- Zero external dependencies beyond existing tokio and std libraries
- Follows existing code patterns and conventions

## Testing
The implementation follows the same `HeapStorage` trait interface as `FileHeapStorage` and `S3HeapStorage`, ensuring compatibility with existing code paths.
