### PR TITLE
Add in-memory heap storage implementation

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,7 +12,7 @@ use rmcp::transport::sse_server::{SseServer, SseServerConfig};
 use tokio_util::sync::CancellationToken;
 
 mod mcp;
-use mcp::{StatelessService, StatefulService, initialize_v8};
+use mcp::{StatelessService, StatefulService, initialize_v8, MemoryHeapStorage};
 use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage};
 
 /// Command line arguments for configuring heap storage
@@ -21,15 +21,19 @@ use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage};
 struct Cli {
 
     /// S3 bucket name (required if --use-s3)
-    #[arg(long, conflicts_with_all = ["directory_path", "stateless"])]
+    #[arg(long, conflicts_with_all = ["directory_path", "stateless", "memory"])]
     s3_bucket: Option<String>,
 
     /// Directory path for filesystem storage (required if --use-filesystem)
-    #[arg(long, conflicts_with_all = ["s3_bucket", "stateless"])]
+    #[arg(long, conflicts_with_all = ["s3_bucket", "stateless", "memory"])]
     directory_path: Option<String>,
 
+    /// Use in-memory storage for heap snapshots (data is lost when process terminates)
+    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path", "stateless"])]
+    memory: bool,
+
     /// Run in stateless mode - no heap snapshots are saved or loaded
-    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path"])]
+    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path", "memory"])]
     stateless: bool,
 
     /// HTTP port to listen on (if not specified, uses stdio transport)
@@ -81,6 +85,8 @@ async fn main() -> Result<()> {
             AnyHeapStorage::S3(S3HeapStorage::new(bucket).await)
         } else if let Some(dir) = cli.directory_path {
             AnyHeapStorage::File(FileHeapStorage::new(dir))
+        } else if cli.memory {
+            AnyHeapStorage::Memory(MemoryHeapStorage::new())
         } else {
             // default to file /tmp/mcp-v8-heaps
             AnyHeapStorage::File(FileHeapStorage::new("/tmp/mcp-v8-heaps"))

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -11,6 +11,7 @@ use std::sync::Once;
 use v8::{self};
 
 pub(crate) mod heap_storage;
+pub use crate::mcp::heap_storage::MemoryHeapStorage;
 use crate::mcp::heap_storage::{HeapStorage, AnyHeapStorage};
 
 


### PR DESCRIPTION
## Summary
This PR adds an in-memory heap storage option for the MCP V8 JavaScript server.

## Changes
- **New `MemoryHeapStorage` struct**: Implements heap storage using `Arc<RwLock<HashMap<String, Vec<u8>>>>`
- **New `--memory` CLI flag**: Allows users to run the server with in-memory storage
- **Updated `AnyHeapStorage` enum**: Added `Memory` variant to support the new storage type
- **Module exports**: Exported `MemoryHeapStorage` from the mcp module

## Use Cases
In-memory storage is ideal for:
- **Testing and development**: Quick iterations without filesystem I/O
- **Ephemeral workloads**: Scenarios where persistence is not required
- **Performance**: Faster than filesystem-based storage for short-lived sessions
- **Containerized environments**: No need for volume mounts for heap data

## Usage
```bash
# Use in-memory storage with stdio transport
mcp-v8 --memory

# Use in-memory storage with HTTP transport
mcp-v8 --memory --http-port 8080

# Use in-memory storage with SSE transport
mcp-v8 --memory --sse-port 8081
```

## Implementation Details
- Uses `tokio::sync::RwLock` for async-safe concurrent access
- Data is wrapped in `Arc` for efficient cloning across threads
- Storage is automatically cleaned up when the process terminates
- Follows the same `HeapStorage` trait as S3 and filesystem implementations

## Notes
⚠️ **Data is not persisted** - All heap snapshots are lost when the server process terminates.
