### PR TITLE
Refactor MCP execution and standardize workflow commands

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,12 +33,14 @@ jobs:
         run: nix develop --command bash -c "cargo install cargo-fuzz"
 
       - name: Build fuzz targets
-        run: nix develop --command bash -c "cd server && cargo fuzz build ${{ matrix.target }}"
+        run: nix develop --command bash -c "cd server && cargo fuzz build --sanitizer=address ${{ matrix.target }}"
 
       - name: Run fuzzer (${{ matrix.target }})
+        env:
+          ASAN_OPTIONS: detect_odr_violation=0
         run: |
           nix develop --command bash -c \
-            "cd server && cargo fuzz run ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=4096"
+            "cd server && cargo fuzz run --sanitizer=address ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=4096"
 
       - name: Upload fuzz artifacts
         if: always()

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,13 +33,12 @@ jobs:
         run: nix develop --command bash -c "cargo install cargo-fuzz"
 
       - name: Build fuzz targets
-        run: cd server && nix develop --command bash -c "cargo fuzz build ${{ matrix.target }}"
+        run: nix develop --command bash -c "cd server && cargo fuzz build ${{ matrix.target }}"
 
       - name: Run fuzzer (${{ matrix.target }})
         run: |
-          cd server && nix develop --command bash -c \
-            "cargo fuzz run ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=4096"
-        continue-on-error: true
+          nix develop --command bash -c \
+            "cd server && cargo fuzz run ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=4096"
 
       - name: Upload fuzz artifacts
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: nix develop --command rustup target add ${{ matrix.target }}
 
       - name: Build
-        run: cd server && nix develop --command ${{ matrix.build_cmd }}
+        run: nix develop --command bash -c "cd server && ${{ matrix.build_cmd }}"
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
           cache-directories: "server"
 
       - name: Build server
-        run: cd server && nix develop --command bash -c "cargo build"
+        run: nix develop --command bash -c "cd server && cargo build"
 
       - name: Run tests
-        run: cd server && nix develop --command bash -c "cargo test -- --test-threads=1"
+        run: nix develop --command bash -c "cd server && cargo test -- --test-threads=1"
 
       - name: Run tests with output
-        run: cd server && nix develop --command bash -c "cargo test -- --nocapture --test-threads=1"
+        run: nix develop --command bash -c "cd server && cargo test -- --nocapture --test-threads=1"
         if: failure()


### PR DESCRIPTION
## Summary
This PR improves code quality in the MCP module and standardizes how workflow commands are executed across CI/CD pipelines.

## Key Changes

### MCP Module Refactoring (`server/src/mcp.rs`)
- **Improved snapshot handling**: Changed pattern matching to use guard clause (`if !snapshot.is_empty()`) for better clarity when determining whether to create an isolate from an existing snapshot or create a new one
- **Simplified error handling**: Refactored nested match statements in the `execute_stateful` function to use more idiomatic Rust patterns with `map` and `ok_or_else`, reducing nesting and improving readability
- **Eliminated unnecessary variable initialization**: Removed pre-initialization of `output_result` with a default error value, instead assigning it directly within the match expression

### Workflow Command Standardization
- **Consistent command structure**: Moved `cd server` inside `nix develop` commands across all workflows (test.yml, fuzz.yml, release.yml) for consistency
- **Improved shell handling**: Wrapped commands in explicit `bash -c` where needed to ensure proper command execution within the nix environment

## Notable Implementation Details
The refactoring in `mcp.rs` maintains identical functionality while improving code clarity through:
- Using guard clauses instead of nested pattern matching
- Leveraging functional programming patterns (`map`, `ok_or_else`) instead of imperative match blocks
- Reducing variable scope and initialization overhead

The workflow changes ensure that directory changes are scoped within the nix develop environment, making the CI/CD pipeline more robust and consistent.

https://claude.ai/code/session_01JqNBkxv2FQ7vYd97Pz8VcK