### PR TITLE
Add session logging with sled-backed persistent storage

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -530,7 +530,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -543,6 +543,12 @@ dependencies = [
  "shlex",
  "syn",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -564,6 +570,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -741,6 +753,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +908,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1014,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1520,6 +1566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,7 +1721,7 @@ version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1709,6 +1764,31 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "paste"
@@ -1861,6 +1941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2030,7 +2119,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2043,7 +2132,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2163,6 +2252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,7 +2273,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2275,6 +2370,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "axum",
+ "chrono",
  "clap",
  "futures",
  "hyper 1.6.0",
@@ -2284,6 +2380,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sled",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tokio-util 0.7.15",
@@ -2335,6 +2433,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2414,7 +2528,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2822,7 +2936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "278d906d3513fce0be40e1b28eb4c482f44e9d3bf7c1be880441e706bebf5e43"
 dependencies = [
  "bindgen",
- "bitflags",
+ "bitflags 2.9.0",
  "fslock",
  "gzip-header",
  "home",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,6 +28,8 @@ aws-sdk-s3 = "0.0.26-alpha"
 async-trait = "0.1"
 clap = { version = "4.5", features = ["derive"] }
 sha2 = "0.10"
+sled = "0.34"
+chrono = { version = "0.4", features = ["serde"] }
 hyper = { version = "1.5.2", features = ["server", "http1"] }
 hyper-util = { version = "0.1.10", features = ["tokio"] }
 tokio-util = "0.7"
@@ -37,3 +39,6 @@ tokio-test = "0.4"
 reqwest = { version = "0.12", features = ["json", "cookies", "stream"] }
 uuid = { version = "1.0", features = ["v4"] }
 futures = "0.3"
+tempfile = "3"
+chrono = { version = "0.4", features = ["serde"] }
+sled = "0.34"

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -17,7 +17,9 @@ use v8::{self};
 use sha2::{Sha256, Digest};
 
 pub mod heap_storage;
+pub mod session_log;
 use crate::mcp::heap_storage::{HeapStorage, AnyHeapStorage};
+use crate::mcp::session_log::{SessionLog, SessionLogEntry};
 
 
 
@@ -333,6 +335,7 @@ pub trait DataService: Send + Sync + 'static {
 #[derive(Clone)]
 pub struct StatefulService {
     heap_storage: AnyHeapStorage,
+    session_log: Option<SessionLog>,
     heap_memory_max_bytes: usize,
     execution_timeout_secs: u64,
 }
@@ -380,6 +383,40 @@ impl IntoContents for RunJsStatelessResponse {
     }
 }
 
+// Response for list_sessions
+#[derive(Debug, Clone)]
+pub struct ListSessionsResponse {
+    pub sessions: Vec<String>,
+}
+
+impl IntoContents for ListSessionsResponse {
+    fn into_contents(self) -> Vec<Content> {
+        match Content::json(json!({
+            "sessions": self.sessions,
+        })) {
+            Ok(content) => vec![content],
+            Err(e) => vec![Content::text(format!("Failed to convert list_sessions response: {}", e))],
+        }
+    }
+}
+
+// Response for list_session_snapshots
+#[derive(Debug, Clone)]
+pub struct ListSessionSnapshotsResponse {
+    pub entries: Vec<serde_json::Value>,
+}
+
+impl IntoContents for ListSessionSnapshotsResponse {
+    fn into_contents(self) -> Vec<Content> {
+        match Content::json(json!({
+            "entries": self.entries,
+        })) {
+            Ok(content) => vec![content],
+            Err(e) => vec![Content::text(format!("Failed to convert list_session_snapshots response: {}", e))],
+        }
+    }
+}
+
 // Stateless service implementation
 #[tool(tool_box)]
 impl StatelessService {
@@ -420,8 +457,8 @@ impl StatelessService {
 // Stateful service implementation
 #[tool(tool_box)]
 impl StatefulService {
-    pub fn new(heap_storage: AnyHeapStorage, heap_memory_max_bytes: usize, execution_timeout_secs: u64) -> Self {
-        Self { heap_storage, heap_memory_max_bytes, execution_timeout_secs }
+    pub fn new(heap_storage: AnyHeapStorage, session_log: Option<SessionLog>, heap_memory_max_bytes: usize, execution_timeout_secs: u64) -> Self {
+        Self { heap_storage, session_log, heap_memory_max_bytes, execution_timeout_secs }
     }
 
     /// Execute JavaScript code with heap persistence. The heap parameter is the content hash from a previous execution.
@@ -432,6 +469,9 @@ impl StatefulService {
         #[tool(param)]
         #[serde(default)]
         heap: Option<String>,
+        #[tool(param)]
+        #[serde(default)]
+        session: Option<String>,
         #[tool(param)]
         #[serde(default)]
         heap_memory_max_mb: Option<usize>,
@@ -447,6 +487,7 @@ impl StatefulService {
             Some(h) if !h.is_empty() => self.heap_storage.get(h).await.ok(),
             _ => None,
         };
+        let code_for_log = code.clone();
         let v8_result = tokio::task::spawn_blocking(move || execute_stateful(code, snapshot, max_bytes, timeout)).await;
 
         match v8_result {
@@ -457,6 +498,20 @@ impl StatefulService {
                         heap: content_hash,
                     };
                 }
+
+                // Log to session if session name is provided and session log is available
+                if let (Some(session_name), Some(log)) = (&session, &self.session_log) {
+                    let entry = SessionLogEntry {
+                        input_heap: heap.clone(),
+                        output_heap: content_hash.clone(),
+                        code: code_for_log,
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                    };
+                    if let Err(e) = log.append(session_name, entry) {
+                        tracing::warn!("Failed to log session entry: {}", e);
+                    }
+                }
+
                 RunJsStatefulResponse { output, heap: content_hash }
             }
             Ok(Err(e)) => RunJsStatefulResponse {
@@ -466,6 +521,49 @@ impl StatefulService {
             Err(e) => RunJsStatefulResponse {
                 output: format!("Task join error: {}", e),
                 heap: heap.unwrap_or_default(),
+            },
+        }
+    }
+
+    /// List all named sessions in the session log.
+    #[tool(description = "List all named sessions. Returns an array of session names that have been used with the session parameter in run_js.")]
+    pub async fn list_sessions(&self) -> ListSessionsResponse {
+        match &self.session_log {
+            Some(log) => match log.list_sessions() {
+                Ok(sessions) => ListSessionsResponse { sessions },
+                Err(e) => ListSessionsResponse {
+                    sessions: vec![format!("Error: {}", e)],
+                },
+            },
+            None => ListSessionsResponse {
+                sessions: vec!["Session log not configured".to_string()],
+            },
+        }
+    }
+
+    /// List all log entries for a named session.
+    #[tool(description = "List all log entries for a named session. Each entry contains the input heap hash, output heap hash, code executed, and timestamp. Use the fields parameter to select specific fields (comma-separated: index,input_heap,output_heap,code,timestamp).")]
+    pub async fn list_session_snapshots(
+        &self,
+        #[tool(param)] session: String,
+        #[tool(param)]
+        #[serde(default)]
+        fields: Option<String>,
+    ) -> ListSessionSnapshotsResponse {
+        match &self.session_log {
+            Some(log) => {
+                let parsed_fields = fields.map(|f| {
+                    f.split(',').map(|s| s.trim().to_string()).collect::<Vec<_>>()
+                });
+                match log.list_entries(&session, parsed_fields) {
+                    Ok(entries) => ListSessionSnapshotsResponse { entries },
+                    Err(e) => ListSessionSnapshotsResponse {
+                        entries: vec![serde_json::json!({"error": e})],
+                    },
+                }
+            }
+            None => ListSessionSnapshotsResponse {
+                entries: vec![serde_json::json!({"error": "Session log not configured"})],
             },
         }
     }

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -325,12 +325,6 @@ pub fn initialize_v8() {
 
 
 
-#[allow(dead_code)]
-pub trait DataService: Send + Sync + 'static {
-    fn get_data(&self) -> String;
-    fn set_data(&mut self, data: String);
-}
-
 // Stateful service with heap persistence
 #[derive(Clone)]
 pub struct StatefulService {

--- a/server/src/mcp/heap_storage.rs
+++ b/server/src/mcp/heap_storage.rs
@@ -19,8 +19,6 @@ pub struct FileHeapStorage {
 
 impl FileHeapStorage {
 
-    // ignore dead_code warning
-    #[allow(dead_code)]
     pub fn new(dir: impl Into<PathBuf>) -> Self {
         let dir = dir.into();
         std::fs::create_dir_all(&dir).ok();
@@ -100,7 +98,6 @@ impl HeapStorage for S3HeapStorage {
 
 #[derive(Clone)]
 pub enum AnyHeapStorage {
-    #[allow(dead_code)]
     File(FileHeapStorage),
     S3(S3HeapStorage),
 }

--- a/server/src/mcp/session_log.rs
+++ b/server/src/mcp/session_log.rs
@@ -13,7 +13,6 @@ pub struct SessionLog {
     db: sled::Db,
 }
 
-#[allow(dead_code)]
 impl SessionLog {
     pub fn new(path: &str) -> Result<Self, String> {
         let db = sled::open(path).map_err(|e| format!("Failed to open sled db: {}", e))?;

--- a/server/src/mcp/session_log.rs
+++ b/server/src/mcp/session_log.rs
@@ -1,0 +1,202 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionLogEntry {
+    pub input_heap: Option<String>,
+    pub output_heap: String,
+    pub code: String,
+    pub timestamp: String, // ISO 8601 UTC
+}
+
+#[derive(Clone)]
+pub struct SessionLog {
+    db: sled::Db,
+}
+
+#[allow(dead_code)]
+impl SessionLog {
+    pub fn new(path: &str) -> Result<Self, String> {
+        let db = sled::open(path).map_err(|e| format!("Failed to open sled db: {}", e))?;
+        Ok(Self { db })
+    }
+
+    pub fn from_config(config: sled::Config) -> Result<Self, String> {
+        let db = config.open().map_err(|e| format!("Failed to open sled db: {}", e))?;
+        Ok(Self { db })
+    }
+
+    /// Append a log entry to the given session. Returns the sequence number.
+    pub fn append(&self, session: &str, entry: SessionLogEntry) -> Result<u64, String> {
+        let tree = self
+            .db
+            .open_tree(session)
+            .map_err(|e| format!("Failed to open tree '{}': {}", session, e))?;
+
+        let value =
+            serde_json::to_vec(&entry).map_err(|e| format!("Failed to serialize entry: {}", e))?;
+
+        // generate_id() returns a monotonically increasing u64, unique across the Db
+        let seq = self
+            .db
+            .generate_id()
+            .map_err(|e| format!("Failed to generate id: {}", e))?;
+
+        let key = seq.to_be_bytes();
+        tree.insert(key, value)
+            .map_err(|e| format!("Failed to insert entry: {}", e))?;
+
+        Ok(seq)
+    }
+
+    /// List all session names.
+    pub fn list_sessions(&self) -> Result<Vec<String>, String> {
+        let names: Vec<String> = self
+            .db
+            .tree_names()
+            .into_iter()
+            .filter_map(|name| {
+                let s = String::from_utf8(name.to_vec()).ok()?;
+                // Filter out sled's default tree
+                if s == "__sled__default" {
+                    None
+                } else {
+                    Some(s)
+                }
+            })
+            .collect();
+        Ok(names)
+    }
+
+    /// List all entries for a session, optionally filtering to specific fields.
+    /// Valid field names: "index", "input_heap", "output_heap", "code", "timestamp".
+    /// If fields is None, all fields are returned.
+    pub fn list_entries(
+        &self,
+        session: &str,
+        fields: Option<Vec<String>>,
+    ) -> Result<Vec<serde_json::Value>, String> {
+        let tree = self
+            .db
+            .open_tree(session)
+            .map_err(|e| format!("Failed to open tree '{}': {}", session, e))?;
+
+        let mut results = Vec::new();
+
+        for item in tree.iter() {
+            let (key_bytes, val_bytes) =
+                item.map_err(|e| format!("Failed to read entry: {}", e))?;
+
+            let index = u64::from_be_bytes(
+                key_bytes
+                    .as_ref()
+                    .try_into()
+                    .map_err(|_| "Invalid key length".to_string())?,
+            );
+
+            let entry: SessionLogEntry = serde_json::from_slice(&val_bytes)
+                .map_err(|e| format!("Failed to deserialize entry: {}", e))?;
+
+            let value = match &fields {
+                Some(field_list) => {
+                    let mut obj = serde_json::Map::new();
+                    for field in field_list {
+                        match field.as_str() {
+                            "index" => {
+                                obj.insert(
+                                    "index".to_string(),
+                                    serde_json::Value::Number(index.into()),
+                                );
+                            }
+                            "input_heap" => {
+                                obj.insert(
+                                    "input_heap".to_string(),
+                                    match &entry.input_heap {
+                                        Some(h) => serde_json::Value::String(h.clone()),
+                                        None => serde_json::Value::Null,
+                                    },
+                                );
+                            }
+                            "output_heap" => {
+                                obj.insert(
+                                    "output_heap".to_string(),
+                                    serde_json::Value::String(entry.output_heap.clone()),
+                                );
+                            }
+                            "code" => {
+                                obj.insert(
+                                    "code".to_string(),
+                                    serde_json::Value::String(entry.code.clone()),
+                                );
+                            }
+                            "timestamp" => {
+                                obj.insert(
+                                    "timestamp".to_string(),
+                                    serde_json::Value::String(entry.timestamp.clone()),
+                                );
+                            }
+                            _ => {} // ignore unknown fields
+                        }
+                    }
+                    serde_json::Value::Object(obj)
+                }
+                None => {
+                    let mut obj = serde_json::Map::new();
+                    obj.insert(
+                        "index".to_string(),
+                        serde_json::Value::Number(index.into()),
+                    );
+                    obj.insert(
+                        "input_heap".to_string(),
+                        match &entry.input_heap {
+                            Some(h) => serde_json::Value::String(h.clone()),
+                            None => serde_json::Value::Null,
+                        },
+                    );
+                    obj.insert(
+                        "output_heap".to_string(),
+                        serde_json::Value::String(entry.output_heap.clone()),
+                    );
+                    obj.insert(
+                        "code".to_string(),
+                        serde_json::Value::String(entry.code.clone()),
+                    );
+                    obj.insert(
+                        "timestamp".to_string(),
+                        serde_json::Value::String(entry.timestamp.clone()),
+                    );
+                    serde_json::Value::Object(obj)
+                }
+            };
+
+            results.push(value);
+        }
+
+        Ok(results)
+    }
+
+    /// Get the latest entry for a session, if any.
+    pub fn get_latest(&self, session: &str) -> Result<Option<SessionLogEntry>, String> {
+        let tree = self
+            .db
+            .open_tree(session)
+            .map_err(|e| format!("Failed to open tree '{}': {}", session, e))?;
+
+        match tree.last() {
+            Ok(Some((_key, val))) => {
+                let entry: SessionLogEntry = serde_json::from_slice(&val)
+                    .map_err(|e| format!("Failed to deserialize entry: {}", e))?;
+                Ok(Some(entry))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(format!("Failed to get latest entry: {}", e)),
+        }
+    }
+
+    /// Flush all pending writes to disk.
+    pub fn flush(&self) -> Result<(), String> {
+        self.db
+            .flush()
+            .map_err(|e| format!("Failed to flush sled db: {}", e))?;
+        Ok(())
+    }
+}

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -3,6 +3,7 @@ run javascript code in v8
 params:
 - code: the javascript code to run
 - heap (optional): content hash from a previous execution to resume that session, or omit for a fresh session
+- session (optional): a human-readable session name. When provided, a log entry is written recording the input heap, output heap, executed code, and timestamp. Use list_sessions and list_session_snapshots to browse session history.
 - heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (1–64, default: 8). Override the server default for this execution.
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -66,53 +66,78 @@ the source code of the runtime is this
 ```rust
 // Execute JS with snapshot support (preserves heap state)
 pub fn execute_stateful(code: String, snapshot: Option<Vec<u8>>, heap_memory_max_bytes: usize, timeout_secs: u64) -> Result<(String, Vec<u8>, String), String> {
-    let params = Some(create_params_with_heap_limit(heap_memory_max_bytes));
-
     let raw_snapshot = match snapshot {
         Some(data) if !data.is_empty() => Some(unwrap_snapshot(&data)?),
         _ => None,
     };
 
-    let mut snapshot_creator = match raw_snapshot {
-        Some(raw) if !raw.is_empty() => {
-            v8::Isolate::snapshot_creator_from_existing_snapshot(raw, None, params)
-        }
-        _ => {
-            v8::Isolate::snapshot_creator(None, params)
-        }
-    };
-    install_heap_limit_callback(&mut snapshot_creator);
-    let _timeout_guard = install_execution_timeout(&mut snapshot_creator, timeout_secs);
+    let oom_flag = Arc::new(AtomicBool::new(false));
+    let timeout_flag = Arc::new(AtomicBool::new(false));
 
-    let output_result;
-    {
-        let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-        let context = v8::Context::new(scope, Default::default());
-        let scope = &mut v8::ContextScope::new(scope, context);
-        output_result = match eval(scope, &code) {
-            Ok(result) => {
-                result
-                    .to_string(scope)
-                    .map(|s| s.to_rust_string_lossy(scope))
-                    .ok_or_else(|| "Failed to convert result to string".to_string())
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let params = Some(create_params_with_heap_limit(heap_memory_max_bytes));
+
+        let mut snapshot_creator = match raw_snapshot {
+            Some(raw) if !raw.is_empty() => {
+                v8::Isolate::snapshot_creator_from_existing_snapshot(raw, None, params)
             }
-            Err(e) => Err(e),
+            _ => {
+                v8::Isolate::snapshot_creator(None, params)
+            }
         };
-        scope.set_default_context(context);
+
+        let cb_data_ptr = install_heap_limit_callback(&mut snapshot_creator, oom_flag.clone());
+        let _timeout_guard = install_execution_timeout(&mut snapshot_creator, timeout_secs, timeout_flag.clone());
+
+        let output_result;
+        {
+            let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
+            let context = v8::Context::new(scope, Default::default());
+            let scope = &mut v8::ContextScope::new(scope, context);
+            output_result = match eval(scope, &code) {
+                Ok(result) => {
+                    result
+                        .to_string(scope)
+                        .map(|s| s.to_rust_string_lossy(scope))
+                        .ok_or_else(|| "Failed to convert result to string".to_string())
+                }
+                Err(e) => Err(e),
+            };
+            scope.set_default_context(context);
+        }
+
+        unsafe { let _ = Box::from_raw(cb_data_ptr); }
+
+        let startup_data = snapshot_creator.create_blob(v8::FunctionCodeHandling::Clear)
+            .ok_or("Failed to create V8 snapshot blob".to_string())?;
+        let wrapped = wrap_snapshot(&startup_data);
+
+        output_result.map(|output| (output, wrapped.data, wrapped.content_hash))
+    }));
+
+    match result {
+        Ok(inner) => inner.map_err(|e| classify_termination_error(&oom_flag, &timeout_flag, e)),
+        Err(_panic) => Err(classify_termination_error(
+            &oom_flag,
+            &timeout_flag,
+            "V8 execution panicked unexpectedly".to_string(),
+        )),
     }
-
-    let startup_data = snapshot_creator.create_blob(v8::FunctionCodeHandling::Clear)
-        .ok_or("Failed to create V8 snapshot blob".to_string())?;
-    let wrapped = wrap_snapshot(&startup_data);
-
-    output_result.map(|output| (output, wrapped.data, wrapped.content_hash))
 }
 
-// Stateful service implementation
+// Stateful service with heap persistence
+#[derive(Clone)]
+pub struct StatefulService {
+    heap_storage: AnyHeapStorage,
+    session_log: Option<SessionLog>,
+    heap_memory_max_bytes: usize,
+    execution_timeout_secs: u64,
+}
+
 #[tool(tool_box)]
 impl StatefulService {
-    pub fn new(heap_storage: AnyHeapStorage, heap_memory_max_bytes: usize, execution_timeout_secs: u64) -> Self {
-        Self { heap_storage, heap_memory_max_bytes, execution_timeout_secs }
+    pub fn new(heap_storage: AnyHeapStorage, session_log: Option<SessionLog>, heap_memory_max_bytes: usize, execution_timeout_secs: u64) -> Self {
+        Self { heap_storage, session_log, heap_memory_max_bytes, execution_timeout_secs }
     }
 
     #[tool(description = include_str!("run_js_tool_description.md"))]
@@ -122,6 +147,9 @@ impl StatefulService {
         #[tool(param)]
         #[serde(default)]
         heap: Option<String>,
+        #[tool(param)]
+        #[serde(default)]
+        session: Option<String>,
         #[tool(param)]
         #[serde(default)]
         heap_memory_max_mb: Option<usize>,
@@ -137,6 +165,7 @@ impl StatefulService {
             Some(h) if !h.is_empty() => self.heap_storage.get(h).await.ok(),
             _ => None,
         };
+        let code_for_log = code.clone();
         let v8_result = tokio::task::spawn_blocking(move || execute_stateful(code, snapshot, max_bytes, timeout)).await;
 
         match v8_result {
@@ -147,6 +176,20 @@ impl StatefulService {
                         heap: content_hash,
                     };
                 }
+
+                // Log to session if session name is provided and session log is available
+                if let (Some(session_name), Some(log)) = (&session, &self.session_log) {
+                    let entry = SessionLogEntry {
+                        input_heap: heap.clone(),
+                        output_heap: content_hash.clone(),
+                        code: code_for_log,
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                    };
+                    if let Err(e) = log.append(session_name, entry) {
+                        tracing::warn!("Failed to log session entry: {}", e);
+                    }
+                }
+
                 RunJsStatefulResponse { output, heap: content_hash }
             }
             Ok(Err(e)) => RunJsStatefulResponse {

--- a/server/tests/session_log.rs
+++ b/server/tests/session_log.rs
@@ -1,0 +1,310 @@
+use server::mcp::session_log::{SessionLog, SessionLogEntry};
+use std::sync::Arc;
+
+fn make_entry(input: Option<&str>, output: &str, code: &str) -> SessionLogEntry {
+    SessionLogEntry {
+        input_heap: input.map(|s| s.to_string()),
+        output_heap: output.to_string(),
+        code: code.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+fn temp_session_log() -> SessionLog {
+    SessionLog::from_config(sled::Config::new().temporary(true)).expect("failed to open temp sled")
+}
+
+#[test]
+fn test_basic_append_and_list() {
+    let log = temp_session_log();
+
+    // Initially no sessions
+    let sessions = log.list_sessions().unwrap();
+    assert!(sessions.is_empty());
+
+    // Append to a session
+    let seq = log
+        .append("my-session", make_entry(None, "hash_a", "1 + 1"))
+        .unwrap();
+    assert!(seq > 0 || seq == 0); // just check it returns
+
+    // Session should now appear
+    let sessions = log.list_sessions().unwrap();
+    assert_eq!(sessions, vec!["my-session"]);
+
+    // Append another entry
+    log.append(
+        "my-session",
+        make_entry(Some("hash_a"), "hash_b", "2 + 2"),
+    )
+    .unwrap();
+
+    // List entries
+    let entries = log.list_entries("my-session", None).unwrap();
+    assert_eq!(entries.len(), 2);
+
+    // First entry
+    assert_eq!(entries[0]["input_heap"], serde_json::Value::Null);
+    assert_eq!(entries[0]["output_heap"], "hash_a");
+    assert_eq!(entries[0]["code"], "1 + 1");
+
+    // Second entry
+    assert_eq!(entries[1]["input_heap"], "hash_a");
+    assert_eq!(entries[1]["output_heap"], "hash_b");
+    assert_eq!(entries[1]["code"], "2 + 2");
+}
+
+#[test]
+fn test_multiple_sessions() {
+    let log = temp_session_log();
+
+    log.append("session-a", make_entry(None, "h1", "code1"))
+        .unwrap();
+    log.append("session-b", make_entry(None, "h2", "code2"))
+        .unwrap();
+    log.append("session-a", make_entry(Some("h1"), "h3", "code3"))
+        .unwrap();
+
+    let mut sessions = log.list_sessions().unwrap();
+    sessions.sort();
+    assert_eq!(sessions, vec!["session-a", "session-b"]);
+
+    let a_entries = log.list_entries("session-a", None).unwrap();
+    assert_eq!(a_entries.len(), 2);
+
+    let b_entries = log.list_entries("session-b", None).unwrap();
+    assert_eq!(b_entries.len(), 1);
+}
+
+#[test]
+fn test_get_latest() {
+    let log = temp_session_log();
+
+    // No entries yet
+    assert!(log.get_latest("empty").unwrap().is_none());
+
+    log.append("s", make_entry(None, "h1", "c1")).unwrap();
+    log.append("s", make_entry(Some("h1"), "h2", "c2")).unwrap();
+    log.append("s", make_entry(Some("h2"), "h3", "c3")).unwrap();
+
+    let latest = log.get_latest("s").unwrap().unwrap();
+    assert_eq!(latest.output_heap, "h3");
+    assert_eq!(latest.code, "c3");
+}
+
+#[test]
+fn test_field_filtering() {
+    let log = temp_session_log();
+
+    log.append("s", make_entry(None, "h1", "code1")).unwrap();
+    log.append("s", make_entry(Some("h1"), "h2", "code2"))
+        .unwrap();
+
+    // Request only output_heap and code
+    let entries = log
+        .list_entries(
+            "s",
+            Some(vec!["output_heap".to_string(), "code".to_string()]),
+        )
+        .unwrap();
+
+    assert_eq!(entries.len(), 2);
+
+    // Should have only the requested fields
+    let obj = entries[0].as_object().unwrap();
+    assert!(obj.contains_key("output_heap"));
+    assert!(obj.contains_key("code"));
+    assert!(!obj.contains_key("input_heap"));
+    assert!(!obj.contains_key("timestamp"));
+    assert!(!obj.contains_key("index"));
+
+    // Request with index
+    let entries = log
+        .list_entries("s", Some(vec!["index".to_string(), "output_heap".to_string()]))
+        .unwrap();
+    let obj = entries[0].as_object().unwrap();
+    assert!(obj.contains_key("index"));
+    assert!(obj.contains_key("output_heap"));
+    assert!(!obj.contains_key("code"));
+}
+
+#[test]
+fn test_empty_session_entries() {
+    let log = temp_session_log();
+
+    // Listing entries for a non-existent session should return empty (open_tree creates it lazily)
+    let entries = log.list_entries("nonexistent", None).unwrap();
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn test_monotonic_sequence_numbers() {
+    let log = temp_session_log();
+
+    let mut seqs = Vec::new();
+    for i in 0..10 {
+        let seq = log
+            .append("s", make_entry(None, &format!("h{}", i), &format!("c{}", i)))
+            .unwrap();
+        seqs.push(seq);
+    }
+
+    // Sequence numbers should be strictly increasing
+    for i in 1..seqs.len() {
+        assert!(seqs[i] > seqs[i - 1], "seq[{}]={} should be > seq[{}]={}", i, seqs[i], i - 1, seqs[i - 1]);
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_writes_same_session() {
+    let log = Arc::new(temp_session_log());
+    let num_tasks = 50;
+
+    let mut handles = Vec::new();
+    for i in 0..num_tasks {
+        let log = log.clone();
+        handles.push(tokio::spawn(async move {
+            log.append(
+                "concurrent-session",
+                make_entry(None, &format!("hash_{}", i), &format!("code_{}", i)),
+            )
+            .unwrap()
+        }));
+    }
+
+    let mut seqs: Vec<u64> = Vec::new();
+    for handle in handles {
+        seqs.push(handle.await.unwrap());
+    }
+
+    // All sequence numbers should be unique
+    seqs.sort();
+    seqs.dedup();
+    assert_eq!(seqs.len(), num_tasks);
+
+    // All entries should be present
+    let entries = log.list_entries("concurrent-session", None).unwrap();
+    assert_eq!(entries.len(), num_tasks);
+
+    // Entries should be in sequence order (sled iterates by key order = big-endian u64)
+    let indices: Vec<u64> = entries
+        .iter()
+        .map(|e| e["index"].as_u64().unwrap())
+        .collect();
+    for i in 1..indices.len() {
+        assert!(indices[i] > indices[i - 1]);
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_writes_different_sessions() {
+    let log = Arc::new(temp_session_log());
+    let num_sessions = 10;
+    let entries_per_session = 20;
+
+    let mut handles = Vec::new();
+    for s in 0..num_sessions {
+        for i in 0..entries_per_session {
+            let log = log.clone();
+            let session_name = format!("session_{}", s);
+            handles.push(tokio::spawn(async move {
+                log.append(
+                    &session_name,
+                    make_entry(None, &format!("h_{}_{}", s, i), &format!("c_{}_{}", s, i)),
+                )
+                .unwrap()
+            }));
+        }
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    // Each session should have exactly entries_per_session entries
+    for s in 0..num_sessions {
+        let entries = log
+            .list_entries(&format!("session_{}", s), None)
+            .unwrap();
+        assert_eq!(
+            entries.len(),
+            entries_per_session,
+            "session_{} should have {} entries, got {}",
+            s,
+            entries_per_session,
+            entries.len()
+        );
+    }
+
+    let mut sessions = log.list_sessions().unwrap();
+    sessions.sort();
+    assert_eq!(sessions.len(), num_sessions);
+}
+
+#[tokio::test]
+async fn test_read_write_atomicity() {
+    // One task writes entries while another reads them.
+    // Reads should never see partial/corrupted entries.
+    let log = Arc::new(temp_session_log());
+    let num_writes = 100;
+
+    let writer_log = log.clone();
+    let writer = tokio::spawn(async move {
+        for i in 0..num_writes {
+            writer_log
+                .append(
+                    "atomic-session",
+                    make_entry(
+                        Some(&format!("input_{}", i)),
+                        &format!("output_{}", i),
+                        &format!("code_{}", i),
+                    ),
+                )
+                .unwrap();
+        }
+    });
+
+    let reader_log = log.clone();
+    let reader = tokio::spawn(async move {
+        let mut max_seen = 0;
+        for _ in 0..200 {
+            let entries = reader_log
+                .list_entries("atomic-session", None)
+                .unwrap();
+
+            // Entry count should only increase
+            assert!(
+                entries.len() >= max_seen,
+                "entry count decreased from {} to {}",
+                max_seen,
+                entries.len()
+            );
+            max_seen = entries.len();
+
+            // Each entry should be complete and valid
+            for entry in &entries {
+                let obj = entry.as_object().unwrap();
+                assert!(obj.contains_key("index"));
+                assert!(obj.contains_key("input_heap"));
+                assert!(obj.contains_key("output_heap"));
+                assert!(obj.contains_key("code"));
+                assert!(obj.contains_key("timestamp"));
+
+                // output_heap and code should be non-empty strings
+                assert!(obj["output_heap"].is_string());
+                assert!(!obj["output_heap"].as_str().unwrap().is_empty());
+                assert!(obj["code"].is_string());
+                assert!(!obj["code"].as_str().unwrap().is_empty());
+            }
+
+            tokio::task::yield_now().await;
+        }
+    });
+
+    writer.await.unwrap();
+    reader.await.unwrap();
+
+    // Final state: all entries present
+    let entries = log.list_entries("atomic-session", None).unwrap();
+    assert_eq!(entries.len(), num_writes);
+}

--- a/server/tests/session_simulation.rs
+++ b/server/tests/session_simulation.rs
@@ -1,0 +1,339 @@
+//! Simulation-style deterministic tests for session log, following sled's
+//! simulation testing philosophy. Tests crash/recovery semantics and
+//! concurrent workload correctness.
+
+use server::mcp::session_log::{SessionLog, SessionLogEntry};
+use std::sync::Arc;
+
+fn make_entry(input: Option<&str>, output: &str, code: &str) -> SessionLogEntry {
+    SessionLogEntry {
+        input_heap: input.map(|s| s.to_string()),
+        output_heap: output.to_string(),
+        code: code.to_string(),
+        timestamp: "2026-01-01T00:00:00Z".to_string(), // deterministic timestamp
+    }
+}
+
+/// Simulate a workload: append N entries to a session, then verify.
+fn run_workload(log: &SessionLog, session: &str, count: usize) -> Vec<u64> {
+    let mut seqs = Vec::new();
+    let mut prev_hash: Option<String> = None;
+
+    for i in 0..count {
+        let output = format!("hash_{}", i);
+        let entry = make_entry(prev_hash.as_deref(), &output, &format!("step_{}", i));
+        let seq = log.append(session, entry).unwrap();
+        seqs.push(seq);
+        prev_hash = Some(output);
+    }
+
+    seqs
+}
+
+/// Verify that a session contains the expected chain of entries.
+fn verify_chain(log: &SessionLog, session: &str, expected_count: usize) {
+    let entries = log.list_entries(session, None).unwrap();
+    assert_eq!(
+        entries.len(),
+        expected_count,
+        "expected {} entries, got {}",
+        expected_count,
+        entries.len()
+    );
+
+    for (i, entry) in entries.iter().enumerate() {
+        let obj = entry.as_object().unwrap();
+        assert_eq!(
+            obj["output_heap"].as_str().unwrap(),
+            format!("hash_{}", i),
+            "entry {} has wrong output_heap",
+            i
+        );
+        assert_eq!(
+            obj["code"].as_str().unwrap(),
+            format!("step_{}", i),
+            "entry {} has wrong code",
+            i
+        );
+
+        if i == 0 {
+            assert!(
+                obj["input_heap"].is_null(),
+                "first entry should have null input_heap"
+            );
+        } else {
+            assert_eq!(
+                obj["input_heap"].as_str().unwrap(),
+                format!("hash_{}", i - 1),
+                "entry {} has wrong input_heap",
+                i
+            );
+        }
+    }
+}
+
+#[test]
+fn test_flush_and_recovery() {
+    // Use a real (non-temporary) path so we can reopen after drop.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("session_db");
+    let db_path_str = db_path.to_str().unwrap();
+
+    // Phase 1: write entries and flush
+    {
+        let log = SessionLog::new(db_path_str).unwrap();
+        run_workload(&log, "recovery-session", 10);
+        log.flush().unwrap();
+        // Drop triggers close
+    }
+
+    // Phase 2: reopen and verify all flushed entries survived
+    {
+        let log = SessionLog::new(db_path_str).unwrap();
+        verify_chain(&log, "recovery-session", 10);
+
+        // Sessions list should include our session
+        let sessions = log.list_sessions().unwrap();
+        assert!(sessions.contains(&"recovery-session".to_string()));
+    }
+}
+
+#[test]
+fn test_crash_recovery_partial_flush() {
+    // Simulate: write some entries, flush, write more (unflushed), drop (crash), reopen.
+    // Flushed entries must survive. Unflushed entries may or may not survive (sled
+    // makes no guarantee for unflushed data on crash), but whatever is present
+    // must be valid (no partial/corrupted entries).
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("session_db");
+    let db_path_str = db_path.to_str().unwrap();
+
+    let flushed_count = 5;
+    let unflushed_count = 5;
+
+    // Phase 1: write and partially flush
+    {
+        let log = SessionLog::new(db_path_str).unwrap();
+
+        // Write and flush first batch
+        run_workload(&log, "partial-session", flushed_count);
+        log.flush().unwrap();
+
+        // Write more without flushing (simulating crash before flush)
+        let mut prev = format!("hash_{}", flushed_count - 1);
+        for i in flushed_count..(flushed_count + unflushed_count) {
+            let output = format!("hash_{}", i);
+            log.append(
+                "partial-session",
+                make_entry(Some(&prev), &output, &format!("step_{}", i)),
+            )
+            .unwrap();
+            prev = output;
+        }
+        // Drop without flush — simulates crash
+    }
+
+    // Phase 2: reopen and verify
+    {
+        let log = SessionLog::new(db_path_str).unwrap();
+        let entries = log.list_entries("partial-session", None).unwrap();
+
+        // At least the flushed entries must survive
+        assert!(
+            entries.len() >= flushed_count,
+            "expected at least {} flushed entries, got {}",
+            flushed_count,
+            entries.len()
+        );
+
+        // All surviving entries must be valid (deserializable, complete)
+        for entry in &entries {
+            let obj = entry.as_object().unwrap();
+            assert!(obj.contains_key("index"));
+            assert!(obj.contains_key("input_heap"));
+            assert!(obj.contains_key("output_heap"));
+            assert!(obj.contains_key("code"));
+            assert!(obj.contains_key("timestamp"));
+            assert!(obj["output_heap"].is_string());
+            assert!(!obj["output_heap"].as_str().unwrap().is_empty());
+        }
+    }
+}
+
+#[test]
+fn test_repeated_open_close_cycles() {
+    // Open, write, close, reopen, write more — multiple cycles.
+    // Verify cumulative state is correct after each reopen.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("session_db");
+    let db_path_str = db_path.to_str().unwrap();
+
+    let entries_per_cycle = 3;
+    let num_cycles = 5;
+
+    for cycle in 0..num_cycles {
+        let log = SessionLog::new(db_path_str).unwrap();
+
+        let offset = cycle * entries_per_cycle;
+        let mut prev = if offset > 0 {
+            Some(format!("hash_{}", offset - 1))
+        } else {
+            None
+        };
+
+        for i in 0..entries_per_cycle {
+            let idx = offset + i;
+            let output = format!("hash_{}", idx);
+            log.append(
+                "cycle-session",
+                make_entry(prev.as_deref(), &output, &format!("step_{}", idx)),
+            )
+            .unwrap();
+            prev = Some(output);
+        }
+
+        log.flush().unwrap();
+
+        // Verify total entries so far
+        let entries = log.list_entries("cycle-session", None).unwrap();
+        assert_eq!(
+            entries.len(),
+            (cycle + 1) * entries_per_cycle,
+            "after cycle {}, expected {} entries",
+            cycle,
+            (cycle + 1) * entries_per_cycle
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_concurrent_session_writers_no_duplicates() {
+    // Two "nodes" (tasks) writing to the same session concurrently.
+    // Assert no duplicate sequence numbers and all entries are present.
+    let log = Arc::new(
+        SessionLog::from_config(sled::Config::new().temporary(true))
+            .expect("failed to open temp sled"),
+    );
+
+    let num_per_writer = 50;
+
+    let log1 = log.clone();
+    let writer1 = tokio::spawn(async move {
+        let mut seqs = Vec::new();
+        for i in 0..num_per_writer {
+            let seq = log1
+                .append(
+                    "shared-session",
+                    make_entry(None, &format!("w1_hash_{}", i), &format!("w1_code_{}", i)),
+                )
+                .unwrap();
+            seqs.push(seq);
+        }
+        seqs
+    });
+
+    let log2 = log.clone();
+    let writer2 = tokio::spawn(async move {
+        let mut seqs = Vec::new();
+        for i in 0..num_per_writer {
+            let seq = log2
+                .append(
+                    "shared-session",
+                    make_entry(None, &format!("w2_hash_{}", i), &format!("w2_code_{}", i)),
+                )
+                .unwrap();
+            seqs.push(seq);
+        }
+        seqs
+    });
+
+    let seqs1 = writer1.await.unwrap();
+    let seqs2 = writer2.await.unwrap();
+
+    // All sequence numbers should be globally unique
+    let mut all_seqs: Vec<u64> = seqs1.into_iter().chain(seqs2).collect();
+    let total = all_seqs.len();
+    all_seqs.sort();
+    all_seqs.dedup();
+    assert_eq!(
+        all_seqs.len(),
+        total,
+        "duplicate sequence numbers detected"
+    );
+
+    // Total entries should be 2 * num_per_writer
+    let entries = log.list_entries("shared-session", None).unwrap();
+    assert_eq!(entries.len(), num_per_writer * 2);
+
+    // All entries should be valid
+    for entry in &entries {
+        let obj = entry.as_object().unwrap();
+        let output = obj["output_heap"].as_str().unwrap();
+        assert!(
+            output.starts_with("w1_hash_") || output.starts_with("w2_hash_"),
+            "unexpected output_heap: {}",
+            output
+        );
+    }
+}
+
+#[test]
+fn test_deterministic_workload_replay() {
+    // Run the exact same workload twice on two separate DBs.
+    // The resulting entries should be identical (excluding sequence numbers,
+    // which depend on global sled state).
+    let log1 =
+        SessionLog::from_config(sled::Config::new().temporary(true)).expect("open temp sled");
+    let log2 =
+        SessionLog::from_config(sled::Config::new().temporary(true)).expect("open temp sled");
+
+    let count = 20;
+    run_workload(&log1, "deterministic", count);
+    run_workload(&log2, "deterministic", count);
+
+    let entries1 = log1.list_entries("deterministic", None).unwrap();
+    let entries2 = log2.list_entries("deterministic", None).unwrap();
+
+    assert_eq!(entries1.len(), entries2.len());
+
+    for (e1, e2) in entries1.iter().zip(entries2.iter()) {
+        // Content should be identical (ignoring index which may differ)
+        assert_eq!(e1["input_heap"], e2["input_heap"]);
+        assert_eq!(e1["output_heap"], e2["output_heap"]);
+        assert_eq!(e1["code"], e2["code"]);
+        assert_eq!(e1["timestamp"], e2["timestamp"]);
+    }
+}
+
+#[test]
+fn test_linearizable_session_operations() {
+    // Simulate a sequence of operations and verify the observed results
+    // are consistent with a serial execution.
+    let log =
+        SessionLog::from_config(sled::Config::new().temporary(true)).expect("open temp sled");
+
+    // Operation sequence: append, append, list, append, get_latest, list
+    log.append("linear", make_entry(None, "h0", "c0")).unwrap();
+    log.append("linear", make_entry(Some("h0"), "h1", "c1"))
+        .unwrap();
+
+    let entries = log.list_entries("linear", None).unwrap();
+    assert_eq!(entries.len(), 2);
+
+    log.append("linear", make_entry(Some("h1"), "h2", "c2"))
+        .unwrap();
+
+    let latest = log.get_latest("linear").unwrap().unwrap();
+    assert_eq!(latest.output_heap, "h2");
+
+    let entries = log.list_entries("linear", None).unwrap();
+    assert_eq!(entries.len(), 3);
+
+    // Verify full chain manually (uses h0/h1/h2 naming, not hash_N)
+    assert!(entries[0]["input_heap"].is_null());
+    assert_eq!(entries[0]["output_heap"], "h0");
+    assert_eq!(entries[1]["input_heap"], "h0");
+    assert_eq!(entries[1]["output_heap"], "h1");
+    assert_eq!(entries[2]["input_heap"], "h1");
+    assert_eq!(entries[2]["output_heap"], "h2");
+}


### PR DESCRIPTION
## Summary
This PR introduces a session logging system that persists execution history for stateful JavaScript runs. It enables tracking of code execution chains with input/output heap hashes and timestamps, supporting both crash recovery and concurrent access patterns.

## Key Changes

- **New `SessionLog` module** (`server/src/mcp/session_log.rs`):
  - Persistent session storage backed by sled embedded database
  - Core operations: `append()` for logging entries, `list_entries()` for retrieval, `get_latest()` for the most recent entry
  - Field filtering support to selectively return entry components (index, input_heap, output_heap, code, timestamp)
  - Monotonically increasing sequence numbers via sled's `generate_id()`
  - Flush capability for explicit durability control

- **Integration with `StatefulService`**:
  - Added optional `session_log` field to track execution history
  - New `session` parameter in `run_js()` to associate executions with named sessions
  - Automatic logging of each execution with input heap, output heap, code, and timestamp
  - New `list_sessions()` tool to enumerate all named sessions
  - New `list_session_snapshots()` tool to retrieve entries for a specific session with optional field filtering

- **CLI configuration**:
  - New `--session-db-path` flag (default: `/tmp/mcp-v8-sessions`) to configure sled database location
  - Graceful degradation if session log initialization fails (logs warning, continues without session tracking)

- **Comprehensive test coverage**:
  - `session_log.rs`: Unit tests covering basic operations, multiple sessions, concurrent writes, atomicity, and field filtering
  - `session_simulation.rs`: Deterministic simulation tests following sled's philosophy, including crash/recovery semantics, repeated open/close cycles, and linearizability verification

## Implementation Details

- Session entries form a chain where each entry's `input_heap` references the previous entry's `output_heap`, enabling full execution history reconstruction
- Sequence numbers are globally unique across all sessions via sled's database-level ID generator
- Entries are stored as JSON-serialized `SessionLogEntry` structs with big-endian u64 keys for ordered iteration
- The system handles concurrent writes safely through sled's internal locking mechanisms
- Unflushed entries may be lost on crash (sled guarantee), but flushed entries are durable and all surviving entries are guaranteed to be complete and valid

https://claude.ai/code/session_01XdzU1iZfVswuWLeemBLgiY