### PR TITLE
Add panic handling and session logging to V8 execution

### DIFF
--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -66,53 +66,78 @@ the source code of the runtime is this
 ```rust
 // Execute JS with snapshot support (preserves heap state)
 pub fn execute_stateful(code: String, snapshot: Option<Vec<u8>>, heap_memory_max_bytes: usize, timeout_secs: u64) -> Result<(String, Vec<u8>, String), String> {
-    let params = Some(create_params_with_heap_limit(heap_memory_max_bytes));
-
     let raw_snapshot = match snapshot {
         Some(data) if !data.is_empty() => Some(unwrap_snapshot(&data)?),
         _ => None,
     };
 
-    let mut snapshot_creator = match raw_snapshot {
-        Some(raw) if !raw.is_empty() => {
-            v8::Isolate::snapshot_creator_from_existing_snapshot(raw, None, params)
-        }
-        _ => {
-            v8::Isolate::snapshot_creator(None, params)
-        }
-    };
-    install_heap_limit_callback(&mut snapshot_creator);
-    let _timeout_guard = install_execution_timeout(&mut snapshot_creator, timeout_secs);
+    let oom_flag = Arc::new(AtomicBool::new(false));
+    let timeout_flag = Arc::new(AtomicBool::new(false));
 
-    let output_result;
-    {
-        let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-        let context = v8::Context::new(scope, Default::default());
-        let scope = &mut v8::ContextScope::new(scope, context);
-        output_result = match eval(scope, &code) {
-            Ok(result) => {
-                result
-                    .to_string(scope)
-                    .map(|s| s.to_rust_string_lossy(scope))
-                    .ok_or_else(|| "Failed to convert result to string".to_string())
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let params = Some(create_params_with_heap_limit(heap_memory_max_bytes));
+
+        let mut snapshot_creator = match raw_snapshot {
+            Some(raw) if !raw.is_empty() => {
+                v8::Isolate::snapshot_creator_from_existing_snapshot(raw, None, params)
             }
-            Err(e) => Err(e),
+            _ => {
+                v8::Isolate::snapshot_creator(None, params)
+            }
         };
-        scope.set_default_context(context);
+
+        let cb_data_ptr = install_heap_limit_callback(&mut snapshot_creator, oom_flag.clone());
+        let _timeout_guard = install_execution_timeout(&mut snapshot_creator, timeout_secs, timeout_flag.clone());
+
+        let output_result;
+        {
+            let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
+            let context = v8::Context::new(scope, Default::default());
+            let scope = &mut v8::ContextScope::new(scope, context);
+            output_result = match eval(scope, &code) {
+                Ok(result) => {
+                    result
+                        .to_string(scope)
+                        .map(|s| s.to_rust_string_lossy(scope))
+                        .ok_or_else(|| "Failed to convert result to string".to_string())
+                }
+                Err(e) => Err(e),
+            };
+            scope.set_default_context(context);
+        }
+
+        unsafe { let _ = Box::from_raw(cb_data_ptr); }
+
+        let startup_data = snapshot_creator.create_blob(v8::FunctionCodeHandling::Clear)
+            .ok_or("Failed to create V8 snapshot blob".to_string())?;
+        let wrapped = wrap_snapshot(&startup_data);
+
+        output_result.map(|output| (output, wrapped.data, wrapped.content_hash))
+    }));
+
+    match result {
+        Ok(inner) => inner.map_err(|e| classify_termination_error(&oom_flag, &timeout_flag, e)),
+        Err(_panic) => Err(classify_termination_error(
+            &oom_flag,
+            &timeout_flag,
+            "V8 execution panicked unexpectedly".to_string(),
+        )),
     }
-
-    let startup_data = snapshot_creator.create_blob(v8::FunctionCodeHandling::Clear)
-        .ok_or("Failed to create V8 snapshot blob".to_string())?;
-    let wrapped = wrap_snapshot(&startup_data);
-
-    output_result.map(|output| (output, wrapped.data, wrapped.content_hash))
 }
 
-// Stateful service implementation
+// Stateful service with heap persistence
+#[derive(Clone)]
+pub struct StatefulService {
+    heap_storage: AnyHeapStorage,
+    session_log: Option<SessionLog>,
+    heap_memory_max_bytes: usize,
+    execution_timeout_secs: u64,
+}
+
 #[tool(tool_box)]
 impl StatefulService {
-    pub fn new(heap_storage: AnyHeapStorage, heap_memory_max_bytes: usize, execution_timeout_secs: u64) -> Self {
-        Self { heap_storage, heap_memory_max_bytes, execution_timeout_secs }
+    pub fn new(heap_storage: AnyHeapStorage, session_log: Option<SessionLog>, heap_memory_max_bytes: usize, execution_timeout_secs: u64) -> Self {
+        Self { heap_storage, session_log, heap_memory_max_bytes, execution_timeout_secs }
     }
 
     #[tool(description = include_str!("run_js_tool_description.md"))]
@@ -122,6 +147,9 @@ impl StatefulService {
         #[tool(param)]
         #[serde(default)]
         heap: Option<String>,
+        #[tool(param)]
+        #[serde(default)]
+        session: Option<String>,
         #[tool(param)]
         #[serde(default)]
         heap_memory_max_mb: Option<usize>,
@@ -137,6 +165,7 @@ impl StatefulService {
             Some(h) if !h.is_empty() => self.heap_storage.get(h).await.ok(),
             _ => None,
         };
+        let code_for_log = code.clone();
         let v8_result = tokio::task::spawn_blocking(move || execute_stateful(code, snapshot, max_bytes, timeout)).await;
 
         match v8_result {
@@ -147,6 +176,20 @@ impl StatefulService {
                         heap: content_hash,
                     };
                 }
+
+                // Log to session if session name is provided and session log is available
+                if let (Some(session_name), Some(log)) = (&session, &self.session_log) {
+                    let entry = SessionLogEntry {
+                        input_heap: heap.clone(),
+                        output_heap: content_hash.clone(),
+                        code: code_for_log,
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                    };
+                    if let Err(e) = log.append(session_name, entry) {
+                        tracing::warn!("Failed to log session entry: {}", e);
+                    }
+                }
+
                 RunJsStatefulResponse { output, heap: content_hash }
             }
             Ok(Err(e)) => RunJsStatefulResponse {


### PR DESCRIPTION
## Summary

This PR enhances the V8 JavaScript execution runtime with improved error handling and session logging capabilities. The changes add panic recovery for V8 execution, better error classification for OOM and timeout conditions, and a new session logging system to track execution history in stateful mode.

## Key Changes

- **Panic Recovery**: Wrapped both stateful and stateless execution functions with `catch_unwind` to gracefully handle V8 panics and convert them to error messages instead of crashing the process.

- **Enhanced Error Classification**: Introduced `classify_termination_error()` function that distinguishes between out-of-memory errors, timeouts, and other execution failures by checking atomic flags set by the heap limit and timeout callbacks.

- **Callback Data Management**: Updated heap limit and timeout callbacks to return pointers to allocated data that are properly cleaned up after execution, preventing memory leaks.

- **Session Logging System**: 
  - Added `SessionLog` support to `StatefulService` for recording execution history
  - Each execution can now be tagged with a `session` parameter
  - Session entries capture input heap, output heap, code, and timestamp
  - Added `--session-db-path` CLI option to configure the sled database location (defaults to `/tmp/mcp-v8-sessions`)

- **New Session Tools** (in stateful mode):
  - `list_sessions`: Returns all session names that have been used
  - `list_session_snapshots`: Returns log entries for a given session with optional field filtering

- **Documentation Updates**: Updated README and tool descriptions to document the new CLI options and session logging workflow.

## Implementation Details

- Atomic flags (`oom_flag`, `timeout_flag`) are shared between the execution closure and error classification logic to determine the cause of termination
- Session logging is optional and only occurs when both a session name and session log are provided
- Failed session log writes are logged as warnings but don't interrupt execution
- The execution timeout and heap limit callbacks now properly manage callback data lifecycle

https://claude.ai/code/session_01QtPrgwyDj421RpskgZcuS4