### PR TITLE
Remove unused #[allow(dead_code)] attributes

### DIFF
--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -325,12 +325,6 @@ pub fn initialize_v8() {
 
 
 
-#[allow(dead_code)]
-pub trait DataService: Send + Sync + 'static {
-    fn get_data(&self) -> String;
-    fn set_data(&mut self, data: String);
-}
-
 // Stateful service with heap persistence
 #[derive(Clone)]
 pub struct StatefulService {

--- a/server/src/mcp/heap_storage.rs
+++ b/server/src/mcp/heap_storage.rs
@@ -19,8 +19,6 @@ pub struct FileHeapStorage {
 
 impl FileHeapStorage {
 
-    // ignore dead_code warning
-    #[allow(dead_code)]
     pub fn new(dir: impl Into<PathBuf>) -> Self {
         let dir = dir.into();
         std::fs::create_dir_all(&dir).ok();
@@ -100,7 +98,6 @@ impl HeapStorage for S3HeapStorage {
 
 #[derive(Clone)]
 pub enum AnyHeapStorage {
-    #[allow(dead_code)]
     File(FileHeapStorage),
     S3(S3HeapStorage),
 }

--- a/server/src/mcp/session_log.rs
+++ b/server/src/mcp/session_log.rs
@@ -13,7 +13,6 @@ pub struct SessionLog {
     db: sled::Db,
 }
 
-#[allow(dead_code)]
 impl SessionLog {
     pub fn new(path: &str) -> Result<Self, String> {
         let db = sled::open(path).map_err(|e| format!("Failed to open sled db: {}", e))?;


### PR DESCRIPTION
## Summary
This PR removes unnecessary `#[allow(dead_code)]` attributes from the codebase. These attributes were suppressing compiler warnings for code that is actually being used or no longer needs the suppression.

## Key Changes
- Removed unused `DataService` trait from `server/src/mcp.rs` that was marked with `#[allow(dead_code)]`
- Removed `#[allow(dead_code)]` attribute from `FileHeapStorage::new()` method in `server/src/mcp/heap_storage.rs` - this method is actively used
- Removed `#[allow(dead_code)]` attribute from the `File` variant in the `AnyHeapStorage` enum in `server/src/mcp/heap_storage.rs`
- Removed `#[allow(dead_code)]` attribute from the `SessionLog` impl block in `server/src/mcp/session_log.rs`

## Details
These changes clean up the codebase by removing dead code suppression attributes that are no longer necessary. The `DataService` trait was completely unused and has been removed. The other attributes were suppressing legitimate compiler warnings for code that is actually in use, so removing them allows the compiler to properly validate the code without unnecessary suppressions.

https://claude.ai/code/session_01BrL9AjA7ToQmLhfo4et9qg