### PR TITLE
Add S3 write-through cache with local filesystem

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 mod mcp;
 use mcp::{StatelessService, StatefulService, initialize_v8, DEFAULT_EXECUTION_TIMEOUT_SECS};
-use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, FileHeapStorage};
+use mcp::heap_storage::{AnyHeapStorage, S3HeapStorage, S3WithFsCacheHeapStorage, FileHeapStorage};
 use mcp::session_log::SessionLog;
 
 /// Command line arguments for configuring heap storage
@@ -24,6 +24,10 @@ struct Cli {
     /// S3 bucket name (required if --use-s3)
     #[arg(long, conflicts_with_all = ["directory_path", "stateless"])]
     s3_bucket: Option<String>,
+
+    /// Local filesystem cache directory for S3 write-through caching (only used with --s3-bucket)
+    #[arg(long, requires = "s3_bucket")]
+    cache_dir: Option<String>,
 
     /// Directory path for filesystem storage (required if --use-filesystem)
     #[arg(long, conflicts_with_all = ["s3_bucket", "stateless"])]
@@ -96,7 +100,12 @@ async fn main() -> Result<()> {
     } else {
         // Stateful mode - with heap persistence
         let heap_storage = if let Some(bucket) = cli.s3_bucket {
-            AnyHeapStorage::S3(S3HeapStorage::new(bucket).await)
+            if let Some(cache_dir) = cli.cache_dir {
+                tracing::info!("Using S3 storage with FS write-through cache at {}", cache_dir);
+                AnyHeapStorage::S3WithFsCache(S3WithFsCacheHeapStorage::new(bucket, cache_dir).await)
+            } else {
+                AnyHeapStorage::S3(S3HeapStorage::new(bucket).await)
+            }
         } else if let Some(dir) = cli.directory_path {
             AnyHeapStorage::File(FileHeapStorage::new(dir))
         } else {

--- a/server/src/mcp/heap_storage.rs
+++ b/server/src/mcp/heap_storage.rs
@@ -96,10 +96,52 @@ impl HeapStorage for S3HeapStorage {
     }
 }
 
+/// S3 storage with a local filesystem write-through cache.
+/// On put: writes to both the local FS cache and S3.
+/// On get: checks the FS cache first; falls back to S3 and caches the result locally.
+#[derive(Clone)]
+pub struct S3WithFsCacheHeapStorage {
+    s3: S3HeapStorage,
+    cache: FileHeapStorage,
+}
+
+impl S3WithFsCacheHeapStorage {
+    pub async fn new(bucket: impl Into<String>, cache_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            s3: S3HeapStorage::new(bucket).await,
+            cache: FileHeapStorage::new(cache_dir),
+        }
+    }
+}
+
+#[async_trait]
+impl HeapStorage for S3WithFsCacheHeapStorage {
+    async fn put(&self, name: &str, data: &[u8]) -> Result<(), String> {
+        // Write-through: write to both FS cache and S3
+        self.cache.put(name, data).await?;
+        self.s3.put(name, data).await?;
+        Ok(())
+    }
+    async fn get(&self, name: &str) -> Result<Vec<u8>, String> {
+        // Check FS cache first
+        if let Ok(data) = self.cache.get(name).await {
+            return Ok(data);
+        }
+        // Cache miss: fetch from S3 and populate cache
+        let data = self.s3.get(name).await?;
+        // Best-effort cache population; don't fail if local write fails
+        if let Err(e) = self.cache.put(name, &data).await {
+            tracing::warn!("Failed to populate FS cache for {}: {}", name, e);
+        }
+        Ok(data)
+    }
+}
+
 #[derive(Clone)]
 pub enum AnyHeapStorage {
     File(FileHeapStorage),
     S3(S3HeapStorage),
+    S3WithFsCache(S3WithFsCacheHeapStorage),
 }
 
 
@@ -111,12 +153,14 @@ impl HeapStorage for AnyHeapStorage {
         match self {
             AnyHeapStorage::File(inner) => inner.put(name, data).await,
             AnyHeapStorage::S3(inner) => inner.put(name, data).await,
+            AnyHeapStorage::S3WithFsCache(inner) => inner.put(name, data).await,
         }
     }
     async fn get(&self, name: &str) -> Result<Vec<u8>, String> {
         match self {
             AnyHeapStorage::File(inner) => inner.get(name).await,
             AnyHeapStorage::S3(inner) => inner.get(name).await,
+            AnyHeapStorage::S3WithFsCache(inner) => inner.get(name).await,
         }
     }
 } 

--- a/server/tests/write_through_cache.rs
+++ b/server/tests/write_through_cache.rs
@@ -1,0 +1,189 @@
+/// Tests for WriteThroughCacheHeapStorage.
+///
+/// Uses FileHeapStorage as the primary backend (standing in for S3)
+/// so the write-through cache logic can be exercised without AWS credentials.
+
+use server::mcp::heap_storage::{FileHeapStorage, HeapStorage, WriteThroughCacheHeapStorage};
+use std::path::PathBuf;
+
+fn temp_dir(suffix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "mcp-wt-cache-test-{}-{}-{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("unknown"),
+        suffix
+    ));
+    std::fs::create_dir_all(&dir).ok();
+    dir
+}
+
+fn cleanup(dir: &PathBuf) {
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[tokio::test]
+async fn test_put_writes_to_both_cache_and_primary() {
+    let primary_dir = temp_dir("primary-put");
+    let cache_dir = temp_dir("cache-put");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    let data = b"hello world";
+    cached.put("key1", data).await.unwrap();
+
+    // Verify data exists in both the cache and primary directories
+    let cached_data = std::fs::read(cache_dir.join("key1")).unwrap();
+    assert_eq!(cached_data, data);
+
+    let primary_data = std::fs::read(primary_dir.join("key1")).unwrap();
+    assert_eq!(primary_data, data);
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}
+
+#[tokio::test]
+async fn test_get_returns_from_cache_on_hit() {
+    let primary_dir = temp_dir("primary-cache-hit");
+    let cache_dir = temp_dir("cache-cache-hit");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    // Write data via the cache (populates both)
+    cached.put("key1", b"original").await.unwrap();
+
+    // Now change the primary directly to prove the cache is used, not the primary
+    std::fs::write(primary_dir.join("key1"), b"modified-in-primary").unwrap();
+
+    let result = cached.get("key1").await.unwrap();
+    assert_eq!(result, b"original", "Should return cached data, not primary");
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}
+
+#[tokio::test]
+async fn test_get_falls_back_to_primary_on_cache_miss() {
+    let primary_dir = temp_dir("primary-miss");
+    let cache_dir = temp_dir("cache-miss");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    // Write data only to the primary directory (simulating data in S3 but not cached)
+    std::fs::write(primary_dir.join("key1"), b"from-primary").unwrap();
+
+    let result = cached.get("key1").await.unwrap();
+    assert_eq!(result, b"from-primary", "Should fall back to primary on cache miss");
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}
+
+#[tokio::test]
+async fn test_get_populates_cache_after_primary_fetch() {
+    let primary_dir = temp_dir("primary-populate");
+    let cache_dir = temp_dir("cache-populate");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    // Write data only to the primary (cache miss scenario)
+    std::fs::write(primary_dir.join("key1"), b"from-primary").unwrap();
+
+    // First get: cache miss, fetches from primary
+    let result = cached.get("key1").await.unwrap();
+    assert_eq!(result, b"from-primary");
+
+    // Verify the cache was populated
+    let cache_data = std::fs::read(cache_dir.join("key1")).unwrap();
+    assert_eq!(cache_data, b"from-primary", "Cache should be populated after miss");
+
+    // Second get: should now come from cache even if primary is changed
+    std::fs::write(primary_dir.join("key1"), b"modified-in-primary").unwrap();
+    let result2 = cached.get("key1").await.unwrap();
+    assert_eq!(result2, b"from-primary", "Second get should use cached copy");
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}
+
+#[tokio::test]
+async fn test_get_returns_error_when_both_miss() {
+    let primary_dir = temp_dir("primary-both-miss");
+    let cache_dir = temp_dir("cache-both-miss");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    let result = cached.get("nonexistent").await;
+    assert!(result.is_err(), "Should return error when key is in neither cache nor primary");
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}
+
+#[tokio::test]
+async fn test_multiple_keys_isolated() {
+    let primary_dir = temp_dir("primary-multi");
+    let cache_dir = temp_dir("cache-multi");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    cached.put("key1", b"value1").await.unwrap();
+    cached.put("key2", b"value2").await.unwrap();
+
+    assert_eq!(cached.get("key1").await.unwrap(), b"value1");
+    assert_eq!(cached.get("key2").await.unwrap(), b"value2");
+
+    // Keys don't interfere with each other
+    assert_ne!(cached.get("key1").await.unwrap(), cached.get("key2").await.unwrap());
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}
+
+#[tokio::test]
+async fn test_put_overwrites_existing_data() {
+    let primary_dir = temp_dir("primary-overwrite");
+    let cache_dir = temp_dir("cache-overwrite");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    cached.put("key1", b"first").await.unwrap();
+    assert_eq!(cached.get("key1").await.unwrap(), b"first");
+
+    cached.put("key1", b"second").await.unwrap();
+    assert_eq!(cached.get("key1").await.unwrap(), b"second");
+
+    // Both locations updated
+    assert_eq!(std::fs::read(cache_dir.join("key1")).unwrap(), b"second");
+    assert_eq!(std::fs::read(primary_dir.join("key1")).unwrap(), b"second");
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}
+
+#[tokio::test]
+async fn test_large_binary_data() {
+    let primary_dir = temp_dir("primary-large");
+    let cache_dir = temp_dir("cache-large");
+
+    let primary = FileHeapStorage::new(&primary_dir);
+    let cached = WriteThroughCacheHeapStorage::new(primary, &cache_dir);
+
+    // Simulate a realistic heap snapshot size (512KB)
+    let data: Vec<u8> = (0..512 * 1024).map(|i| (i % 256) as u8).collect();
+
+    cached.put("big-heap", &data).await.unwrap();
+
+    let result = cached.get("big-heap").await.unwrap();
+    assert_eq!(result, data, "Large binary data should round-trip correctly");
+
+    cleanup(&primary_dir);
+    cleanup(&cache_dir);
+}


### PR DESCRIPTION
## Summary
Introduces a new `S3WithFsCacheHeapStorage` implementation that combines S3 object storage with a local filesystem write-through cache, improving read performance for frequently accessed objects while maintaining durability through S3.

## Key Changes
- **New storage backend**: `S3WithFsCacheHeapStorage` that wraps both `S3HeapStorage` and `FileHeapStorage`
  - On `put`: writes to both local FS cache and S3 (write-through)
  - On `get`: checks FS cache first, falls back to S3 on cache miss, and populates cache with best-effort semantics
- **Updated `AnyHeapStorage` enum**: Added `S3WithFsCache` variant to support the new storage type
- **CLI configuration**: Added `--cache-dir` argument that requires `--s3-bucket` to enable the caching layer
- **Main initialization logic**: Updated to instantiate `S3WithFsCacheHeapStorage` when both S3 bucket and cache directory are specified

## Implementation Details
- Cache misses are handled gracefully: if local cache population fails after fetching from S3, a warning is logged but the operation succeeds
- The write-through cache ensures consistency between local and S3 storage
- The `--cache-dir` argument is marked as requiring `--s3-bucket`, preventing misconfiguration

https://claude.ai/code/session_01L3MCmBS73hpKR6RvGhKvJ5