### PR TITLE
Add bounded ArrayBuffer allocator to prevent typed-array OOM crashes

### DIFF
--- a/server/tests/heap_limit.rs
+++ b/server/tests/heap_limit.rs
@@ -172,7 +172,6 @@ try {
 "#;
 
 #[test]
-#[ignore] // Currently crashes the process (SIGSEGV) — un-ignore once typed-array OOM is handled
 fn test_typed_array_oom_does_not_crash_stateless() {
     ensure_v8();
 
@@ -193,7 +192,6 @@ fn test_typed_array_oom_does_not_crash_stateless() {
 }
 
 #[test]
-#[ignore] // Currently crashes the process (SIGSEGV) — un-ignore once typed-array OOM is handled
 fn test_typed_array_oom_does_not_crash_stateful() {
     ensure_v8();
 

--- a/server/tests/heap_limit.rs
+++ b/server/tests/heap_limit.rs
@@ -145,3 +145,66 @@ fn test_different_limits_produce_different_outcomes() {
         "256MB limit should allow large allocation"
     );
 }
+
+// ── Typed-array OOM (hard crash regression) ──────────────────────────────
+
+/// Typed arrays (Uint8Array) allocate backing stores outside V8's managed
+/// JS heap, so an OOM from unbounded typed-array growth can terminate the
+/// isolate at a lower level than normal JS-heap OOM — causing a hard crash
+/// ("Error occurred during tool execution") instead of a clean error.
+///
+/// This test reproduces the scenario: allocate 1 MB Uint8Array chunks in a
+/// loop with an 8 MB heap limit, and asserts the engine returns an error
+/// rather than crashing the process.
+const TYPED_ARRAY_OOM_JS: &str = r#"
+let totalBytes = 0;
+const chunks = [];
+try {
+  while (true) {
+    const buf = new Uint8Array(1024 * 1024); // 1MB at a time
+    buf.fill(0xFF);
+    chunks.push(buf);
+    totalBytes += buf.length;
+  }
+} catch(e) {
+  `Allocated ${chunks.length} x 1MB chunks = ${totalBytes / 1e6}MB before OOM`
+}
+"#;
+
+#[test]
+#[ignore] // Currently crashes the process (SIGSEGV) — un-ignore once typed-array OOM is handled
+fn test_typed_array_oom_does_not_crash_stateless() {
+    ensure_v8();
+
+    // 8 MB heap — typed array backing stores will exceed this quickly
+    let heap_bytes = 8 * 1024 * 1024;
+    let (result, _oom) = server::engine::execute_stateless(TYPED_ARRAY_OOM_JS, heap_bytes, no_handle());
+
+    // We don't care whether it's Ok (the JS catch fired) or Err (V8 killed it) —
+    // the critical thing is that we *get here* instead of a process crash.
+    // If this is an Err, the message should be descriptive.
+    if let Err(ref e) = result {
+        assert!(
+            !e.contains("Error occurred during tool execution"),
+            "Typed-array OOM should produce a V8-level error, not a hard crash. Got: {}",
+            e,
+        );
+    }
+}
+
+#[test]
+#[ignore] // Currently crashes the process (SIGSEGV) — un-ignore once typed-array OOM is handled
+fn test_typed_array_oom_does_not_crash_stateful() {
+    ensure_v8();
+
+    let heap_bytes = 8 * 1024 * 1024;
+    let (result, _oom) = server::engine::execute_stateful(TYPED_ARRAY_OOM_JS, None, heap_bytes, no_handle());
+
+    if let Err(ref e) = result {
+        assert!(
+            !e.contains("Error occurred during tool execution"),
+            "Typed-array OOM should produce a V8-level error, not a hard crash. Got: {}",
+            e,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a custom bounded ArrayBuffer allocator to V8 that prevents out-of-memory crashes when typed arrays (Uint8Array, etc.) exceed the heap limit. Previously, unbounded growth of typed-array backing stores could cause hard process crashes instead of clean JS-level errors.

## Key Changes
- **New `BoundedAllocatorState` struct**: Tracks total allocated bytes across all typed-array backing stores with an atomic counter and enforces a configurable limit
- **Custom allocator functions**: Implemented `bounded_allocate`, `bounded_allocate_uninitialized`, `bounded_free`, and `bounded_drop` that:
  - Atomically reserve/release allocation space
  - Return null on allocation failure (triggering V8's RangeError instead of abort)
  - Use proper memory alignment (16 bytes) matching platform malloc
  - Handle layout errors gracefully
- **Integration with V8 CreateParams**: Modified `create_params_with_heap_limit()` to attach the bounded allocator with the same limit as the JS heap
- **Comprehensive test coverage**: Added two regression tests (`test_typed_array_oom_does_not_crash_stateless` and `test_typed_array_oom_does_not_crash_stateful`) that verify typed-array OOM produces a clean error rather than a process crash

## Implementation Details
- Uses `AtomicUsize` with `SeqCst` ordering for thread-safe allocation tracking
- Implements V8's `RustAllocatorVtable` interface for custom memory management
- Gracefully handles edge cases: zero-length allocations, layout failures, and allocation failures
- Maintains proper accounting by undoing atomic increments if allocation fails

https://claude.ai/code/session_01Cg9AfHdJhGgbrHfvYfmCQz