### PR TITLE
Refactor V8 execution with async timeout, concurrency control, and improved docs

### DIFF
--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -100,7 +100,7 @@ impl McpService {
         }
     }
 
-    #[tool(description = "List all named sessions. Returns an array of session names that have been used with the session parameter in run_js.")]
+    #[tool(description = "List all named sessions (stateful mode only). Returns an array of session names that have been used with the session parameter in run_js.")]
     pub async fn list_sessions(&self) -> ListSessionsResponse {
         match self.engine.list_sessions().await {
             Ok(sessions) => ListSessionsResponse { sessions },
@@ -110,7 +110,7 @@ impl McpService {
         }
     }
 
-    #[tool(description = "List all log entries for a named session. Each entry contains the input heap hash, output heap hash, code executed, and timestamp. Use the fields parameter to select specific fields (comma-separated: index,input_heap,output_heap,code,timestamp).")]
+    #[tool(description = "List all log entries for a named session (stateful mode only). Each entry contains the input heap hash, output heap hash, code executed, and timestamp. Use the fields parameter to select specific fields (comma-separated: index,input_heap,output_heap,code,timestamp).")]
     pub async fn list_session_snapshots(
         &self,
         #[tool(param)] session: String,

--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -1,7 +1,9 @@
-run javascript code in v8
+run javascript or typescript code in v8
+
+TypeScript support is type removal only — types are stripped before execution, not checked. Invalid types will be silently removed, not reported as errors.
 
 params:
-- code: the javascript code to run
+- code: the javascript or typescript code to run
 - heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (1–64, default: 8). Override the server default for this execution.
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 
@@ -10,10 +12,7 @@ returns:
 
 
 
-
 ## Limitations
-
-While `mcp-v8` provides a powerful and persistent JavaScript execution environment, there are limitations to its runtime. 
 
 - **No `async`/`await` or Promises**: Asynchronous JavaScript is not supported. All code must be synchronous.
 - **No `fetch` or network access**: There is no built-in way to make HTTP requests or access the network.
@@ -63,24 +62,31 @@ you are running in stateless mode, so the heap is not persisted between executio
 the source code of the runtime is this
 
 ```rust
-// Execute JS in a stateless isolate (no snapshot creation)
-pub fn execute_stateless(code: String, heap_memory_max_bytes: usize, timeout_secs: u64) -> Result<String, String> {
+/// Stateless V8 execution — runs V8 on the calling thread. Publishes an
+/// IsolateHandle for external cancellation (e.g. async timeout in `run_js`).
+/// Returns (result, oom_flag).
+pub fn execute_stateless(
+    code: &str,
+    heap_memory_max_bytes: usize,
+    isolate_handle: Arc<Mutex<Option<v8::IsolateHandle>>>,
+) -> (Result<String, String>, bool) {
     let oom_flag = Arc::new(AtomicBool::new(false));
-    let timeout_flag = Arc::new(AtomicBool::new(false));
 
     let result = catch_unwind(AssertUnwindSafe(|| {
         let params = create_params_with_heap_limit(heap_memory_max_bytes);
         let mut isolate = v8::Isolate::new(params);
 
+        // Publish handle immediately so caller can terminate us.
+        *isolate_handle.lock().unwrap() = Some(isolate.thread_safe_handle());
+
         let cb_data_ptr = install_heap_limit_callback(&mut isolate, oom_flag.clone());
-        let _timeout_guard = install_execution_timeout(&mut isolate, timeout_secs, timeout_flag.clone());
 
         let eval_result = {
             let scope = &mut v8::HandleScope::new(&mut isolate);
             let context = v8::Context::new(scope, Default::default());
             let scope = &mut v8::ContextScope::new(scope, context);
 
-            match eval(scope, &code) {
+            match eval(scope, code) {
                 Ok(value) => match value.to_string(scope) {
                     Some(s) => Ok(s.to_rust_string_lossy(scope)),
                     None => Err("Failed to convert result to string".to_string()),
@@ -89,56 +95,37 @@ pub fn execute_stateless(code: String, heap_memory_max_bytes: usize, timeout_sec
             }
         };
 
+        // Clear handle BEFORE destroying isolate.
+        *isolate_handle.lock().unwrap() = None;
         drop(isolate);
         unsafe { let _ = Box::from_raw(cb_data_ptr); }
 
         eval_result
     }));
 
+    let oom = oom_flag.load(Ordering::SeqCst);
     match result {
-        Ok(Ok(output)) => Ok(output),
-        Ok(Err(e)) => Err(classify_termination_error(&oom_flag, &timeout_flag, e)),
-        Err(_panic) => Err(classify_termination_error(
-            &oom_flag,
-            &timeout_flag,
-            "V8 execution panicked unexpectedly".to_string(),
-        )),
+        Ok(Ok(output)) => (Ok(output), oom),
+        Ok(Err(e)) => (Err(classify_termination_error(&oom_flag, false, e)), oom),
+        Err(_panic) => (Err(classify_termination_error(
+            &oom_flag, false, "V8 execution panicked unexpectedly".to_string(),
+        )), oom),
     }
 }
 
-// Stateless service implementation
-#[tool(tool_box)]
-impl StatelessService {
-    pub fn new(heap_memory_max_bytes: usize, execution_timeout_secs: u64) -> Self {
-        Self { heap_memory_max_bytes, execution_timeout_secs }
-    }
-
-    #[tool(description = include_str!("run_js_tool_stateless.md"))]
-    pub async fn run_js(
-        &self,
-        #[tool(param)] code: String,
-        #[tool(param)]
-        #[serde(default)]
-        heap_memory_max_mb: Option<usize>,
-        #[tool(param)]
-        #[serde(default)]
-        execution_timeout_secs: Option<u64>,
-    ) -> RunJsStatelessResponse {
-        let max_bytes = heap_memory_max_mb
-            .map(|mb| mb * 1024 * 1024)
-            .unwrap_or(self.heap_memory_max_bytes);
-        let timeout = execution_timeout_secs.unwrap_or(self.execution_timeout_secs);
-        let v8_result = tokio::task::spawn_blocking(move || execute_stateless(code, max_bytes, timeout)).await;
-
-        match v8_result {
-            Ok(Ok(output)) => RunJsStatelessResponse { output },
-            Ok(Err(e)) => RunJsStatelessResponse {
-                output: format!("V8 error: {}", e),
-            },
-            Err(e) => RunJsStatelessResponse {
-                output: format!("Task join error: {}", e),
-            },
-        }
-    }
+// Engine.run_js handles TypeScript stripping, timeout enforcement,
+// and concurrency control:
+pub async fn run_js(
+    &self,
+    code: String,
+    heap: Option<String>,
+    session: Option<String>,
+    heap_memory_max_mb: Option<usize>,
+    execution_timeout_secs: Option<u64>,
+) -> Result<JsResult, String> {
+    // Strip TypeScript types before V8 execution (no-op for plain JS)
+    let code = strip_typescript_types(&code)?;
+    // ... acquires semaphore permit, runs execute_stateless on
+    // blocking thread with async timeout via tokio::select! ...
 }
 ```


### PR DESCRIPTION
## Summary

This PR refactors the V8 execution layer to support async timeout enforcement via external isolate termination, adds semaphore-based concurrency control, and significantly expands documentation for clustering, transport options, and deployment scenarios.

## Key Changes

### Core V8 Execution Refactoring
- **Async timeout support**: `execute_stateful()` and `execute_stateless()` now return `(Result, bool)` tuples and publish `IsolateHandle` to a mutex, allowing external async code to terminate execution via `isolate.terminate_execution()` rather than relying on synchronous timeout guards
- **Removed timeout parameters**: Timeout enforcement is now handled at the `Engine::run_js()` level using `tokio::select!` with async timeouts, decoupling V8 execution from timeout logic
- **OOM flag exposure**: Both functions now return the OOM flag alongside results for better error classification
- **Signature changes**: Functions now take `&str` instead of `String` for code parameter, reducing allocations

### Concurrency Control
- Added `--max-concurrent-executions` CLI flag (defaults to CPU core count)
- `Engine` now uses a semaphore to limit concurrent V8 isolate executions
- `run_js()` acquires a permit before spawning blocking V8 execution

### TypeScript Support
- Added `strip_typescript_types()` function to remove type annotations before V8 execution
- Updated tool descriptions to document TypeScript support (type removal only, no type checking)
- Both stateful and stateless modes now support TypeScript input

### Documentation Improvements
- **README.md**: Reorganized CLI arguments into sections (Storage, Transport, Execution Limits, Session Logging, Cluster Options)
- **HTTP transport**: Updated to "Streamable HTTP (MCP 2025-03-26+)" with `/mcp` endpoint and `/api/exec` plain HTTP API
- **Clustering**: Added comprehensive documentation for Raft-based clustering with node IDs, peer discovery, and heartbeat configuration
- **S3 caching**: Documented write-through cache option (`--cache-dir`)
- **Claude Code CLI**: Added integration examples
- **Configuration examples**: Updated to use `args` array format instead of inline command strings
- **SSE_IMPLEMENTATION.md**: Clarified transport comparison table and updated endpoint descriptions

### Tool Descriptions
- Updated `run_js_tool_description.md` and `run_js_tool_stateless.md` to clarify:
  - SHA-256 hex string format for heap content hashes
  - Stateful vs stateless mode behavior
  - Removed redundant introductory text about limitations
- Updated `mcp.rs` tool descriptions to note stateful-mode-only features

### Docker & Deployment
- Updated `DOCKER.md` with examples for S3 caching, stateless mode, and SSE transport
- Added references to pre-configured docker-compose files for single-node and cluster deployments

## Implementation Details

The refactoring maintains backward compatibility at the API level while improving internal architecture:
- `Engine::run_js()` now orchestrates TypeScript stripping, semaphore acquisition, blocking V8 execution, and async timeout via `tokio::select!`
- Timeout is enforced by cancelling the blocking task, which triggers isolate termination via the published handle
- Session logging and heap storage remain unchanged in behavior
- All three transport modes (stdio, Streamable HTTP, SSE) use the same unified `Engine` implementation

https://claude.ai/code/session_0171SGAKv5NVtwkkXrPUphkr