### PR TITLE
Add extreme OOM handling and stateless mode support

### DIFF
--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -6,7 +6,7 @@ params:
 - code: the javascript or typescript code to run
 - heap (optional): content hash (SHA-256 hex string) from a previous execution to resume that session, or omit for a fresh session
 - session (optional): a human-readable session name. When provided, a log entry is written recording the input heap, output heap, executed code, and timestamp. Use list_sessions and list_session_snapshots to browse session history.
-- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (1–64, default: 8). Override the server default for this execution.
+- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (4–64, default: 8). Override the server default for this execution.
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 
 returns:


### PR DESCRIPTION
## Summary
This PR adds robust handling for extreme out-of-memory (OOM) scenarios in V8 and introduces a stateless mode variant of the MCP service. The changes ensure that pathological allocations (e.g., `new Array(1e9)`) that exceed V8's internal structural limits are handled gracefully without corrupting the parent process state.

## Key Changes

### Extreme OOM Handling
- **V8 Fatal OOM Handler**: Installed `oom_error_handler` to intercept V8's `FatalProcessOutOfMemory` calls. When V8 encounters allocations exceeding internal limits (like `FixedArray::kMaxLength`), it now logs a descriptive message and aborts cleanly rather than leaving global state corrupted.
- **Minimum Heap Memory Floor**: Added `MIN_HEAP_MEMORY_MB` constant (4 MB) to prevent allocations below V8's internal bookkeeping requirements. Heap requests are clamped to this minimum to avoid triggering fatal OOM before the near-heap-limit callback can fire.
- **Subprocess Testing**: Added comprehensive regression tests (`test_extreme_oom_1mb_heap_subprocess_stateless` and `test_extreme_oom_1mb_heap_subprocess_stateful`) that spawn child processes to test pathological allocations. The parent process verifies it remains unaffected after the child aborts.

### Stateless Mode Support
- **StatelessMcpService**: New service variant that only exposes `run_js` without heap/session persistence parameters. This prevents agents from attempting to use stateful features in stateless deployments.
- **Service Factory Pattern**: Updated `main.rs` to use a generic service factory pattern, allowing HTTP and SSE transports to instantiate either `McpService` (stateful) or `StatelessMcpService` (stateless) based on engine configuration.
- **Updated Documentation**: Simplified `run_js_tool_stateless.md` to clarify that each execution starts with a fresh V8 isolate.

### Implementation Details
- Heap limit clamping is applied consistently in `create_params_with_heap_limit()` and `Engine::run_js()` to ensure the minimum is enforced across all execution paths.
- Panic handling in `execute_stateless()` and `execute_stateful()` now properly clears the isolate handle before returning, preventing dangling references.
- The OOM error handler is installed per-isolate in `install_heap_limit_callback()` to catch fatal OOM conditions early.
- Heap memory parameter validation updated to reflect the 4 MB minimum in tool documentation.

https://claude.ai/code/session_01D9uMsxd95YvwXyYNiWBwoU