### PR TITLE
Replace WASM preamble generation with native V8 API injection

### DIFF
--- a/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
@@ -42,5 +42,5 @@ fuzz_target!(|input: StatefulInput| {
     // can cause OOM on CI runners.
     let max_bytes = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateful(&input.code, raw_snapshot, max_bytes, handle);
+    let _ = server::engine::execute_stateful(&input.code, raw_snapshot, max_bytes, handle, &[]);
 });

--- a/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
@@ -26,5 +26,5 @@ fuzz_target!(|data: &[u8]| {
     // can cause OOM on CI runners.
     let max_bytes = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateless(&code, max_bytes, handle);
+    let _ = server::engine::execute_stateless(&code, max_bytes, handle, &[]);
 });

--- a/server/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
+++ b/server/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
@@ -31,5 +31,5 @@ fuzz_target!(|data: &[u8]| {
     // If validation passes (extremely unlikely with random data), run V8.
     let max_bytes = 64 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateful("1", raw_snapshot, max_bytes, handle);
+    let _ = server::engine::execute_stateful("1", raw_snapshot, max_bytes, handle, &[]);
 });

--- a/server/tests/heap_limit.rs
+++ b/server/tests/heap_limit.rs
@@ -36,7 +36,7 @@ fn test_stateless_small_heap_limit_rejects_large_allocation() {
 
     // 5 MB heap limit — too small for a 2M-element string array
     let max_bytes = 5 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle(), &[]);
 
     assert!(
         result.is_err(),
@@ -50,7 +50,7 @@ fn test_stateless_default_limit_allows_small_code() {
     ensure_v8();
 
     let max_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(SMALL_JS, max_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateless(SMALL_JS, max_bytes, no_handle(), &[]);
 
     assert!(
         result.is_ok(),
@@ -66,7 +66,7 @@ fn test_stateless_generous_limit_allows_large_allocation() {
 
     // 256 MB — should be plenty for 2M strings
     let max_bytes = 256 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle(), &[]);
 
     assert!(
         result.is_ok(),
@@ -82,7 +82,7 @@ fn test_stateful_small_heap_limit_rejects_large_allocation() {
 
     // 5 MB heap limit — too small for a 2M-element string array
     let max_bytes = 5 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle(), &[]);
 
     assert!(
         result.is_err(),
@@ -96,7 +96,7 @@ fn test_stateful_default_limit_allows_small_code() {
     ensure_v8();
 
     let max_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(SMALL_JS, None, max_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateful(SMALL_JS, None, max_bytes, no_handle(), &[]);
 
     assert!(
         result.is_ok(),
@@ -114,7 +114,7 @@ fn test_stateful_generous_limit_allows_large_allocation() {
 
     // 256 MB — should be plenty for 2M strings
     let max_bytes = 256 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle(), &[]);
 
     assert!(
         result.is_ok(),
@@ -133,8 +133,8 @@ fn test_different_limits_produce_different_outcomes() {
     let small_limit = 5 * 1024 * 1024;
     let large_limit = 256 * 1024 * 1024;
 
-    let (small_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, small_limit, no_handle());
-    let (large_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, large_limit, no_handle());
+    let (small_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, small_limit, no_handle(), &[]);
+    let (large_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, large_limit, no_handle(), &[]);
 
     assert!(
         small_result.is_err(),
@@ -177,7 +177,7 @@ fn test_typed_array_oom_does_not_crash_stateless() {
 
     // 8 MB heap — typed array backing stores will exceed this quickly
     let heap_bytes = 8 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(TYPED_ARRAY_OOM_JS, heap_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateless(TYPED_ARRAY_OOM_JS, heap_bytes, no_handle(), &[]);
 
     // We don't care whether it's Ok (the JS catch fired) or Err (V8 killed it) —
     // the critical thing is that we *get here* instead of a process crash.
@@ -196,7 +196,7 @@ fn test_typed_array_oom_does_not_crash_stateful() {
     ensure_v8();
 
     let heap_bytes = 8 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(TYPED_ARRAY_OOM_JS, None, heap_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateful(TYPED_ARRAY_OOM_JS, None, heap_bytes, no_handle(), &[]);
 
     if let Err(ref e) = result {
         assert!(
@@ -236,7 +236,7 @@ fn extreme_oom_subprocess_worker() {
 
     match mode.as_str() {
         "stateless" => {
-            let (result, _) = server::engine::execute_stateless(code, heap_bytes, no_handle());
+            let (result, _) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[]);
             // If we reach here (V8 didn't abort), exit cleanly.
             if result.is_err() {
                 std::process::exit(0);
@@ -244,7 +244,7 @@ fn extreme_oom_subprocess_worker() {
             std::process::exit(0);
         }
         "stateful" => {
-            let (result, _) = server::engine::execute_stateful(code, None, heap_bytes, no_handle());
+            let (result, _) = server::engine::execute_stateful(code, None, heap_bytes, no_handle(), &[]);
             if result.is_err() {
                 std::process::exit(0);
             }
@@ -276,7 +276,7 @@ fn run_extreme_oom_subprocess(mode: &str) {
     // The parent process is still running — V8 global state is intact.
     // Verify by running a simple V8 execution.
     ensure_v8();
-    let (result, _) = server::engine::execute_stateless("1 + 1", 8 * 1024 * 1024, no_handle());
+    let (result, _) = server::engine::execute_stateless("1 + 1", 8 * 1024 * 1024, no_handle(), &[]);
     assert!(
         result.is_ok(),
         "Parent process V8 should be unaffected after subprocess OOM, but got: {:?}",

--- a/server/tests/parameter_configs.rs
+++ b/server/tests/parameter_configs.rs
@@ -78,7 +78,7 @@ fn test_oom_produces_descriptive_error_not_crash() {
     "#;
     let heap_bytes = 16 * 1024 * 1024; // 16MB
 
-    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[]);
 
     assert!(result.is_err(), "Huge allocation with small heap should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -102,7 +102,7 @@ fn test_oom_stateful_produces_descriptive_error_not_crash() {
     "#;
     let heap_bytes = 16 * 1024 * 1024; // 16MB
 
-    let (result, _oom) = server::engine::execute_stateful(code, None, heap_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateful(code, None, heap_bytes, no_handle(), &[]);
 
     assert!(result.is_err(), "Huge allocation with small heap should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -126,7 +126,7 @@ fn test_fast_computation_succeeds() {
     "#;
     let heap_bytes = 64 * 1024 * 1024;
 
-    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[]);
 
     assert!(result.is_ok(), "Fast computation should succeed, got: {:?}", result);
     assert_eq!(result.unwrap(), "499999500000");
@@ -139,7 +139,7 @@ fn test_bare_call_default_params() {
 
     let heap_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
 
-    let (result, _oom) = server::engine::execute_stateless("1 + 1", heap_bytes, no_handle());
+    let (result, _oom) = server::engine::execute_stateless("1 + 1", heap_bytes, no_handle(), &[]);
 
     assert!(result.is_ok(), "Simple expression should succeed, got: {:?}", result);
     assert_eq!(result.unwrap(), "2");


### PR DESCRIPTION
## Summary
Refactored WASM module initialization to use V8's native C++ API directly instead of generating JavaScript preamble code. This eliminates string serialization of binary WASM bytes and improves performance and maintainability.

## Key Changes
- **Replaced `wasm_preamble()` with `inject_wasm_modules()`**: Changed from generating a JavaScript string that compiles WASM modules to directly using V8's native API (`v8::WasmModuleObject::compile`) to compile and instantiate modules
- **Native V8 compilation**: Uses `v8::WasmModuleObject::compile()` to compile raw `.wasm` bytes directly without converting to hex string literals
- **Direct global binding**: Instantiates modules via `WebAssembly.Instance` constructor and binds exports to global variables using the V8 API instead of injecting JS code
- **Updated function signatures**: Added `wasm_modules` parameter to both `execute_stateless()` and `execute_stateful()` functions to pass modules directly to the execution context
- **Removed preamble injection**: Eliminated the code path in `Engine::execute()` that prepended WASM initialization code to user scripts
- **Updated all call sites**: Modified tests and fuzz targets to pass empty WASM module slices where needed

## Implementation Details
- The new `inject_wasm_modules()` function operates within a V8 context scope and performs all operations using the native V8 API
- Proper error handling with descriptive messages for each step (compilation, instantiation, export extraction, global binding)
- Maintains the same external behavior—WASM modules are still available as globals with their configured names
- Both stateless and stateful execution paths now inject WASM modules before evaluating user code

https://claude.ai/code/session_01NV4FoG5mSPNGEQmARmG3sF