### PR TITLE
Simplify fuzz workflow: use address sanitizer for all targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,21 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Snapshot deserialization doesn't create V8 isolates repeatedly,
-          # so ASAN overhead is manageable.
-          - target: fuzz_snapshot_deserialization
-            sanitizer: address
-          # V8 execution targets create/destroy isolates every iteration.
-          # V8 reserves huge virtual memory regions that ASAN shadows,
-          # causing 16GB+ RSS even with 8MB heap. Use no sanitizer for
-          # these — they still catch crashes, aborts, and panics.
-          - target: fuzz_execute_stateless
-            sanitizer: none
-          - target: fuzz_execute_stateful
-            sanitizer: none
-          - target: fuzz_wasm_compile
-            sanitizer: none
+        target:
+          - fuzz_snapshot_deserialization
+          - fuzz_execute_stateless
+          - fuzz_execute_stateful
+          - fuzz_wasm_compile
 
     steps:
       - name: Checkout code
@@ -48,14 +38,14 @@ jobs:
         run: nix develop .#fuzz --command bash -c "cargo install cargo-fuzz"
 
       - name: Build fuzz targets
-        run: nix develop .#fuzz --command bash -c "cd server && cargo fuzz build --sanitizer=${{ matrix.sanitizer }} ${{ matrix.target }}"
+        run: nix develop .#fuzz --command bash -c "cd server && cargo fuzz build --sanitizer=address ${{ matrix.target }}"
 
       - name: Run fuzzer (${{ matrix.target }})
         env:
           ASAN_OPTIONS: quarantine_size_mb=64:malloc_context_size=5
         run: |
           nix develop .#fuzz --command bash -c \
-            "cd server && cargo fuzz run --sanitizer=${{ matrix.sanitizer }} ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=4096 -max_len=65536 -timeout=120"
+            "cd server && cargo fuzz run --sanitizer=address ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=0 -max_len=65536 -timeout=120"
 
       - name: Upload fuzz artifacts
         if: always()


### PR DESCRIPTION
## Summary
Simplifies the fuzzing workflow by standardizing on the address sanitizer for all fuzz targets, removing the previous conditional logic that varied sanitizer usage based on target type.

## Key Changes
- Removed matrix strategy with conditional sanitizer selection (`include` block with per-target sanitizer configuration)
- Simplified matrix to a flat list of fuzz targets
- Changed all fuzz targets to use `--sanitizer=address` consistently (previously some used `none`)
- Updated RSS limit from `4096` to `0` (unlimited) in the fuzzer run command

## Implementation Details
The previous approach disabled ASAN for V8 execution targets (`fuzz_execute_stateless`, `fuzz_execute_stateful`, `fuzz_wasm_compile`) due to memory overhead concerns with virtual memory shadowing. This change unifies the approach to always use address sanitizer, likely indicating either:
- Improved confidence in memory usage with current configurations
- Acceptance of higher resource usage for better bug detection
- Changes to the underlying V8 or test infrastructure that mitigate the original concerns

The removal of the RSS limit constraint (`rss_limit_mb=4096` → `rss_limit_mb=0`) aligns with this shift toward prioritizing sanitizer coverage over resource constraints.

https://claude.ai/code/session_01RUZqEok6bTRrd8nUif4pw5