### PR TITLE
Add SQLite WASM support with manual instantiation for modules with imports

### DIFF
--- a/.github/workflows/sqlite-wasm-e2e.yml
+++ b/.github/workflows/sqlite-wasm-e2e.yml
@@ -1,0 +1,83 @@
+name: SQLite WASM E2E Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  sqlite-wasm-e2e:
+    name: SQLite WASM E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            sandbox = relaxed
+
+      - uses: DeterminateSystems/flake-checker-action@main
+
+      - name: Build SQLite WASM
+        run: nix build .#sqlite-wasm --print-build-logs -L
+
+      - name: Build mcp-v8
+        run: nix build .#default --print-build-logs -L
+
+      - name: Run SQLite WASM E2E test
+        run: |
+          WASM_PATH=$(nix build .#sqlite-wasm --print-out-paths)/sqlite3.wasm
+          SERVER_BIN=$(nix build .#default --print-out-paths)/bin/server
+
+          echo "WASM: $WASM_PATH"
+          echo "Server: $SERVER_BIN"
+
+          # Start server in HTTP mode with the SQLite WASM module
+          $SERVER_BIN --stateless --http-port 8080 \
+            --wasm-module sqlite="$WASM_PATH" \
+            --heap-memory-max 32 &
+          SERVER_PID=$!
+
+          # Wait for server to be ready (up to 30s)
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/api/exec \
+              -H 'Content-Type: application/json' \
+              -d '{"code": "1+1"}' > /dev/null 2>&1; then
+              echo "Server is ready"
+              break
+            fi
+            sleep 1
+          done
+
+          # Run the SQLite WASM example
+          RESULT=$(curl -sf http://localhost:8080/api/exec \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -Rs '{code: .}' < examples/sqlite-wasm/example.js)")
+
+          echo "Result: $RESULT"
+
+          # Parse and verify the output
+          OUTPUT=$(echo "$RESULT" | jq -r '.output')
+          echo "Output: $OUTPUT"
+
+          # Verify we got 3 users back
+          echo "$OUTPUT" | jq -e '.users | length == 3'
+
+          # Verify users are sorted by age (Bob=25, Alice=30, Charlie=35)
+          echo "$OUTPUT" | jq -e '.users[0].name == "Bob"'
+          echo "$OUTPUT" | jq -e '.users[1].name == "Alice"'
+          echo "$OUTPUT" | jq -e '.users[2].name == "Charlie"'
+
+          # Verify stats
+          echo "$OUTPUT" | jq -e '.stats.count == 3'
+          echo "$OUTPUT" | jq -e '.stats.avg_age == 30'
+
+          echo "SQLite WASM E2E test passed!"
+
+          kill $SERVER_PID

--- a/.github/workflows/sqlite-wasm-e2e.yml
+++ b/.github/workflows/sqlite-wasm-e2e.yml
@@ -41,8 +41,12 @@ jobs:
           # Start server in HTTP mode with the SQLite WASM module
           $SERVER_BIN --stateless --http-port 8080 \
             --wasm-module sqlite="$WASM_PATH" \
-            --heap-memory-max 32 &
+            --heap-memory-max 128 &
           SERVER_PID=$!
+
+          # Ensure we always clean up the server process
+          cleanup() { kill $SERVER_PID 2>/dev/null || true; }
+          trap cleanup EXIT
 
           # Wait for server to be ready (up to 30s)
           for i in $(seq 1 30); do
@@ -55,12 +59,21 @@ jobs:
             sleep 1
           done
 
-          # Run the SQLite WASM example
-          RESULT=$(curl -sf http://localhost:8080/api/exec \
+          # Run the SQLite WASM example — capture response even on HTTP errors
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w '%{http_code}' \
+            http://localhost:8080/api/exec \
             -H 'Content-Type: application/json' \
             -d "$(jq -Rs '{code: .}' < examples/sqlite-wasm/example.js)")
 
+          RESULT=$(cat /tmp/response.json)
+          echo "HTTP status: $HTTP_CODE"
           echo "Result: $RESULT"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "ERROR: Server returned HTTP $HTTP_CODE"
+            echo "Response body: $RESULT"
+            exit 1
+          fi
 
           # Parse and verify the output
           OUTPUT=$(echo "$RESULT" | jq -r '.output')
@@ -79,5 +92,3 @@ jobs:
           echo "$OUTPUT" | jq -e '.stats.avg_age == 30'
 
           echo "SQLite WASM E2E test passed!"
-
-          kill $SERVER_PID

--- a/.github/workflows/sqlite-wasm-e2e.yml
+++ b/.github/workflows/sqlite-wasm-e2e.yml
@@ -41,7 +41,7 @@ jobs:
           # Start server in HTTP mode with the SQLite WASM module
           $SERVER_BIN --stateless --http-port 8080 \
             --wasm-module sqlite="$WASM_PATH" \
-            --heap-memory-max 128 &
+            --heap-memory-max 64 &
           SERVER_PID=$!
 
           # Ensure we always clean up the server process

--- a/examples/sqlite-wasm/README.md
+++ b/examples/sqlite-wasm/README.md
@@ -1,0 +1,169 @@
+# SQLite WASM Example
+
+Run a full [SQLite](https://sqlite.org/) database inside mcp-v8 using [WebAssembly](https://github.com/sqlite/sqlite-wasm).
+
+The SQLite `.wasm` module is pre-loaded at server startup with `--wasm-module`. Because the WASM binary has WASI imports, it cannot be auto-instantiated — the compiled `WebAssembly.Module` is exposed as `__wasm_sqlite`, and the JavaScript code provides the necessary import stubs and instantiates it manually.
+
+## Prerequisites
+
+- [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html) (`emcc` on PATH)
+- mcp-v8 binary (built from this repo or installed via `install.sh`)
+
+## Build
+
+```bash
+./examples/sqlite-wasm/build.sh
+```
+
+This downloads the [SQLite amalgamation](https://sqlite.org/amalgamation.html) and compiles it to WASM. The output is `examples/sqlite-wasm/sqlite3.wasm`.
+
+### Compile flags
+
+Key flags used during compilation:
+
+| Flag | Purpose |
+|------|---------|
+| `STANDALONE_WASM=1` | Produce a WASI-compatible standalone `.wasm` file |
+| `SQLITE_OS_OTHER=1` | Disable platform-specific VFS (only `:memory:` databases) |
+| `SQLITE_THREADSAFE=0` | Single-threaded (no mutex overhead) |
+| `FILESYSTEM=0` | No Emscripten filesystem emulation |
+| `--no-entry` | No `main()` — library-only |
+| `ALLOW_MEMORY_GROWTH=1` | WASM linear memory can grow as needed |
+
+## Run
+
+### Stateless mode
+
+```bash
+mcp-v8 --stateless --wasm-module sqlite=examples/sqlite-wasm/sqlite3.wasm
+```
+
+### Stateful mode (persistent sessions)
+
+```bash
+mcp-v8 --directory-path /tmp/mcp-v8-heaps --wasm-module sqlite=examples/sqlite-wasm/sqlite3.wasm
+```
+
+In stateful mode the SQLite wrapper code is snapshotted into the V8 heap, so you only need to initialize it once and can continue using it across subsequent calls by passing the `heap` hash.
+
+### HTTP transport
+
+```bash
+mcp-v8 --stateless --http-port 8080 --wasm-module sqlite=examples/sqlite-wasm/sqlite3.wasm
+```
+
+Then test with curl:
+
+```bash
+curl -s http://localhost:8080/api/exec \
+  -H 'Content-Type: application/json' \
+  -d "$(cat examples/sqlite-wasm/example.js | jq -Rs '{code: .}')"
+```
+
+## Example code
+
+See [`example.js`](example.js) for a complete working example. The key steps are:
+
+### 1. Provide WASI import stubs
+
+```javascript
+var wasiStubs = {
+    fd_close: function () { return 0; },
+    fd_write: function (fd, iovs, iovsLen, nwrittenPtr) {
+        // discard output
+        var view = new DataView(memory.buffer);
+        var total = 0;
+        for (var i = 0; i < iovsLen; i++)
+            total += view.getUint32(iovs + i * 8 + 4, true);
+        view.setUint32(nwrittenPtr, total, true);
+        return 0;
+    },
+    fd_read: function () { return 0; },
+    fd_seek: function () { return 0; },
+    fd_fdstat_get: function () { return 0; },
+    environ_get: function () { return 0; },
+    environ_sizes_get: function (countPtr, bufSizePtr) {
+        var view = new DataView(memory.buffer);
+        view.setUint32(countPtr, 0, true);
+        view.setUint32(bufSizePtr, 0, true);
+        return 0;
+    },
+    proc_exit: function () {},
+    clock_time_get: function (id, precLo, precHi, timePtr) {
+        var view = new DataView(memory.buffer);
+        view.setBigUint64(timePtr, BigInt(0), true);
+        return 0;
+    },
+};
+```
+
+### 2. Instantiate the module
+
+```javascript
+// __wasm_sqlite is the compiled WebAssembly.Module (set by --wasm-module)
+var instance = new WebAssembly.Instance(__wasm_sqlite, {
+    wasi_snapshot_preview1: wasiStubs,
+    env: { emscripten_notify_memory_growth: function () {} },
+});
+var exports = instance.exports;
+var memory = exports.memory;
+```
+
+### 3. Use SQLite
+
+```javascript
+var db = new SQLite();                         // opens :memory: database
+db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, val TEXT)");
+db.exec("INSERT INTO t (val) VALUES ('hello')");
+var result = db.query("SELECT * FROM t");
+db.close();
+
+JSON.stringify(result.rows);
+// → [{"id":1,"val":"hello"}]
+```
+
+## How it works
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  mcp-v8  (Rust)                                          │
+│                                                          │
+│  --wasm-module sqlite=sqlite3.wasm                       │
+│      │                                                   │
+│      ├─ wasmparser: validates .wasm bytes                │
+│      ├─ v8::WasmModuleObject::compile(bytes)             │
+│      ├─ detects imports → skips auto-instantiation       │
+│      └─ sets global: __wasm_sqlite = WebAssembly.Module  │
+│                                                          │
+│  run_js("... example.js ...")                            │
+│      │                                                   │
+│      ├─ JS provides WASI stubs                           │
+│      ├─ new WebAssembly.Instance(__wasm_sqlite, imports) │
+│      ├─ SQLite C API via WASM exports                    │
+│      └─ returns JSON result                              │
+└──────────────────────────────────────────────────────────┘
+```
+
+## Limitations
+
+- **In-memory databases only** — compiled with `SQLITE_OS_OTHER=1`, so there is no filesystem VFS. Only `:memory:` databases work.
+- **No async** — all SQLite operations are synchronous (which is fine since mcp-v8's runtime is synchronous).
+- **No extensions** — `SQLITE_OMIT_LOAD_EXTENSION` is set.
+- **Heap size** — for large databases, you may need to increase `--heap-memory-max` (default 8 MB). The WASM linear memory also grows independently.
+
+## Claude Desktop / Cursor configuration
+
+```json
+{
+  "mcpServers": {
+    "js": {
+      "command": "mcp-v8",
+      "args": [
+        "--stateless",
+        "--wasm-module", "sqlite=/path/to/sqlite3.wasm",
+        "--heap-memory-max", "32"
+      ]
+    }
+  }
+}
+```

--- a/examples/sqlite-wasm/build.sh
+++ b/examples/sqlite-wasm/build.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build SQLite as a standalone WASM module for use with mcp-v8.
+#
+# Prerequisites:
+#   - Emscripten SDK (emsdk) installed and activated
+#     https://emscripten.org/docs/getting_started/downloads.html
+#
+# Output: sqlite3.wasm — a WASI-compatible WASM module that can be loaded
+#         with `mcp-v8 --wasm-module sqlite=sqlite3.wasm`
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build"
+SQLITE_VERSION="3490100"
+SQLITE_YEAR="2025"
+SQLITE_URL="https://www.sqlite.org/${SQLITE_YEAR}/sqlite-amalgamation-${SQLITE_VERSION}.zip"
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+# Download SQLite amalgamation if not already present
+if [ ! -f "sqlite3.c" ]; then
+    echo "Downloading SQLite amalgamation..."
+    curl -fSL "$SQLITE_URL" -o sqlite-amalgamation.zip
+    unzip -o sqlite-amalgamation.zip
+    cp "sqlite-amalgamation-${SQLITE_VERSION}/sqlite3.c" .
+    cp "sqlite-amalgamation-${SQLITE_VERSION}/sqlite3.h" .
+    rm -rf "sqlite-amalgamation-${SQLITE_VERSION}" sqlite-amalgamation.zip
+fi
+
+echo "Compiling SQLite to WASM..."
+
+emcc sqlite3.c \
+    -o sqlite3.wasm \
+    -O2 \
+    -s STANDALONE_WASM=1 \
+    -s EXPORTED_FUNCTIONS='[
+        "_sqlite3_open",
+        "_sqlite3_close",
+        "_sqlite3_exec",
+        "_sqlite3_errmsg",
+        "_sqlite3_prepare_v2",
+        "_sqlite3_step",
+        "_sqlite3_column_count",
+        "_sqlite3_column_type",
+        "_sqlite3_column_int",
+        "_sqlite3_column_double",
+        "_sqlite3_column_text",
+        "_sqlite3_column_bytes",
+        "_sqlite3_column_name",
+        "_sqlite3_finalize",
+        "_sqlite3_changes",
+        "_sqlite3_last_insert_rowid",
+        "_malloc",
+        "_free"
+    ]' \
+    -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
+    -s ALLOW_MEMORY_GROWTH=1 \
+    -s INITIAL_MEMORY=16777216 \
+    -s STACK_SIZE=65536 \
+    -s FILESYSTEM=0 \
+    --no-entry \
+    -DSQLITE_OS_OTHER=1 \
+    -DSQLITE_OMIT_LOAD_EXTENSION \
+    -DSQLITE_OMIT_WAL \
+    -DSQLITE_THREADSAFE=0 \
+    -DSQLITE_OMIT_LOCALTIME \
+    -DSQLITE_OMIT_RANDOMNESS \
+    -DSQLITE_TEMP_STORE=3 \
+    -DSQLITE_OMIT_DEPRECATED
+
+cp sqlite3.wasm "$SCRIPT_DIR/sqlite3.wasm"
+
+echo "Done! Output: $SCRIPT_DIR/sqlite3.wasm"
+echo ""
+echo "Usage:"
+echo "  mcp-v8 --stateless --wasm-module sqlite=examples/sqlite-wasm/sqlite3.wasm"

--- a/examples/sqlite-wasm/example.js
+++ b/examples/sqlite-wasm/example.js
@@ -1,0 +1,279 @@
+// SQLite WASM example for mcp-v8
+//
+// This script is designed to run inside mcp-v8 with the SQLite WASM module
+// pre-loaded via:
+//
+//   mcp-v8 --stateless --wasm-module sqlite=examples/sqlite-wasm/sqlite3.wasm
+//
+// The compiled WebAssembly.Module is available as the global `__wasm_sqlite`.
+// Because the module has WASI imports, it is NOT auto-instantiated — we
+// provide the imports ourselves and instantiate it manually.
+
+// ── WASI stubs ──────────────────────────────────────────────────────────
+// SQLite compiled with Emscripten STANDALONE_WASM imports a handful of
+// WASI functions. For an in-memory-only database none of these need real
+// implementations — simple stubs are sufficient.
+
+var wasiStubs = {
+    // fd_close(fd) -> errno
+    fd_close: function () { return 0; },
+    // fd_fdstat_get(fd, buf) -> errno
+    fd_fdstat_get: function () { return 0; },
+    // fd_seek(fd, offset_lo, offset_hi, whence, newoffset_ptr) -> errno
+    fd_seek: function () { return 0; },
+    // fd_write(fd, iovs, iovs_len, nwritten_ptr) -> errno
+    fd_write: function (fd, iovs, iovsLen, nwrittenPtr) {
+        // Silently discard output (used by sqlite3_log / fprintf)
+        var view = new DataView(memory.buffer);
+        var totalWritten = 0;
+        for (var i = 0; i < iovsLen; i++) {
+            var len = view.getUint32(iovs + i * 8 + 4, true);
+            totalWritten += len;
+        }
+        view.setUint32(nwrittenPtr, totalWritten, true);
+        return 0;
+    },
+    // fd_read(fd, iovs, iovs_len, nread_ptr) -> errno
+    fd_read: function () { return 0; },
+    // environ_get(environ, environ_buf) -> errno
+    environ_get: function () { return 0; },
+    // environ_sizes_get(count_ptr, buf_size_ptr) -> errno
+    environ_sizes_get: function (countPtr, bufSizePtr) {
+        var view = new DataView(memory.buffer);
+        view.setUint32(countPtr, 0, true);
+        view.setUint32(bufSizePtr, 0, true);
+        return 0;
+    },
+    // proc_exit(code) — should never be called
+    proc_exit: function () {},
+    // clock_time_get(id, precision, time_ptr) -> errno
+    clock_time_get: function (id, precLo, precHi, timePtr) {
+        var view = new DataView(memory.buffer);
+        view.setBigUint64(timePtr, BigInt(0), true);
+        return 0;
+    },
+};
+
+// ── Instantiate the WASM module ─────────────────────────────────────────
+
+var memory; // will be set from the module's exported memory
+
+var instance = new WebAssembly.Instance(__wasm_sqlite, {
+    wasi_snapshot_preview1: wasiStubs,
+    env: {
+        emscripten_notify_memory_growth: function () {},
+    },
+});
+
+var exports = instance.exports;
+memory = exports.memory;
+
+// ── Low-level helpers ───────────────────────────────────────────────────
+// These translate between JS strings and WASM linear memory.
+
+function encodeString(str) {
+    var bytes = [];
+    for (var i = 0; i < str.length; i++) {
+        var c = str.charCodeAt(i);
+        if (c < 0x80) {
+            bytes.push(c);
+        } else if (c < 0x800) {
+            bytes.push(0xc0 | (c >> 6));
+            bytes.push(0x80 | (c & 0x3f));
+        } else if (c >= 0xd800 && c <= 0xdbff) {
+            // surrogate pair
+            var hi = c;
+            var lo = str.charCodeAt(++i);
+            var cp = ((hi - 0xd800) << 10) + (lo - 0xdc00) + 0x10000;
+            bytes.push(0xf0 | (cp >> 18));
+            bytes.push(0x80 | ((cp >> 12) & 0x3f));
+            bytes.push(0x80 | ((cp >> 6) & 0x3f));
+            bytes.push(0x80 | (cp & 0x3f));
+        } else {
+            bytes.push(0xe0 | (c >> 12));
+            bytes.push(0x80 | ((c >> 6) & 0x3f));
+            bytes.push(0x80 | (c & 0x3f));
+        }
+    }
+    bytes.push(0); // null terminator
+    return bytes;
+}
+
+function allocString(str) {
+    var bytes = encodeString(str);
+    var ptr = exports.malloc(bytes.length);
+    if (ptr === 0) throw new Error("malloc failed");
+    var view = new Uint8Array(memory.buffer);
+    for (var j = 0; j < bytes.length; j++) view[ptr + j] = bytes[j];
+    return ptr;
+}
+
+function readCString(ptr) {
+    if (ptr === 0) return null;
+    var view = new Uint8Array(memory.buffer);
+    var end = ptr;
+    while (view[end] !== 0) end++;
+    var bytes = view.slice(ptr, end);
+    // Decode UTF-8
+    var result = "";
+    var i = 0;
+    while (i < bytes.length) {
+        var b = bytes[i];
+        if (b < 0x80) {
+            result += String.fromCharCode(b);
+            i++;
+        } else if (b < 0xe0) {
+            result += String.fromCharCode(((b & 0x1f) << 6) | (bytes[i + 1] & 0x3f));
+            i += 2;
+        } else if (b < 0xf0) {
+            result += String.fromCharCode(
+                ((b & 0x0f) << 12) | ((bytes[i + 1] & 0x3f) << 6) | (bytes[i + 2] & 0x3f)
+            );
+            i += 3;
+        } else {
+            var cp =
+                ((b & 0x07) << 18) |
+                ((bytes[i + 1] & 0x3f) << 12) |
+                ((bytes[i + 2] & 0x3f) << 6) |
+                (bytes[i + 3] & 0x3f);
+            cp -= 0x10000;
+            result += String.fromCharCode(0xd800 + (cp >> 10), 0xdc00 + (cp & 0x3ff));
+            i += 4;
+        }
+    }
+    return result;
+}
+
+// ── SQLite wrapper ──────────────────────────────────────────────────────
+
+var SQLITE_OK = 0;
+var SQLITE_ROW = 100;
+var SQLITE_DONE = 101;
+
+// Column type constants
+var SQLITE_INTEGER = 1;
+var SQLITE_FLOAT = 2;
+var SQLITE_TEXT = 3;
+var SQLITE_BLOB = 4;
+var SQLITE_NULL = 5;
+
+function SQLite() {
+    // Allocate a pointer-sized slot for sqlite3_open's output parameter
+    this._dbPtrPtr = exports.malloc(4);
+    var namePtr = allocString(":memory:");
+    var rc = exports.sqlite3_open(namePtr, this._dbPtrPtr);
+    exports.free(namePtr);
+    if (rc !== SQLITE_OK) {
+        throw new Error("sqlite3_open failed: " + rc);
+    }
+    var view = new DataView(memory.buffer);
+    this._db = view.getUint32(this._dbPtrPtr, true);
+}
+
+SQLite.prototype.errmsg = function () {
+    var ptr = exports.sqlite3_errmsg(this._db);
+    return readCString(ptr);
+};
+
+SQLite.prototype.exec = function (sql) {
+    var sqlPtr = allocString(sql);
+    var rc = exports.sqlite3_exec(this._db, sqlPtr, 0, 0, 0);
+    exports.free(sqlPtr);
+    if (rc !== SQLITE_OK) {
+        throw new Error("sqlite3_exec error (" + rc + "): " + this.errmsg());
+    }
+};
+
+SQLite.prototype.query = function (sql) {
+    var sqlPtr = allocString(sql);
+    var stmtPtrPtr = exports.malloc(4);
+    var rc = exports.sqlite3_prepare_v2(this._db, sqlPtr, -1, stmtPtrPtr, 0);
+    exports.free(sqlPtr);
+    if (rc !== SQLITE_OK) {
+        exports.free(stmtPtrPtr);
+        throw new Error("sqlite3_prepare_v2 error (" + rc + "): " + this.errmsg());
+    }
+
+    var view = new DataView(memory.buffer);
+    var stmt = view.getUint32(stmtPtrPtr, true);
+    exports.free(stmtPtrPtr);
+
+    var colCount = exports.sqlite3_column_count(stmt);
+
+    // Read column names
+    var columns = [];
+    for (var c = 0; c < colCount; c++) {
+        var namePtr = exports.sqlite3_column_name(stmt, c);
+        columns.push(readCString(namePtr));
+    }
+
+    // Read rows
+    var rows = [];
+    while (true) {
+        rc = exports.sqlite3_step(stmt);
+        if (rc === SQLITE_DONE) break;
+        if (rc !== SQLITE_ROW) {
+            exports.sqlite3_finalize(stmt);
+            throw new Error("sqlite3_step error (" + rc + "): " + this.errmsg());
+        }
+
+        var row = {};
+        for (var c = 0; c < colCount; c++) {
+            var colType = exports.sqlite3_column_type(stmt, c);
+            var name = columns[c];
+            if (colType === SQLITE_NULL) {
+                row[name] = null;
+            } else if (colType === SQLITE_INTEGER) {
+                row[name] = exports.sqlite3_column_int(stmt, c);
+            } else if (colType === SQLITE_FLOAT) {
+                row[name] = exports.sqlite3_column_double(stmt, c);
+            } else {
+                // TEXT or BLOB — read as string
+                var textPtr = exports.sqlite3_column_text(stmt, c);
+                row[name] = readCString(textPtr);
+            }
+        }
+        rows.push(row);
+    }
+
+    exports.sqlite3_finalize(stmt);
+    return { columns: columns, rows: rows };
+};
+
+SQLite.prototype.changes = function () {
+    return exports.sqlite3_changes(this._db);
+};
+
+SQLite.prototype.lastInsertRowId = function () {
+    return exports.sqlite3_last_insert_rowid(this._db);
+};
+
+SQLite.prototype.close = function () {
+    if (this._db) {
+        exports.sqlite3_close(this._db);
+        exports.free(this._dbPtrPtr);
+        this._db = 0;
+    }
+};
+
+// ── Demo ────────────────────────────────────────────────────────────────
+
+var db = new SQLite();
+
+// Create a table
+db.exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT, age INTEGER)");
+
+// Insert data
+db.exec("INSERT INTO users (name, email, age) VALUES ('Alice', 'alice@example.com', 30)");
+db.exec("INSERT INTO users (name, email, age) VALUES ('Bob', 'bob@example.com', 25)");
+db.exec("INSERT INTO users (name, email, age) VALUES ('Charlie', 'charlie@example.com', 35)");
+
+// Query data
+var result = db.query("SELECT * FROM users ORDER BY age");
+
+// Aggregate query
+var stats = db.query("SELECT COUNT(*) as count, AVG(age) as avg_age FROM users");
+
+db.close();
+
+JSON.stringify({ users: result.rows, stats: stats.rows[0] });

--- a/examples/sqlite-wasm/memvfs.c
+++ b/examples/sqlite-wasm/memvfs.c
@@ -1,0 +1,185 @@
+/*
+ * Minimal in-memory VFS for SQLite WASM builds using SQLITE_OS_OTHER=1.
+ *
+ * Provides sqlite3_os_init() / sqlite3_os_end() which register a bare-minimum
+ * VFS that supports :memory: databases and temporary files stored in memory.
+ * No real filesystem access is performed.
+ */
+#include "sqlite3.h"
+#include <string.h>
+#include <stdlib.h>
+
+/* ── In-memory file ────────────────────────────────────────────────── */
+
+typedef struct MemFile {
+    sqlite3_file base;
+    char *buf;
+    int sz;
+    int cap;
+} MemFile;
+
+static int memClose(sqlite3_file *pFile) {
+    MemFile *p = (MemFile *)pFile;
+    free(p->buf);
+    p->buf = NULL;
+    p->sz = 0;
+    p->cap = 0;
+    return SQLITE_OK;
+}
+
+static int memRead(sqlite3_file *pFile, void *zBuf, int iAmt, sqlite3_int64 iOfst) {
+    MemFile *p = (MemFile *)pFile;
+    int avail = p->sz - (int)iOfst;
+    if (avail <= 0) {
+        memset(zBuf, 0, iAmt);
+        return SQLITE_IOERR_SHORT_READ;
+    }
+    if (avail < iAmt) {
+        memcpy(zBuf, p->buf + iOfst, avail);
+        memset((char *)zBuf + avail, 0, iAmt - avail);
+        return SQLITE_IOERR_SHORT_READ;
+    }
+    memcpy(zBuf, p->buf + iOfst, iAmt);
+    return SQLITE_OK;
+}
+
+static int memWrite(sqlite3_file *pFile, const void *zBuf, int iAmt, sqlite3_int64 iOfst) {
+    MemFile *p = (MemFile *)pFile;
+    int needed = (int)iOfst + iAmt;
+    if (needed > p->cap) {
+        int newCap = p->cap ? p->cap : 4096;
+        while (newCap < needed) newCap *= 2;
+        char *newBuf = (char *)realloc(p->buf, newCap);
+        if (!newBuf) return SQLITE_NOMEM;
+        /* Zero the gap between old size and the write offset */
+        if ((int)iOfst > p->sz) {
+            memset(newBuf + p->sz, 0, (int)iOfst - p->sz);
+        }
+        p->buf = newBuf;
+        p->cap = newCap;
+    }
+    memcpy(p->buf + iOfst, zBuf, iAmt);
+    if (needed > p->sz) p->sz = needed;
+    return SQLITE_OK;
+}
+
+static int memTruncate(sqlite3_file *pFile, sqlite3_int64 size) {
+    MemFile *p = (MemFile *)pFile;
+    if ((int)size < p->sz) p->sz = (int)size;
+    return SQLITE_OK;
+}
+
+static int memSync(sqlite3_file *pFile, int flags) {
+    (void)pFile; (void)flags;
+    return SQLITE_OK;
+}
+
+static int memFileSize(sqlite3_file *pFile, sqlite3_int64 *pSize) {
+    *pSize = ((MemFile *)pFile)->sz;
+    return SQLITE_OK;
+}
+
+static int memLock(sqlite3_file *f, int l) { (void)f; (void)l; return SQLITE_OK; }
+static int memUnlock(sqlite3_file *f, int l) { (void)f; (void)l; return SQLITE_OK; }
+static int memCheckReservedLock(sqlite3_file *f, int *pOut) { (void)f; *pOut = 0; return SQLITE_OK; }
+static int memFileControl(sqlite3_file *f, int op, void *a) { (void)f; (void)op; (void)a; return SQLITE_NOTFOUND; }
+static int memSectorSize(sqlite3_file *f) { (void)f; return 512; }
+static int memDeviceCharacteristics(sqlite3_file *f) { (void)f; return 0; }
+
+static const sqlite3_io_methods memIoMethods = {
+    1,                          /* iVersion */
+    memClose,
+    memRead,
+    memWrite,
+    memTruncate,
+    memSync,
+    memFileSize,
+    memLock,
+    memUnlock,
+    memCheckReservedLock,
+    memFileControl,
+    memSectorSize,
+    memDeviceCharacteristics,
+};
+
+/* ── VFS methods ───────────────────────────────────────────────────── */
+
+static int memVfsOpen(sqlite3_vfs *pVfs, const char *zName,
+                      sqlite3_file *pFile, int flags, int *pOutFlags) {
+    (void)pVfs; (void)zName; (void)flags;
+    MemFile *p = (MemFile *)pFile;
+    memset(p, 0, sizeof(*p));
+    p->base.pMethods = &memIoMethods;
+    if (pOutFlags) *pOutFlags = flags;
+    return SQLITE_OK;
+}
+
+static int memVfsDelete(sqlite3_vfs *v, const char *n, int s) {
+    (void)v; (void)n; (void)s;
+    return SQLITE_OK;
+}
+
+static int memVfsAccess(sqlite3_vfs *v, const char *zName, int flags, int *pResOut) {
+    (void)v; (void)zName; (void)flags;
+    *pResOut = 0;  /* file does not exist */
+    return SQLITE_OK;
+}
+
+static int memVfsFullPathname(sqlite3_vfs *v, const char *zIn, int nOut, char *zOut) {
+    (void)v;
+    int n = (int)strlen(zIn);
+    if (n >= nOut) n = nOut - 1;
+    memcpy(zOut, zIn, n);
+    zOut[n] = '\0';
+    return SQLITE_OK;
+}
+
+static int memVfsRandomness(sqlite3_vfs *v, int nByte, char *zOut) {
+    (void)v;
+    memset(zOut, 0, nByte);
+    return nByte;
+}
+
+static int memVfsSleep(sqlite3_vfs *v, int microseconds) {
+    (void)v; (void)microseconds;
+    return 0;
+}
+
+static int memVfsCurrentTime(sqlite3_vfs *v, double *pOut) {
+    (void)v;
+    *pOut = 2460000.5;  /* arbitrary Julian day number */
+    return SQLITE_OK;
+}
+
+static int memVfsGetLastError(sqlite3_vfs *v, int n, char *buf) {
+    (void)v; (void)n; (void)buf;
+    return 0;
+}
+
+static sqlite3_vfs memVfs = {
+    1,                          /* iVersion */
+    (int)sizeof(MemFile),       /* szOsFile */
+    512,                        /* mxPathname */
+    0,                          /* pNext */
+    "memvfs",                   /* zName */
+    0,                          /* pAppData */
+    memVfsOpen,
+    memVfsDelete,
+    memVfsAccess,
+    memVfsFullPathname,
+    0, 0, 0, 0,                /* xDlOpen, xDlError, xDlSym, xDlClose */
+    memVfsRandomness,
+    memVfsSleep,
+    memVfsCurrentTime,
+    memVfsGetLastError,
+};
+
+/* ── OS interface required by SQLITE_OS_OTHER ─────────────────────── */
+
+int sqlite3_os_init(void) {
+    return sqlite3_vfs_register(&memVfs, 1 /* make default */);
+}
+
+int sqlite3_os_end(void) {
+    return SQLITE_OK;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,9 @@
         # NOTE: v8 (rusty_v8) requires a pre-built static library.  Set
         # RUSTY_V8_ARCHIVE to the path of the .a file if the automatic
         # download does not work inside the Nix sandbox.
+        # SQLite compiled to WASM via Emscripten — used by the sqlite-wasm example.
+        packages.sqlite-wasm = import ./nix/sqlite-wasm.nix { inherit pkgs; };
+
         packages.default = rustPlatform.buildRustPackage {
           pname = "mcp-js-server";
           version = "0.1.0";

--- a/nix/sqlite-wasm.nix
+++ b/nix/sqlite-wasm.nix
@@ -1,0 +1,66 @@
+# Build SQLite as a standalone WASM module for use with mcp-v8.
+#
+# Uses the SQLite autoconf source from nixpkgs (which includes the
+# amalgamation sqlite3.c) and Emscripten to produce a WASI-compatible
+# sqlite3.wasm that can be loaded with `--wasm-module sqlite=sqlite3.wasm`.
+{ pkgs }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "sqlite3-wasm";
+  version = pkgs.sqlite.version;
+
+  # Re-use the SQLite autoconf source that nixpkgs already fetches.
+  # It contains the amalgamation (sqlite3.c / sqlite3.h) at the top level.
+  src = pkgs.sqlite.src;
+
+  nativeBuildInputs = [ pkgs.emscripten ];
+
+  buildPhase = ''
+    # Emscripten needs a writable cache directory
+    export EM_CACHE=$(mktemp -d)
+
+    emcc sqlite3.c \
+      -o sqlite3.wasm \
+      -O2 \
+      -sSTANDALONE_WASM=1 \
+      -sEXPORTED_FUNCTIONS='[
+        "_sqlite3_open",
+        "_sqlite3_close",
+        "_sqlite3_exec",
+        "_sqlite3_errmsg",
+        "_sqlite3_prepare_v2",
+        "_sqlite3_step",
+        "_sqlite3_column_count",
+        "_sqlite3_column_type",
+        "_sqlite3_column_int",
+        "_sqlite3_column_double",
+        "_sqlite3_column_text",
+        "_sqlite3_column_bytes",
+        "_sqlite3_column_name",
+        "_sqlite3_finalize",
+        "_sqlite3_changes",
+        "_sqlite3_last_insert_rowid",
+        "_malloc",
+        "_free"
+      ]' \
+      -sERROR_ON_UNDEFINED_SYMBOLS=0 \
+      -sALLOW_MEMORY_GROWTH=1 \
+      -sINITIAL_MEMORY=16777216 \
+      -sSTACK_SIZE=65536 \
+      -sFILESYSTEM=0 \
+      --no-entry \
+      -DSQLITE_OS_OTHER=1 \
+      -DSQLITE_OMIT_LOAD_EXTENSION \
+      -DSQLITE_OMIT_WAL \
+      -DSQLITE_THREADSAFE=0 \
+      -DSQLITE_OMIT_LOCALTIME \
+      -DSQLITE_OMIT_RANDOMNESS \
+      -DSQLITE_TEMP_STORE=3 \
+      -DSQLITE_OMIT_DEPRECATED
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp sqlite3.wasm $out/sqlite3.wasm
+  '';
+}

--- a/nix/sqlite-wasm.nix
+++ b/nix/sqlite-wasm.nix
@@ -19,7 +19,11 @@ pkgs.stdenv.mkDerivation {
     # Emscripten needs a writable cache directory
     export EM_CACHE=$(mktemp -d)
 
-    emcc sqlite3.c \
+    # Copy the minimal in-memory VFS into the build directory
+    # (sqlite3.h is already here from the amalgamation source)
+    cp ${../examples/sqlite-wasm/memvfs.c} memvfs.c
+
+    emcc sqlite3.c memvfs.c \
       -o sqlite3.wasm \
       -O2 \
       -sSTANDALONE_WASM=1 \


### PR DESCRIPTION
## Summary

This PR adds support for WebAssembly modules that require imports (such as WASI modules), enabling SQLite to run inside mcp-v8 via WebAssembly. Previously, only self-contained WASM modules without imports were supported.

## Key Changes

- **WASM module import detection**: Added `wasm_has_imports()` function to detect whether a compiled WASM module has any imports by parsing the module's import section.

- **Dual exposure strategy**: 
  - All WASM modules now expose their compiled `WebAssembly.Module` as `__wasm_<name>` global, allowing manual instantiation in JavaScript
  - Modules without imports continue to be auto-instantiated with exports bound to `<name>` (backwards compatible)
  - Modules with imports skip auto-instantiation and require manual instantiation with an imports object

- **SQLite WASM example**: Added a complete working example (`examples/sqlite-wasm/`) including:
  - `example.js`: Full SQLite wrapper with WASI stub implementations, string encoding/decoding, and SQL query execution
  - `build.sh`: Build script to compile SQLite to WASM using Emscripten
  - `README.md`: Comprehensive documentation on building, running, and using SQLite WASM
  - Nix build support via `nix/sqlite-wasm.nix`

- **E2E testing**: Added GitHub Actions workflow (`sqlite-wasm-e2e.yml`) that builds SQLite WASM and runs the example against a live mcp-v8 server, verifying database operations work correctly.

- **Test coverage**: Added four new tests in `server/tests/wasm.rs`:
  - Verify `__wasm_<name>` Module global is exposed for modules without imports
  - Verify manual instantiation works for self-contained modules
  - Verify modules with imports are NOT auto-instantiated
  - Verify manual instantiation with imports object works correctly

- **Documentation**: Updated main README with WASM import support details and SQLite WASM quick start guide.

## Implementation Details

The WASM module injection logic now:
1. Compiles the WASM bytes to a `WebAssembly.Module` using V8's native API
2. Checks if the module has any imports using wasmparser
3. Always exposes the compiled Module as `__wasm_<name>` for manual instantiation
4. Only auto-instantiates modules without imports, binding their exports to `<name>`

The SQLite example demonstrates proper WASI stub implementation (fd_write, environ_get, clock_time_get, etc.) and provides a complete JavaScript wrapper around SQLite's C API for creating tables, inserting data, and executing queries.

https://claude.ai/code/session_01No4C9PZgDRfWPcehoE4hqY