### PR TITLE
Improve V8 error handling and WASM import resilience

### DIFF
--- a/.github/workflows/sqlite-wasm-e2e.yml
+++ b/.github/workflows/sqlite-wasm-e2e.yml
@@ -41,8 +41,12 @@ jobs:
           # Start server in HTTP mode with the SQLite WASM module
           $SERVER_BIN --stateless --http-port 8080 \
             --wasm-module sqlite="$WASM_PATH" \
-            --heap-memory-max 32 &
+            --heap-memory-max 128 &
           SERVER_PID=$!
+
+          # Ensure we always clean up the server process
+          cleanup() { kill $SERVER_PID 2>/dev/null || true; }
+          trap cleanup EXIT
 
           # Wait for server to be ready (up to 30s)
           for i in $(seq 1 30); do
@@ -55,12 +59,21 @@ jobs:
             sleep 1
           done
 
-          # Run the SQLite WASM example
-          RESULT=$(curl -sf http://localhost:8080/api/exec \
+          # Run the SQLite WASM example — capture response even on HTTP errors
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w '%{http_code}' \
+            http://localhost:8080/api/exec \
             -H 'Content-Type: application/json' \
             -d "$(jq -Rs '{code: .}' < examples/sqlite-wasm/example.js)")
 
+          RESULT=$(cat /tmp/response.json)
+          echo "HTTP status: $HTTP_CODE"
           echo "Result: $RESULT"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "ERROR: Server returned HTTP $HTTP_CODE"
+            echo "Response body: $RESULT"
+            exit 1
+          fi
 
           # Parse and verify the output
           OUTPUT=$(echo "$RESULT" | jq -r '.output')
@@ -79,5 +92,3 @@ jobs:
           echo "$OUTPUT" | jq -e '.stats.avg_age == 30'
 
           echo "SQLite WASM E2E test passed!"
-
-          kill $SERVER_PID


### PR DESCRIPTION
## Summary
This PR enhances error reporting in V8 script execution and improves the robustness of WASM module imports in the SQLite example. It also strengthens the E2E test with better error handling and increased memory allocation.

## Key Changes

### Engine Error Handling (`server/src/engine/mod.rs`)
- Wrapped V8 script compilation and execution in `TryCatch` scopes to properly capture exceptions
- Added `format_trycatch_exception()` helper function that extracts human-readable error messages from V8 exceptions, including line numbers when available
- Improved error messages for both compilation and runtime failures, providing better debugging information

### WASM Import Resilience (`examples/sqlite-wasm/example.js`)
- Refactored WebAssembly import object construction to dynamically enumerate module imports using `WebAssembly.Module.imports()`
- Provides known stubs for recognized imports (WASI and Emscripten functions) while falling back to no-op functions for unknown imports
- Makes the example resilient to different Emscripten versions that may add or remove imports

### E2E Test Improvements (`.github/workflows/sqlite-wasm-e2e.yml`)
- Increased heap memory limit from 32MB to 128MB to accommodate larger WASM modules
- Added proper process cleanup with trap handler to ensure server process is always terminated
- Enhanced HTTP response handling to capture and validate status codes
- Improved error reporting by capturing response body on HTTP errors
- Better diagnostics with explicit HTTP status code and response body logging

## Implementation Details
- The `format_trycatch_exception()` function gracefully handles cases where exception details may not be available, falling back to converting the exception object to a string
- The dynamic import enumeration approach maintains backward compatibility while supporting future Emscripten changes
- The E2E test now properly validates HTTP responses before attempting JSON parsing, preventing silent failures

https://claude.ai/code/session_017zMFs3pbgnWbUw5f47Ty4i