### PR TITLE
Reduce heap memory limit in SQLite WASM e2e test

### DIFF
--- a/.github/workflows/sqlite-wasm-e2e.yml
+++ b/.github/workflows/sqlite-wasm-e2e.yml
@@ -41,7 +41,7 @@ jobs:
           # Start server in HTTP mode with the SQLite WASM module
           $SERVER_BIN --stateless --http-port 8080 \
             --wasm-module sqlite="$WASM_PATH" \
-            --heap-memory-max 128 &
+            --heap-memory-max 64 &
           SERVER_PID=$!
 
           # Ensure we always clean up the server process


### PR DESCRIPTION
## Summary
Reduced the maximum heap memory allocation for the SQLite WASM module in the end-to-end test workflow from 128 MB to 64 MB.

## Changes
- Decreased `--heap-memory-max` parameter from 128 to 64 in the SQLite WASM e2e test server startup command

## Details
This change optimizes the test environment's resource usage by halving the heap memory limit. This adjustment helps validate that the SQLite WASM module operates efficiently within tighter memory constraints and may improve CI/CD pipeline performance by reducing resource consumption during test execution.

https://claude.ai/code/session_01MZZ7VgVn2t3wPkK6po7kRJ