### PR TITLE
Fix CI builds by prefetching rusty_v8 static library

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {}, rustToolchain ? null }:
+{ pkgs ? import <nixpkgs> {}, rustToolchain ? null, rustyV8Archive ? null }:
   pkgs.mkShell rec {
     buildInputs = with pkgs; [
       (if rustToolchain != null then rustToolchain else rustup)
@@ -19,7 +19,10 @@
       export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
       # Set library path for OpenSSL
       export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH
-      '';
+    '' + pkgs.lib.optionalString (rustyV8Archive != null) ''
+      # Point v8 build.rs to the pre-fetched static library
+      export RUSTY_V8_ARCHIVE=${rustyV8Archive}
+    '';
     # Add precompiled library to rustc search path
     RUSTFLAGS = (builtins.map (a: ''-L ${a}/lib'') [
       # add libraries here (e.g. pkgs.libvmi)


### PR DESCRIPTION
## Summary
- Both CI workflows (SQLite WASM E2E, Fuzz) fail because v8 v145.0.0's build.rs can't download the prebuilt `librusty_v8` static library at build time — the Nix sandbox blocks network access and the self-hosted runner has connectivity issues
- Replace `__noChroot = true` (unreliable network download during build) with Nix `fetchurl` to prefetch the archive for all 4 platforms (x86_64/aarch64 × linux/darwin) with pinned hashes
- Set `RUSTY_V8_ARCHIVE` env var in both the package build and dev shells so the v8 build script uses the local copy
- Remove `curl`/`cacert` from `nativeBuildInputs` since network access is no longer needed

## Test plan
- [ ] Verify SQLite WASM E2E CI job passes (was: `error: failed to run custom build command for v8 v145.0.0`)
- [ ] Verify Fuzz CI job passes (was: `RemoteDisconnected: Remote end closed connection without response`)
- [ ] Verify `nix build .#default` works locally
- [ ] Verify `nix develop` shell sets `RUSTY_V8_ARCHIVE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)