### PR TITLE
Add Docker Compose for OPA and example fetch policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  opa:
+    image: openpolicyagent/opa:latest
+    command: ["run", "--server", "--addr", "0.0.0.0:8181", "/policies"]
+    ports:
+      - "8181:8181"
+    volumes:
+      - ./policies:/policies:ro

--- a/policies/fetch.rego
+++ b/policies/fetch.rego
@@ -1,0 +1,52 @@
+package mcp.fetch
+
+default allow = false
+
+# Read-only: GET and HEAD only
+allow if {
+    input.method == "GET"
+    domain_allowed
+}
+
+allow if {
+    input.method == "HEAD"
+    domain_allowed
+}
+
+# Exact domain matches
+exact_domains := {
+    "github.com",
+    "api.github.com",
+    "bedrock-runtime.us-west-2.amazonaws.com",
+    "bedrock.us-west-2.amazonaws.com",
+    "sts.amazonaws.com",
+    "sts.us-west-2.amazonaws.com",
+    "otel.cua.ai",
+    "cache.nixos.org",
+    "channels.nixos.org",
+    "nixos.org",
+    "proxy.golang.org",
+    "sum.golang.org",
+    "gopkg.in",
+    "golang.org",
+    "google.golang.org",
+    "files.pythonhosted.org",
+    "pypi.org",
+    "registry.npmjs.org",
+}
+
+# Wildcard suffix matches (*.example.com)
+wildcard_suffixes := {
+    ".github.com",
+    ".githubusercontent.com",
+    ".cachix.org",
+}
+
+domain_allowed if {
+    exact_domains[input.url_parsed.host]
+}
+
+domain_allowed if {
+    some suffix in wildcard_suffixes
+    endswith(input.url_parsed.host, suffix)
+}


### PR DESCRIPTION
## Summary
- Adds `docker-compose.yml` to run an OPA server on port 8181 with policies mounted read-only
- Adds `policies/fetch.rego` — a read-only (GET/HEAD) allowlist policy for the OPA-gated fetch feature, covering GitHub, AWS, npm, PyPI, Go proxy, Nix caches, and more

## Usage
```bash
docker compose up -d
mcp-v8 --stateless --opa-url http://localhost:8181
```

## Test plan
- [x] `docker compose up -d` starts OPA and loads the policy
- [x] Allowed GET to `api.github.com` — passes policy
- [x] Allowed GET to `registry.npmjs.org` — 200 OK
- [x] Denied GET to `example.com` — blocked by policy
- [x] Denied POST to `api.github.com` — blocked (read-only)
- [x] Wildcard match `raw.githubusercontent.com` — 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)