### PR TITLE
Implement async execution tracking with console output streaming

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -68,7 +68,7 @@ jobs:
       # ── Prepare data directories ────────────────────────────────────
       - name: Create data directories
         run: |
-          rm -rf /tmp/loadtest
+          rm -rf /tmp/loadtest /tmp/mcp-v8-sessions /tmp/mcp-v8-executions*
           mkdir -p /tmp/loadtest/node1/heaps /tmp/loadtest/node1/sessions
           mkdir -p /tmp/loadtest/node2/heaps /tmp/loadtest/node2/sessions
           mkdir -p /tmp/loadtest/node3/heaps /tmp/loadtest/node3/sessions
@@ -83,7 +83,7 @@ jobs:
             if [ "${{ matrix.mode }}" = "stateful" ]; then
               ARGS="--http-port=3001 --directory-path=/tmp/loadtest/node1/heaps --session-db-path=/tmp/loadtest/node1/sessions"
             else
-              ARGS="--http-port=3001 --stateless"
+              ARGS="--http-port=3001 --stateless --session-db-path=/tmp/loadtest/node1/sessions"
             fi
 
             echo "Starting single node on port 3001..."
@@ -112,7 +112,7 @@ jobs:
               if [ "${{ matrix.mode }}" = "stateful" ]; then
                 MODE_ARGS="--directory-path=/tmp/loadtest/${NODE_ID}/heaps --session-db-path=/tmp/loadtest/${NODE_ID}/sessions"
               else
-                MODE_ARGS="--stateless"
+                MODE_ARGS="--stateless --session-db-path=/tmp/loadtest/${NODE_ID}/sessions"
               fi
 
               echo "Starting ${NODE_ID} on HTTP ${HTTP_PORT}, cluster ${CLUSTER_PORT}..."

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -142,10 +142,14 @@ jobs:
           for URL in "${URLS[@]}"; do
             echo "Checking ${URL}..."
             for i in $(seq 1 60); do
-              if curl -sf --max-time 10 -o /dev/null -X POST "${URL}/api/exec" \
+              # The exec endpoint now returns 202 Accepted (async).
+              # Use -w to check the HTTP status code.
+              HTTP_CODE=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' \
+                -X POST "${URL}/api/exec" \
                 -H 'Content-Type: application/json' \
-                -d '{"code":"1"}' 2>/dev/null; then
-                echo "${URL} is ready (attempt ${i})"
+                -d '{"code":"1"}' 2>/dev/null || echo "000")
+              if [ "$HTTP_CODE" = "202" ] || [ "$HTTP_CODE" = "200" ]; then
+                echo "${URL} is ready (attempt ${i}, HTTP ${HTTP_CODE})"
                 break
               fi
               if [ "$i" -eq 60 ]; then
@@ -180,7 +184,7 @@ jobs:
           URL="${URLS[0]}"
 
           echo "=== Smoke test: POST /api/exec on ${URL} ==="
-          RESP=$(curl -sf --max-time 10 -X POST "${URL}/api/exec" \
+          RESP=$(curl -s --max-time 10 -X POST "${URL}/api/exec" \
             -H 'Content-Type: application/json' \
             -d '{"code":"1 + 1"}')
           echo "Response: $RESP"
@@ -191,14 +195,42 @@ jobs:
             exit 1
           fi
 
-          # Verify the output field contains "2"
-          OUTPUT=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('output',''))" 2>/dev/null || true)
-          if [ "$OUTPUT" != "2" ]; then
-            echo "ERROR: Expected output '2', got '${OUTPUT}'"
+          # The exec endpoint now returns 202 with an execution_id.
+          # Poll the execution status until it completes.
+          EXEC_ID=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('execution_id',''))" 2>/dev/null || true)
+          if [ -z "$EXEC_ID" ]; then
+            echo "ERROR: No execution_id in response"
             cat /tmp/loadtest/*.log || true
             exit 1
           fi
-          echo "Smoke test passed"
+          echo "Execution ID: $EXEC_ID"
+
+          # Poll for completion (up to 30 seconds)
+          for i in $(seq 1 30); do
+            STATUS_RESP=$(curl -s --max-time 10 "${URL}/api/executions/${EXEC_ID}" 2>/dev/null)
+            STATUS=$(echo "$STATUS_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
+            if [ "$STATUS" = "Completed" ] || [ "$STATUS" = "completed" ]; then
+              echo "Execution completed"
+              RESULT=$(echo "$STATUS_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))" 2>/dev/null || true)
+              echo "Result: $RESULT"
+              if [ "$RESULT" != "2" ]; then
+                echo "ERROR: Expected result '2', got '${RESULT}'"
+                cat /tmp/loadtest/*.log || true
+                exit 1
+              fi
+              echo "Smoke test passed"
+              exit 0
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "failed" ]; then
+              echo "ERROR: Execution failed"
+              echo "$STATUS_RESP"
+              cat /tmp/loadtest/*.log || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "ERROR: Execution did not complete within 30s"
+          cat /tmp/loadtest/*.log || true
+          exit 1
 
       # ── Load tests at each rate ─────────────────────────────────────
       - name: Run load tests

--- a/.github/workflows/sqlite-wasm-e2e.yml
+++ b/.github/workflows/sqlite-wasm-e2e.yml
@@ -50,33 +50,56 @@ jobs:
 
           # Wait for server to be ready (up to 30s)
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:8080/api/exec \
+            HTTP_CODE=$(curl -s --max-time 10 -o /dev/null -w '%{http_code}' \
+              http://localhost:8080/api/exec \
               -H 'Content-Type: application/json' \
-              -d '{"code": "1+1"}' > /dev/null 2>&1; then
-              echo "Server is ready"
+              -d '{"code": "1+1"}' 2>/dev/null || echo "000")
+            if [ "$HTTP_CODE" = "202" ] || [ "$HTTP_CODE" = "200" ]; then
+              echo "Server is ready (HTTP $HTTP_CODE)"
               break
             fi
             sleep 1
           done
 
-          # Run the SQLite WASM example — capture response even on HTTP errors
-          HTTP_CODE=$(curl -s -o /tmp/response.json -w '%{http_code}' \
+          # Run the SQLite WASM example — submit for async execution
+          HTTP_CODE=$(curl -s -o /tmp/submit.json -w '%{http_code}' \
             http://localhost:8080/api/exec \
             -H 'Content-Type: application/json' \
             -d "$(jq -Rs '{code: .}' < examples/sqlite-wasm/example.js)")
 
-          RESULT=$(cat /tmp/response.json)
-          echo "HTTP status: $HTTP_CODE"
-          echo "Result: $RESULT"
+          echo "Submit HTTP status: $HTTP_CODE"
+          cat /tmp/submit.json
 
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "ERROR: Server returned HTTP $HTTP_CODE"
-            echo "Response body: $RESULT"
+          if [ "$HTTP_CODE" != "202" ]; then
+            echo "ERROR: Server returned HTTP $HTTP_CODE (expected 202)"
+            cat /tmp/submit.json
             exit 1
           fi
 
+          EXEC_ID=$(cat /tmp/submit.json | jq -r '.execution_id')
+          echo "Execution ID: $EXEC_ID"
+
+          # Poll for completion (up to 60s for WASM compilation)
+          for i in $(seq 1 60); do
+            STATUS_RESP=$(curl -s http://localhost:8080/api/executions/${EXEC_ID})
+            STATUS=$(echo "$STATUS_RESP" | jq -r '.status')
+            if [ "$STATUS" = "Completed" ] || [ "$STATUS" = "completed" ]; then
+              echo "Execution completed"
+              break
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "failed" ] || [ "$STATUS" = "TimedOut" ]; then
+              echo "ERROR: Execution $STATUS"
+              echo "$STATUS_RESP"
+              exit 1
+            fi
+            sleep 1
+          done
+
+          # Get the result
+          RESULT=$(echo "$STATUS_RESP" | jq -r '.result')
+          echo "Result: $RESULT"
+
           # Parse and verify the output
-          OUTPUT=$(echo "$RESULT" | jq -r '.output')
+          OUTPUT="$RESULT"
           echo "Output: $OUTPUT"
 
           # Verify we got 3 users back

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
           # so we can inject our fixed replace-workspace-values script.
           cargoDeps = (rustPlatform.fetchCargoVendor {
             src = ./server;
-            hash = "sha256-VpbOZxX1qeBEsZE0xMmK1a+jg87TIccAKprqBV0JZy4=";
+            hash = "sha256-7IxMRJQnEaVS+hDLJ0yq3O3fxgrDTuu27UUvevL/mCc=";
           }).overrideAttrs (old: {
             nativeBuildInputs = map (dep:
               if (dep.name or "") == "replace-workspace-values"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1053,6 +1053,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3194,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "dashmap 6.1.0",
  "deno_core",
  "deno_error",
  "futures",
@@ -3454,7 +3469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7133338c3bef796430deced151b0eaa5430710a90e38da19e8e3045e8e36eeb"
 dependencies = [
  "anyhow",
- "dashmap",
+ "dashmap 5.5.3",
  "once_cell",
  "regex",
  "rustc-hash",
@@ -3679,7 +3694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e7635afe1e1e798d61ff3107b8d27e437e61f243dd226a47fb10724693be66"
 dependencies = [
  "base64 0.22.1",
- "dashmap",
+ "dashmap 5.5.3",
  "indexmap",
  "once_cell",
  "rustc-hash",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,6 +48,8 @@ reqwest = { version = "0.12", features = ["json"] }
 url = "2"
 futures = "0.3"
 wasmparser = "0.225"
+uuid = { version = "1.0", features = ["v4"] }
+dashmap = "6"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
@@ -72,5 +72,5 @@ fuzz_target!(|input: StatefulInput| {
     let max_bytes = 8 * 1024 * 1024;
     let wasm_default = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateful(&input.code, raw_snapshot, max_bytes, handle, &modules, wasm_default, None);
+    let _ = server::engine::execute_stateful(&input.code, raw_snapshot, max_bytes, handle, &modules, wasm_default, None, None);
 });

--- a/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
@@ -59,5 +59,5 @@ fuzz_target!(|input: StatelessInput| {
     let max_bytes = 8 * 1024 * 1024;
     let wasm_default = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateless(&input.code, max_bytes, handle, &modules, wasm_default, None);
+    let _ = server::engine::execute_stateless(&input.code, max_bytes, handle, &modules, wasm_default, None, None);
 });

--- a/server/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
+++ b/server/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
@@ -39,5 +39,5 @@ fuzz_target!(|data: &[u8]| {
     let max_bytes = 64 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
     let wasm_default = 16 * 1024 * 1024;
-    let _ = server::engine::execute_stateful("1", raw_snapshot, max_bytes, handle, &[], wasm_default, None);
+    let _ = server::engine::execute_stateful("1", raw_snapshot, max_bytes, handle, &[], wasm_default, None, None);
 });

--- a/server/fuzz/fuzz_targets/fuzz_wasm_compile.rs
+++ b/server/fuzz/fuzz_targets/fuzz_wasm_compile.rs
@@ -43,5 +43,5 @@ fuzz_target!(|data: &[u8]| {
     let max_bytes = 64 * 1024 * 1024;
     let wasm_default = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateless("1", max_bytes, handle, &modules, wasm_default, None);
+    let _ = server::engine::execute_stateless("1", max_bytes, handle, &modules, wasm_default, None, None);
 });

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -1,10 +1,10 @@
 use axum::{
-    extract::State,
+    extract::{Path, Query, State},
     http::StatusCode,
-    routing::post,
+    routing::{get, post},
     Json, Router,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashMap;
 
 use crate::engine::Engine;
@@ -24,17 +24,11 @@ struct ExecRequest {
     tags: Option<HashMap<String, String>>,
 }
 
-#[derive(Serialize)]
-struct ExecResponse {
-    output: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    heap: Option<String>,
-}
 
 async fn exec_handler(
     State(engine): State<Engine>,
     Json(req): Json<ExecRequest>,
-) -> (StatusCode, Json<ExecResponse>) {
+) -> (StatusCode, Json<serde_json::Value>) {
     match engine
         .run_js(
             req.code,
@@ -46,19 +40,114 @@ async fn exec_handler(
         )
         .await
     {
-        Ok(result) => (
-            StatusCode::OK,
-            Json(ExecResponse {
-                output: result.output,
-                heap: result.heap,
-            }),
+        Ok(execution_id) => (
+            StatusCode::ACCEPTED,
+            Json(serde_json::json!({ "execution_id": execution_id })),
         ),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ExecResponse {
-                output: format!("Error: {}", e),
-                heap: None,
-            }),
+            Json(serde_json::json!({ "error": e })),
+        ),
+    }
+}
+
+async fn get_execution_handler(
+    State(engine): State<Engine>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match engine.get_execution(&id) {
+        Ok(info) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "execution_id": info.id,
+                "status": info.status,
+                "result": info.result,
+                "heap": info.heap,
+                "error": info.error,
+                "started_at": info.started_at,
+                "completed_at": info.completed_at,
+            })),
+        ),
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": e })),
+        ),
+    }
+}
+
+#[derive(Deserialize)]
+struct OutputQuery {
+    #[serde(default)]
+    line_offset: Option<u64>,
+    #[serde(default)]
+    line_limit: Option<u64>,
+    #[serde(default)]
+    byte_offset: Option<u64>,
+    #[serde(default)]
+    byte_limit: Option<u64>,
+}
+
+async fn get_execution_output_handler(
+    State(engine): State<Engine>,
+    Path(id): Path<String>,
+    Query(query): Query<OutputQuery>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let status = engine.get_execution(&id)
+        .map(|info| info.status)
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    match engine.get_execution_output(&id, query.line_offset, query.line_limit, query.byte_offset, query.byte_limit) {
+        Ok(page) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "execution_id": id,
+                "data": page.data,
+                "start_line": page.start_line,
+                "end_line": page.end_line,
+                "next_line_offset": page.next_line_offset,
+                "total_lines": page.total_lines,
+                "start_byte": page.start_byte,
+                "end_byte": page.end_byte,
+                "next_byte_offset": page.next_byte_offset,
+                "total_bytes": page.total_bytes,
+                "has_more": page.has_more,
+                "status": status,
+            })),
+        ),
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": e })),
+        ),
+    }
+}
+
+async fn cancel_execution_handler(
+    State(engine): State<Engine>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match engine.cancel_execution(&id) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "ok": false, "error": e })),
+        ),
+    }
+}
+
+async fn list_executions_handler(
+    State(engine): State<Engine>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match engine.list_executions() {
+        Ok(executions) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "executions": executions })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e })),
         ),
     }
 }
@@ -66,5 +155,9 @@ async fn exec_handler(
 pub fn api_router(engine: Engine) -> Router {
     Router::new()
         .route("/api/exec", post(exec_handler))
+        .route("/api/executions", get(list_executions_handler))
+        .route("/api/executions/{id}", get(get_execution_handler))
+        .route("/api/executions/{id}/output", get(get_execution_output_handler))
+        .route("/api/executions/{id}/cancel", post(cancel_execution_handler))
         .with_state(engine)
 }

--- a/server/src/engine/console.rs
+++ b/server/src/engine/console.rs
@@ -1,0 +1,155 @@
+//! Console output capture for the JavaScript runtime.
+//!
+//! Intercepts `console.log`, `console.info`, `console.warn`, and `console.error`
+//! calls and streams the output as a byte stream into a sled tree. Writes are
+//! buffered in-memory and flushed to sled in fixed-size pages (WAL-style) for
+//! efficient batching.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use deno_core::{JsRuntime, OpState, op2};
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+/// Page size for WAL-style writes to sled. When the in-memory buffer reaches
+/// this size, a full page is flushed to sled. Remaining bytes are flushed on
+/// execution end.
+const PAGE_SIZE: usize = 4096;
+
+/// Per-execution console output state, stored in deno_core's `OpState`.
+/// Buffers console output bytes and flushes them to sled in fixed-size pages.
+pub struct ConsoleLogState {
+    tree: sled::Tree,
+    seq: AtomicU64,
+    buffer: RefCell<Vec<u8>>,
+}
+
+// Safety: ConsoleLogState is only accessed from a single V8 thread.
+// The RefCell ensures runtime borrow checking. AtomicU64 is inherently
+// thread-safe. sled::Tree is Send+Sync.
+unsafe impl Send for ConsoleLogState {}
+unsafe impl Sync for ConsoleLogState {}
+
+impl ConsoleLogState {
+    pub fn new(tree: sled::Tree) -> Self {
+        Self {
+            tree,
+            seq: AtomicU64::new(0),
+            buffer: RefCell::new(Vec::with_capacity(PAGE_SIZE)),
+        }
+    }
+
+    /// Append bytes to the buffer, flushing full pages to sled.
+    pub fn write(&self, data: &[u8]) {
+        let mut buf = self.buffer.borrow_mut();
+        buf.extend_from_slice(data);
+        while buf.len() >= PAGE_SIZE {
+            let page: Vec<u8> = buf.drain(..PAGE_SIZE).collect();
+            let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+            let _ = self.tree.insert(seq.to_be_bytes(), page);
+        }
+    }
+
+    /// Flush any remaining buffered bytes to sled (call on execution end).
+    pub fn flush(&self) {
+        let mut buf = self.buffer.borrow_mut();
+        if !buf.is_empty() {
+            let page: Vec<u8> = buf.drain(..).collect();
+            let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+            let _ = self.tree.insert(seq.to_be_bytes(), page);
+        }
+    }
+}
+
+// ── Op definition ────────────────────────────────────────────────────────
+
+/// Sync op: writes formatted console output bytes into the buffered WAL.
+/// Called from JS via `Deno.core.ops.op_console_write(msg, level)`.
+/// level: 0=log, 1=info, 2=warn, 3=error
+#[op2(fast)]
+fn op_console_write(state: &mut OpState, #[string] msg: &str, #[smi] level: i32) {
+    let console_state = state.borrow::<ConsoleLogState>();
+
+    let formatted = match level {
+        2 => format!("[WARN] {}\n", msg),
+        3 => format!("[ERROR] {}\n", msg),
+        1 => format!("[INFO] {}\n", msg),
+        _ => format!("{}\n", msg),
+    };
+
+    console_state.write(formatted.as_bytes());
+}
+
+// ── Extension registration ───────────────────────────────────────────────
+
+deno_core::extension!(
+    console_ext,
+    ops = [op_console_write],
+);
+
+/// Create the console extension for use in `RuntimeOptions::extensions`.
+pub fn create_extension() -> deno_core::Extension {
+    console_ext::init()
+}
+
+// ── Inject console JS wrapper into the global scope ──────────────────────
+
+/// Inject the `globalThis.console` JS wrapper. Must be called after the
+/// runtime is created (with the console extension) but before user code runs.
+pub fn inject_console(runtime: &mut JsRuntime) -> Result<(), String> {
+    runtime
+        .execute_script("<console-setup>", CONSOLE_JS_WRAPPER.to_string())
+        .map_err(|e| format!("Failed to install console wrapper: {}", e))?;
+    Ok(())
+}
+
+/// Overload for JsRuntimeForSnapshot (stateful mode).
+pub fn inject_console_snapshot(runtime: &mut deno_core::JsRuntimeForSnapshot) -> Result<(), String> {
+    runtime
+        .execute_script("<console-setup>", CONSOLE_JS_WRAPPER.to_string())
+        .map_err(|e| format!("Failed to install console wrapper: {}", e))?;
+    Ok(())
+}
+
+/// JavaScript wrapper that overrides `globalThis.console` to route output
+/// through `op_console_write`.
+const CONSOLE_JS_WRAPPER: &str = r#"
+(function() {
+    function formatArgs(args) {
+        return args.map(function(a) {
+            if (typeof a === 'string') return a;
+            try { return JSON.stringify(a); } catch(e) { return String(a); }
+        }).join(' ');
+    }
+    globalThis.console = {
+        log: function() { Deno.core.ops.op_console_write(formatArgs(Array.from(arguments)), 0); },
+        info: function() { Deno.core.ops.op_console_write(formatArgs(Array.from(arguments)), 1); },
+        warn: function() { Deno.core.ops.op_console_write(formatArgs(Array.from(arguments)), 2); },
+        error: function() { Deno.core.ops.op_console_write(formatArgs(Array.from(arguments)), 3); },
+        debug: function() { Deno.core.ops.op_console_write(formatArgs(Array.from(arguments)), 0); },
+        trace: function() { Deno.core.ops.op_console_write(formatArgs(Array.from(arguments)), 0); },
+    };
+})();
+"#;
+
+// ── Flush helper ─────────────────────────────────────────────────────────
+
+/// Flush any remaining console output from the runtime's OpState.
+/// Call this after V8 execution completes but before the runtime is dropped.
+pub fn flush_console(runtime: &mut JsRuntime) {
+    let state = runtime.op_state();
+    let state = state.borrow();
+    if let Some(console_state) = state.try_borrow::<ConsoleLogState>() {
+        console_state.flush();
+    }
+}
+
+/// Flush helper for JsRuntimeForSnapshot (stateful mode).
+pub fn flush_console_snapshot(runtime: &mut deno_core::JsRuntimeForSnapshot) {
+    let state = runtime.op_state();
+    let state = state.borrow();
+    if let Some(console_state) = state.try_borrow::<ConsoleLogState>() {
+        console_state.flush();
+    }
+}

--- a/server/src/engine/execution.rs
+++ b/server/src/engine/execution.rs
@@ -1,0 +1,325 @@
+//! Execution registry — tracks in-flight and completed V8 executions.
+//!
+//! Each execution is assigned a UUID, tracked in an in-memory `DashMap`, and
+//! has its console output stored in a per-execution sled tree (`"ex:{id}"`).
+//! Supports querying console output by line offset or byte offset, and
+//! cancellation via V8's `IsolateHandle::terminate_execution()`.
+
+use std::sync::Arc;
+use dashmap::DashMap;
+use deno_core::v8;
+use serde::Serialize;
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+pub type ExecutionId = String;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+    TimedOut,
+}
+
+impl std::fmt::Display for ExecutionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Running => write!(f, "running"),
+            Self::Completed => write!(f, "completed"),
+            Self::Failed => write!(f, "failed"),
+            Self::Cancelled => write!(f, "cancelled"),
+            Self::TimedOut => write!(f, "timed_out"),
+        }
+    }
+}
+
+/// In-memory record for an execution.
+pub struct ExecutionRecord {
+    pub id: ExecutionId,
+    pub status: ExecutionStatus,
+    pub isolate_handle: Option<v8::IsolateHandle>,
+    pub result: Option<String>,
+    pub heap: Option<String>,
+    pub error: Option<String>,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+}
+
+/// Summary returned by `list()`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecutionSummary {
+    pub id: ExecutionId,
+    pub status: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+}
+
+/// A page of console output, including both line and byte coordinates.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConsoleOutputPage {
+    pub data: String,
+
+    // Line coordinates
+    pub start_line: u64,
+    pub end_line: u64,
+    pub next_line_offset: u64,
+    pub total_lines: u64,
+
+    // Byte coordinates
+    pub start_byte: u64,
+    pub end_byte: u64,
+    pub next_byte_offset: u64,
+    pub total_bytes: u64,
+
+    pub has_more: bool,
+}
+
+// ── ExecutionRegistry ────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct ExecutionRegistry {
+    executions: Arc<DashMap<ExecutionId, ExecutionRecord>>,
+    db: sled::Db,
+}
+
+impl ExecutionRegistry {
+    pub fn new(db_path: &str) -> Result<Self, String> {
+        let db = sled::open(db_path)
+            .map_err(|e| format!("Failed to open execution db at {}: {}", db_path, e))?;
+        Ok(Self {
+            executions: Arc::new(DashMap::new()),
+            db,
+        })
+    }
+
+    /// Register a new execution. Returns the sled tree for console output.
+    pub fn register(&self, id: &str) -> Result<sled::Tree, String> {
+        let tree_name = format!("ex:{}", id);
+        let tree = self.db.open_tree(&tree_name)
+            .map_err(|e| format!("Failed to open console tree '{}': {}", tree_name, e))?;
+
+        let record = ExecutionRecord {
+            id: id.to_string(),
+            status: ExecutionStatus::Running,
+            isolate_handle: None,
+            result: None,
+            heap: None,
+            error: None,
+            started_at: chrono::Utc::now().to_rfc3339(),
+            completed_at: None,
+        };
+        self.executions.insert(id.to_string(), record);
+
+        Ok(tree)
+    }
+
+    /// Store the V8 isolate handle for cancellation support.
+    pub fn set_isolate_handle(&self, id: &str, handle: v8::IsolateHandle) {
+        if let Some(mut record) = self.executions.get_mut(id) {
+            record.isolate_handle = Some(handle);
+        }
+    }
+
+    /// Clear the isolate handle (e.g., after execution completes).
+    pub fn clear_isolate_handle(&self, id: &str) {
+        if let Some(mut record) = self.executions.get_mut(id) {
+            record.isolate_handle = None;
+        }
+    }
+
+    /// Mark execution as completed with its result.
+    pub fn complete(&self, id: &str, output: String, heap: Option<String>) {
+        if let Some(mut record) = self.executions.get_mut(id) {
+            record.status = ExecutionStatus::Completed;
+            record.result = Some(output);
+            record.heap = heap;
+            record.isolate_handle = None;
+            record.completed_at = Some(chrono::Utc::now().to_rfc3339());
+        }
+    }
+
+    /// Mark execution as failed.
+    pub fn fail(&self, id: &str, error: String) {
+        if let Some(mut record) = self.executions.get_mut(id) {
+            record.status = ExecutionStatus::Failed;
+            record.error = Some(error);
+            record.isolate_handle = None;
+            record.completed_at = Some(chrono::Utc::now().to_rfc3339());
+        }
+    }
+
+    /// Mark execution as timed out.
+    pub fn timed_out(&self, id: &str) {
+        if let Some(mut record) = self.executions.get_mut(id) {
+            record.status = ExecutionStatus::TimedOut;
+            record.error = Some("Execution timed out".to_string());
+            record.isolate_handle = None;
+            record.completed_at = Some(chrono::Utc::now().to_rfc3339());
+        }
+    }
+
+    /// Cancel a running execution. Terminates V8 isolate.
+    pub fn cancel(&self, id: &str) -> Result<(), String> {
+        let mut record = self.executions.get_mut(id)
+            .ok_or_else(|| format!("Execution '{}' not found", id))?;
+
+        match record.status {
+            ExecutionStatus::Running => {
+                if let Some(ref handle) = record.isolate_handle {
+                    handle.terminate_execution();
+                }
+                record.status = ExecutionStatus::Cancelled;
+                record.error = Some("Cancelled by user".to_string());
+                record.isolate_handle = None;
+                record.completed_at = Some(chrono::Utc::now().to_rfc3339());
+                Ok(())
+            }
+            _ => Err(format!(
+                "Execution '{}' is not running (status: {})",
+                id, record.status
+            )),
+        }
+    }
+
+    /// Get execution status and result.
+    pub fn get(&self, id: &str) -> Option<ExecutionInfo> {
+        self.executions.get(id).map(|r| ExecutionInfo {
+            id: r.id.clone(),
+            status: r.status.to_string(),
+            result: r.result.clone(),
+            heap: r.heap.clone(),
+            error: r.error.clone(),
+            started_at: r.started_at.clone(),
+            completed_at: r.completed_at.clone(),
+        })
+    }
+
+    /// List all executions.
+    pub fn list(&self) -> Vec<ExecutionSummary> {
+        self.executions.iter().map(|entry| {
+            let r = entry.value();
+            ExecutionSummary {
+                id: r.id.clone(),
+                status: r.status.to_string(),
+                started_at: r.started_at.clone(),
+                completed_at: r.completed_at.clone(),
+            }
+        }).collect()
+    }
+
+    /// Get the execution status string for a given ID.
+    pub fn get_status(&self, id: &str) -> Option<String> {
+        self.executions.get(id).map(|r| r.status.to_string())
+    }
+
+    /// Query console output with dual mode: line-based or byte-based offsets.
+    /// If `byte_offset` is provided, byte-offset mode is used (takes precedence).
+    /// Otherwise, line-offset mode is used.
+    pub fn get_console_output(
+        &self,
+        id: &str,
+        line_offset: Option<u64>,
+        line_limit: Option<u64>,
+        byte_offset: Option<u64>,
+        byte_limit: Option<u64>,
+    ) -> Result<ConsoleOutputPage, String> {
+        let tree_name = format!("ex:{}", id);
+        let tree = self.db.open_tree(&tree_name)
+            .map_err(|e| format!("Failed to open console tree: {}", e))?;
+
+        // Reconstruct full byte stream from WAL pages
+        let mut full_output = Vec::new();
+        for item in tree.iter() {
+            let (_, value) = item.map_err(|e| format!("Failed to read console entry: {}", e))?;
+            full_output.extend_from_slice(&value);
+        }
+        let total_bytes = full_output.len() as u64;
+        let full_str = String::from_utf8_lossy(&full_output);
+        let total_lines = full_str.matches('\n').count() as u64;
+
+        if let Some(byte_off) = byte_offset {
+            // === Byte-offset mode ===
+            let limit = byte_limit.unwrap_or(4096);
+            let start = (byte_off as usize).min(full_output.len());
+            let end = (start + limit as usize).min(full_output.len());
+            let data = String::from_utf8_lossy(&full_output[start..end]).to_string();
+            let start_line = full_output[..start].iter().filter(|&&b| b == b'\n').count() as u64 + 1;
+            let end_line = full_output[..end].iter().filter(|&&b| b == b'\n').count() as u64 + 1;
+
+            Ok(ConsoleOutputPage {
+                data,
+                start_line,
+                end_line,
+                next_line_offset: end_line,
+                total_lines,
+                start_byte: start as u64,
+                end_byte: end as u64,
+                next_byte_offset: end as u64,
+                total_bytes,
+                has_more: end < full_output.len(),
+            })
+        } else {
+            // === Line-offset mode (default) ===
+            let line_off = line_offset.unwrap_or(1);
+            let limit = line_limit.unwrap_or(100);
+
+            let lines: Vec<&str> = full_str.split('\n').collect();
+            let lines = if lines.last() == Some(&"") {
+                &lines[..lines.len() - 1]
+            } else {
+                &lines[..]
+            };
+
+            let start_idx = (line_off.saturating_sub(1)) as usize;
+            let page: Vec<&str> = lines.iter()
+                .skip(start_idx)
+                .take(limit as usize)
+                .copied()
+                .collect();
+
+            // Compute byte range for the selected lines
+            let start_byte: u64 = if start_idx < lines.len() {
+                lines[..start_idx].iter().map(|l| l.len() as u64 + 1).sum()
+            } else {
+                total_bytes
+            };
+            let page_bytes: u64 = page.iter().map(|l| l.len() as u64 + 1).sum();
+
+            let data = page.join("\n");
+            let start_line = if page.is_empty() { 0 } else { line_off };
+            let end_line = if page.is_empty() {
+                0
+            } else {
+                start_line + page.len() as u64 - 1
+            };
+
+            Ok(ConsoleOutputPage {
+                data,
+                start_line,
+                end_line,
+                next_line_offset: if end_line > 0 { end_line + 1 } else { 1 },
+                total_lines,
+                start_byte,
+                end_byte: start_byte + page_bytes,
+                next_byte_offset: start_byte + page_bytes,
+                total_bytes,
+                has_more: (start_idx + page.len()) < lines.len(),
+            })
+        }
+    }
+}
+
+/// Execution info returned to callers.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecutionInfo {
+    pub id: ExecutionId,
+    pub status: String,
+    pub result: Option<String>,
+    pub heap: Option<String>,
+    pub error: Option<String>,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+}

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -677,7 +677,10 @@ pub fn execute_stateless(
 
     let result = catch_unwind(AssertUnwindSafe(|| {
         let params = create_params_with_heap_limit(heap_memory_max_bytes);
-        let mut extensions = vec![console::create_extension()];
+        let mut extensions = Vec::new();
+        if console_tree.is_some() {
+            extensions.push(console::create_extension());
+        }
         if fetch_config.is_some() {
             extensions.push(fetch::create_extension());
         }
@@ -781,7 +784,10 @@ pub fn execute_stateful(
 
         let startup_snapshot = leaked_snapshot.as_ref().map(|(_, s)| *s);
 
-        let mut extensions = vec![console::create_extension()];
+        let mut extensions = Vec::new();
+        if console_tree.is_some() {
+            extensions.push(console::create_extension());
+        }
         if fetch_config.is_some() {
             extensions.push(fetch::create_extension());
         }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -66,7 +66,7 @@ struct Cli {
     max_concurrent_executions: usize,
 
     /// Path to the sled database for session logging (default: /tmp/mcp-v8-sessions)
-    #[arg(long, default_value = "/tmp/mcp-v8-sessions", conflicts_with = "stateless")]
+    #[arg(long, default_value = "/tmp/mcp-v8-sessions")]
     session_db_path: String,
 
     // ── Cluster options ────────────────────────────────────────────────

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -321,15 +321,12 @@ async fn main() -> Result<()> {
     };
 
     // ── Execution registry ──────────────────────────────────────────────
-    let exec_db_path = if cli.stateless {
-        // Use http_port to avoid sled lock contention when multiple
-        // stateless nodes run on the same machine (e.g. cluster mode).
-        match cli.http_port {
-            Some(port) => format!("/tmp/mcp-v8-executions-{}", port),
-            None => "/tmp/mcp-v8-executions".to_string(),
-        }
-    } else {
-        format!("{}/executions", cli.session_db_path)
+    // Use session_db_path for both stateless and stateful modes.
+    // For stateless with http_port, add port suffix to avoid sled lock
+    // contention when multiple nodes run on the same machine.
+    let exec_db_path = match cli.http_port {
+        Some(port) => format!("{}/executions-{}", cli.session_db_path, port),
+        None => format!("{}/executions", cli.session_db_path),
     };
     let engine = match ExecutionRegistry::new(&exec_db_path) {
         Ok(registry) => {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -322,7 +322,12 @@ async fn main() -> Result<()> {
 
     // ── Execution registry ──────────────────────────────────────────────
     let exec_db_path = if cli.stateless {
-        "/tmp/mcp-v8-executions".to_string()
+        // Use http_port to avoid sled lock contention when multiple
+        // stateless nodes run on the same machine (e.g. cluster mode).
+        match cli.http_port {
+            Some(port) => format!("/tmp/mcp-v8-executions-{}", port),
+            None => "/tmp/mcp-v8-executions".to_string(),
+        }
     } else {
         format!("{}/executions", cli.session_db_path)
     };

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -13,19 +13,56 @@ use crate::engine::heap_tags::HeapTagEntry;
 
 #[derive(Debug, Clone)]
 pub struct RunJsResponse {
-    pub output: String,
-    pub heap: Option<String>,
+    pub execution_id: String,
 }
 
 impl IntoContents for RunJsResponse {
     fn into_contents(self) -> Vec<Content> {
-        let value = match self.heap {
-            Some(h) => json!({ "output": self.output, "heap": h }),
-            None => json!({ "output": self.output }),
-        };
-        match Content::json(value) {
+        match Content::json(json!({ "execution_id": self.execution_id })) {
             Ok(content) => vec![content],
-            Err(e) => vec![Content::text(format!("Failed to convert run_js response to content: {}", e))],
+            Err(e) => vec![Content::text(format!("Failed to convert run_js response: {}", e))],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionStatusResponse {
+    pub value: serde_json::Value,
+}
+
+impl IntoContents for ExecutionStatusResponse {
+    fn into_contents(self) -> Vec<Content> {
+        match Content::json(self.value) {
+            Ok(content) => vec![content],
+            Err(e) => vec![Content::text(format!("Failed to convert execution status response: {}", e))],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConsoleOutputResponse {
+    pub value: serde_json::Value,
+}
+
+impl IntoContents for ConsoleOutputResponse {
+    fn into_contents(self) -> Vec<Content> {
+        match Content::json(self.value) {
+            Ok(content) => vec![content],
+            Err(e) => vec![Content::text(format!("Failed to convert console output response: {}", e))],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ListExecutionsResponse {
+    pub value: serde_json::Value,
+}
+
+impl IntoContents for ListExecutionsResponse {
+    fn into_contents(self) -> Vec<Content> {
+        match Content::json(self.value) {
+            Ok(content) => vec![content],
+            Err(e) => vec![Content::text(format!("Failed to convert list executions response: {}", e))],
         }
     }
 }
@@ -144,13 +181,99 @@ impl McpService {
         tags: Option<HashMap<String, String>>,
     ) -> RunJsResponse {
         match self.engine.run_js(code, heap, session, heap_memory_max_mb, execution_timeout_secs, tags).await {
-            Ok(result) => RunJsResponse {
-                output: result.output,
-                heap: result.heap,
-            },
+            Ok(execution_id) => RunJsResponse { execution_id },
             Err(e) => RunJsResponse {
-                output: format!("V8 error: {}", e),
-                heap: None,
+                execution_id: format!("error: {}", e),
+            },
+        }
+    }
+
+    #[tool(description = "Get the status and result of an execution. Returns execution_id, status (running/completed/failed/cancelled/timed_out), result (if completed), heap (if stateful), error (if failed), started_at, and completed_at.")]
+    pub async fn get_execution(
+        &self,
+        #[tool(param)] execution_id: String,
+    ) -> ExecutionStatusResponse {
+        match self.engine.get_execution(&execution_id) {
+            Ok(info) => ExecutionStatusResponse {
+                value: json!({
+                    "execution_id": info.id,
+                    "status": info.status,
+                    "result": info.result,
+                    "heap": info.heap,
+                    "error": info.error,
+                    "started_at": info.started_at,
+                    "completed_at": info.completed_at,
+                }),
+            },
+            Err(e) => ExecutionStatusResponse {
+                value: json!({ "error": e }),
+            },
+        }
+    }
+
+    #[tool(description = "Get paginated console output for an execution. Supports two modes: line-based (line_offset + line_limit) or byte-based (byte_offset + byte_limit). If byte_offset is provided, byte mode takes precedence. Response includes both line and byte coordinates for cross-referencing. Use next_line_offset or next_byte_offset from a previous response to resume reading.")]
+    pub async fn get_execution_output(
+        &self,
+        #[tool(param)] execution_id: String,
+        #[tool(param)]
+        #[serde(default)]
+        line_offset: Option<u64>,
+        #[tool(param)]
+        #[serde(default)]
+        line_limit: Option<u64>,
+        #[tool(param)]
+        #[serde(default)]
+        byte_offset: Option<u64>,
+        #[tool(param)]
+        #[serde(default)]
+        byte_limit: Option<u64>,
+    ) -> ConsoleOutputResponse {
+        let status = self.engine.get_execution(&execution_id)
+            .map(|info| info.status)
+            .unwrap_or_else(|_| "unknown".to_string());
+
+        match self.engine.get_execution_output(&execution_id, line_offset, line_limit, byte_offset, byte_limit) {
+            Ok(page) => ConsoleOutputResponse {
+                value: json!({
+                    "execution_id": execution_id,
+                    "data": page.data,
+                    "start_line": page.start_line,
+                    "end_line": page.end_line,
+                    "next_line_offset": page.next_line_offset,
+                    "total_lines": page.total_lines,
+                    "start_byte": page.start_byte,
+                    "end_byte": page.end_byte,
+                    "next_byte_offset": page.next_byte_offset,
+                    "total_bytes": page.total_bytes,
+                    "has_more": page.has_more,
+                    "status": status,
+                }),
+            },
+            Err(e) => ConsoleOutputResponse {
+                value: json!({ "error": e }),
+            },
+        }
+    }
+
+    #[tool(description = "Cancel a running execution. Terminates the V8 isolate.")]
+    pub async fn cancel_execution(
+        &self,
+        #[tool(param)] execution_id: String,
+    ) -> OkResponse {
+        match self.engine.cancel_execution(&execution_id) {
+            Ok(()) => OkResponse { ok: true, error: None },
+            Err(e) => OkResponse { ok: false, error: Some(e) },
+        }
+    }
+
+    #[tool(description = "List all executions with their status.")]
+    pub async fn list_executions(&self) -> ListExecutionsResponse {
+        match self.engine.list_executions() {
+            Ok(executions) => ListExecutionsResponse {
+                value: json!({ "executions": executions }),
+            },
+            Err(e) => ListExecutionsResponse {
+                value: json!({ "error": e }),
             },
         }
     }
@@ -277,9 +400,8 @@ impl ServerHandler for McpService {
 
 // ── StatelessMcpService ─────────────────────────────────────────────────
 //
-// Stateless mode: only exposes `run_js` with no heap/session parameters.
-// This prevents agents from attempting to use stateful features that
-// don't exist in this mode.
+// Stateless mode: exposes `run_js` plus execution query/cancel tools,
+// but no heap/session/tag parameters.
 
 #[derive(Clone)]
 pub struct StatelessMcpService {
@@ -306,13 +428,98 @@ impl StatelessMcpService {
         execution_timeout_secs: Option<u64>,
     ) -> RunJsResponse {
         match self.engine.run_js(code, None, None, heap_memory_max_mb, execution_timeout_secs, None).await {
-            Ok(result) => RunJsResponse {
-                output: result.output,
-                heap: None,
-            },
+            Ok(execution_id) => RunJsResponse { execution_id },
             Err(e) => RunJsResponse {
-                output: format!("V8 error: {}", e),
-                heap: None,
+                execution_id: format!("error: {}", e),
+            },
+        }
+    }
+
+    #[tool(description = "Get the status and result of an execution. Returns execution_id, status (running/completed/failed/cancelled/timed_out), result (if completed), error (if failed), started_at, and completed_at.")]
+    pub async fn get_execution(
+        &self,
+        #[tool(param)] execution_id: String,
+    ) -> ExecutionStatusResponse {
+        match self.engine.get_execution(&execution_id) {
+            Ok(info) => ExecutionStatusResponse {
+                value: json!({
+                    "execution_id": info.id,
+                    "status": info.status,
+                    "result": info.result,
+                    "error": info.error,
+                    "started_at": info.started_at,
+                    "completed_at": info.completed_at,
+                }),
+            },
+            Err(e) => ExecutionStatusResponse {
+                value: json!({ "error": e }),
+            },
+        }
+    }
+
+    #[tool(description = "Get paginated console output for an execution. Supports two modes: line-based (line_offset + line_limit) or byte-based (byte_offset + byte_limit). If byte_offset is provided, byte mode takes precedence. Response includes both line and byte coordinates for cross-referencing.")]
+    pub async fn get_execution_output(
+        &self,
+        #[tool(param)] execution_id: String,
+        #[tool(param)]
+        #[serde(default)]
+        line_offset: Option<u64>,
+        #[tool(param)]
+        #[serde(default)]
+        line_limit: Option<u64>,
+        #[tool(param)]
+        #[serde(default)]
+        byte_offset: Option<u64>,
+        #[tool(param)]
+        #[serde(default)]
+        byte_limit: Option<u64>,
+    ) -> ConsoleOutputResponse {
+        let status = self.engine.get_execution(&execution_id)
+            .map(|info| info.status)
+            .unwrap_or_else(|_| "unknown".to_string());
+
+        match self.engine.get_execution_output(&execution_id, line_offset, line_limit, byte_offset, byte_limit) {
+            Ok(page) => ConsoleOutputResponse {
+                value: json!({
+                    "execution_id": execution_id,
+                    "data": page.data,
+                    "start_line": page.start_line,
+                    "end_line": page.end_line,
+                    "next_line_offset": page.next_line_offset,
+                    "total_lines": page.total_lines,
+                    "start_byte": page.start_byte,
+                    "end_byte": page.end_byte,
+                    "next_byte_offset": page.next_byte_offset,
+                    "total_bytes": page.total_bytes,
+                    "has_more": page.has_more,
+                    "status": status,
+                }),
+            },
+            Err(e) => ConsoleOutputResponse {
+                value: json!({ "error": e }),
+            },
+        }
+    }
+
+    #[tool(description = "Cancel a running execution. Terminates the V8 isolate.")]
+    pub async fn cancel_execution(
+        &self,
+        #[tool(param)] execution_id: String,
+    ) -> OkResponse {
+        match self.engine.cancel_execution(&execution_id) {
+            Ok(()) => OkResponse { ok: true, error: None },
+            Err(e) => OkResponse { ok: false, error: Some(e) },
+        }
+    }
+
+    #[tool(description = "List all executions with their status.")]
+    pub async fn list_executions(&self) -> ListExecutionsResponse {
+        match self.engine.list_executions() {
+            Ok(executions) => ListExecutionsResponse {
+                value: json!({ "executions": executions }),
+            },
+            Err(e) => ListExecutionsResponse {
+                value: json!({ "error": e }),
             },
         }
     }

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -1,5 +1,7 @@
 run javascript or typescript code in v8
 
+Submits code for **async execution** — returns an execution ID immediately. V8 runs in the background. Use `get_execution` to poll status and result, `get_execution_output` to read console output, and `cancel_execution` to stop a running execution.
+
 TypeScript support is type removal only — types are stripped before execution, not checked. Invalid types will be silently removed, not reported as errors.
 
 params:
@@ -11,24 +13,28 @@ params:
 - tags (optional): a JSON object of key-value string pairs to associate with the resulting heap snapshot. Tags can be used to label, categorize, or annotate heaps for later retrieval. Use get_heap_tags, set_heap_tags, delete_heap_tags, and query_heaps_by_tags to manage tags independently.
 
 returns:
-- output: the output of the javascript code
-- heap: content hash of the new heap snapshot — pass this in the next call to resume the session
+- execution_id: UUID of the submitted execution. Use with get_execution, get_execution_output, and cancel_execution.
 
+## Workflow
 
+1. Call `run_js(code)` → get `execution_id`
+2. Call `get_execution(execution_id)` → check `status` (running/completed/failed/cancelled/timed_out)
+3. Call `get_execution_output(execution_id)` → read console output (paginated)
+4. When status is "completed", `get_execution` returns the `result` (final expression value) and `heap` (content hash)
 
-## Limitations
+## Console Output
 
-- **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
-- **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
-- **No `console.log` or standard output**: Output from `console.log` or similar functions will not appear. To return results, ensure the value you want is the last line of your code.
-- **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **No `npm install` or external packages**: You cannot install or import npm packages. Only standard JavaScript (ECMAScript) built-ins are available.
-- **No timers**: Functions like `setTimeout` and `setInterval` are not available.
-- **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
+`console.log`, `console.info`, `console.warn`, and `console.error` are fully supported. Output is streamed to persistent storage during execution and can be queried in real-time using `get_execution_output`.
 
+Console output supports two pagination modes:
+- **Line mode**: `line_offset` + `line_limit` — fetch N lines starting from line M
+- **Byte mode**: `byte_offset` + `byte_limit` — fetch N bytes starting from byte M
 
-The way the runtime works, is that there is no console.log. If you want the results of an execution, you must return it in the last line of code.
+Both modes return position info in both coordinate systems for cross-referencing. Use `next_line_offset` or `next_byte_offset` from a previous response to resume reading.
 
+## Return Values
+
+The final expression value (the last evaluated expression in your code) is available via `get_execution` once the execution completes. To return results, ensure the value you want is the last line of your code.
 
 eg:
 
@@ -37,13 +43,9 @@ const result = 1 + 1;
 result;
 ```
 
-would return:
+After execution completes, `get_execution` will return `result: "2"`.
 
-```
-2
-```
-
-you must also jsonify an object, and return it as a string to see its content.
+You must also jsonify an object, and return it as a string to see its content.
 
 eg:
 
@@ -55,111 +57,19 @@ const obj = {
 JSON.stringify(obj);
 ```
 
-would return:
+After execution completes, `get_execution` will return `result: '{"a":1,"b":2}'`.
 
-```
-{"a":1,"b":2}
-```
+async/await is supported. The runtime resolves top-level Promises automatically.
 
-async/await is supported. The runtime resolves top-level Promises automatically:
+## Limitations
 
-eg:
+- **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
+- **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
+- **No file system access**: The runtime does not provide access to the local file system or environment variables.
+- **No `npm install` or external packages**: You cannot install or import npm packages. Only standard JavaScript (ECMAScript) built-ins are available.
+- **No timers**: Functions like `setTimeout` and `setInterval` are not available.
+- **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
 
-```js
-async function fetchData() {
-  const resp = await fetch("https://api.example.com/data");
-  const data = await resp.json();
-  return JSON.stringify(data);
-}
-fetchData();
-```
+Each execution starts with a fresh V8 isolate — no state is carried between calls.
 
-would return the JSON response as a string.
-
-In stateful mode, each execution returns a SHA-256 content hash for the heap snapshot — pass it back as the `heap` parameter in the next call to resume from that state. Omit `heap` for a fresh session. In stateless mode, no heap is returned and each execution starts fresh.
-the source code of the runtime is this
-
-```rust
-/// Stateful V8 execution — runs V8 on the calling thread. Publishes an
-/// IsolateHandle for external cancellation (e.g. async timeout in `run_js`).
-/// Takes raw (already unwrapped) snapshot data. Returns (result, oom_flag).
-pub fn execute_stateful(
-    code: &str,
-    raw_snapshot: Option<Vec<u8>>,
-    heap_memory_max_bytes: usize,
-    isolate_handle: Arc<Mutex<Option<v8::IsolateHandle>>>,
-) -> (Result<(String, Vec<u8>, String), String>, bool) {
-    let oom_flag = Arc::new(AtomicBool::new(false));
-
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        let params = Some(create_params_with_heap_limit(heap_memory_max_bytes));
-
-        let mut snapshot_creator = match raw_snapshot {
-            Some(raw) if !raw.is_empty() => {
-                v8::Isolate::snapshot_creator_from_existing_snapshot(raw, None, params)
-            }
-            _ => {
-                v8::Isolate::snapshot_creator(None, params)
-            }
-        };
-
-        // Publish handle immediately so caller can terminate us.
-        *isolate_handle.lock().unwrap() = Some(snapshot_creator.thread_safe_handle());
-
-        let cb_data_ptr = install_heap_limit_callback(&mut snapshot_creator, oom_flag.clone());
-
-        let output_result;
-        {
-            let scope = &mut v8::HandleScope::new(&mut snapshot_creator);
-            let context = v8::Context::new(scope, Default::default());
-            let scope = &mut v8::ContextScope::new(scope, context);
-            output_result = match eval(scope, code) {
-                Ok(result) => {
-                    result
-                        .to_string(scope)
-                        .map(|s| s.to_rust_string_lossy(scope))
-                        .ok_or_else(|| "Failed to convert result to string".to_string())
-                }
-                Err(e) => Err(e),
-            };
-            scope.set_default_context(context);
-        }
-
-        // Clear handle before snapshot_creator is consumed.
-        *isolate_handle.lock().unwrap() = None;
-        unsafe { let _ = Box::from_raw(cb_data_ptr); }
-
-        let startup_data = snapshot_creator.create_blob(v8::FunctionCodeHandling::Clear)
-            .ok_or("Failed to create V8 snapshot blob".to_string())?;
-        let wrapped = wrap_snapshot(&startup_data);
-
-        output_result.map(|output| (output, wrapped.data, wrapped.content_hash))
-    }));
-
-    let oom = oom_flag.load(Ordering::SeqCst);
-    match result {
-        Ok(Ok(triple)) => (Ok(triple), oom),
-        Ok(Err(e)) => (Err(classify_termination_error(&oom_flag, false, e)), oom),
-        Err(_panic) => (Err(classify_termination_error(
-            &oom_flag, false, "V8 execution panicked unexpectedly".to_string(),
-        )), oom),
-    }
-}
-
-// Engine.run_js handles TypeScript stripping, timeout enforcement,
-// concurrency control, heap storage, and session logging:
-pub async fn run_js(
-    &self,
-    code: String,
-    heap: Option<String>,
-    session: Option<String>,
-    heap_memory_max_mb: Option<usize>,
-    execution_timeout_secs: Option<u64>,
-) -> Result<JsResult, String> {
-    // Strip TypeScript types before V8 execution (no-op for plain JS)
-    let code = strip_typescript_types(&code)?;
-    // ... acquires semaphore permit, loads snapshot from storage,
-    // runs execute_stateful on blocking thread with async timeout,
-    // saves resulting snapshot, logs to session if named ...
-}
-```
+In stateful mode, each execution returns a SHA-256 content hash for the heap snapshot — pass it back as the `heap` parameter in the next call to resume from that state. Omit `heap` for a fresh session.

--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -1,5 +1,7 @@
 run javascript or typescript code in v8
 
+Submits code for **async execution** — returns an execution ID immediately. V8 runs in the background. Use `get_execution` to poll status and result, `get_execution_output` to read console output, and `cancel_execution` to stop a running execution.
+
 TypeScript support is type removal only — types are stripped before execution, not checked. Invalid types will be silently removed, not reported as errors.
 
 params:
@@ -8,23 +10,28 @@ params:
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 
 returns:
-- output: the output of the javascript code
+- execution_id: UUID of the submitted execution. Use with get_execution, get_execution_output, and cancel_execution.
 
+## Workflow
 
+1. Call `run_js(code)` → get `execution_id`
+2. Call `get_execution(execution_id)` → check `status` (running/completed/failed/cancelled/timed_out)
+3. Call `get_execution_output(execution_id)` → read console output (paginated)
+4. When status is "completed", `get_execution` returns the `result` (final expression value)
 
-## Limitations
+## Console Output
 
-- **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
-- **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
-- **No `console.log` or standard output**: Output from `console.log` or similar functions will not appear. To return results, ensure the value you want is the last line of your code.
-- **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **No `npm install` or external packages**: You cannot install or import npm packages. Only standard JavaScript (ECMAScript) built-ins are available.
-- **No timers**: Functions like `setTimeout` and `setInterval` are not available.
-- **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
+`console.log`, `console.info`, `console.warn`, and `console.error` are fully supported. Output is streamed to persistent storage during execution and can be queried in real-time using `get_execution_output`.
 
+Console output supports two pagination modes:
+- **Line mode**: `line_offset` + `line_limit` — fetch N lines starting from line M
+- **Byte mode**: `byte_offset` + `byte_limit` — fetch N bytes starting from byte M
 
-The way the runtime works, is that there is no console.log. If you want the results of an execution, you must return it in the last line of code.
+Both modes return position info in both coordinate systems for cross-referencing. Use `next_line_offset` or `next_byte_offset` from a previous response to resume reading.
 
+## Return Values
+
+The final expression value (the last evaluated expression in your code) is available via `get_execution` once the execution completes. To return results, ensure the value you want is the last line of your code.
 
 eg:
 
@@ -33,13 +40,9 @@ const result = 1 + 1;
 result;
 ```
 
-would return:
+After execution completes, `get_execution` will return `result: "2"`.
 
-```
-2
-```
-
-you must also jsonify an object, and return it as a string to see its content.
+You must also jsonify an object, and return it as a string to see its content.
 
 eg:
 
@@ -51,26 +54,17 @@ const obj = {
 JSON.stringify(obj);
 ```
 
-would return:
+After execution completes, `get_execution` will return `result: '{"a":1,"b":2}'`.
 
-```
-{"a":1,"b":2}
-```
+async/await is supported. The runtime resolves top-level Promises automatically.
 
-async/await is supported. The runtime resolves top-level Promises automatically:
+## Limitations
 
-eg:
-
-```js
-async function fetchData() {
-  const resp = await fetch("https://api.example.com/data");
-  const data = await resp.json();
-  return JSON.stringify(data);
-}
-fetchData();
-```
-
-would return the JSON response as a string.
-
+- **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
+- **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
+- **No file system access**: The runtime does not provide access to the local file system or environment variables.
+- **No `npm install` or external packages**: You cannot install or import npm packages. Only standard JavaScript (ECMAScript) built-ins are available.
+- **No timers**: Functions like `setTimeout` and `setInterval` are not available.
+- **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
 
 Each execution starts with a fresh V8 isolate — no state is carried between calls.

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -61,3 +61,26 @@ pub fn extract_heap_hash(response: &serde_json::Value) -> Option<String> {
     let parsed: serde_json::Value = serde_json::from_str(text).ok()?;
     parsed["heap"].as_str().map(|s| s.to_string())
 }
+
+/// Extract the execution_id from a run_js response.
+/// The response format is: result.content[0].text = '{"execution_id":"<id>"}'
+pub fn extract_execution_id(response: &serde_json::Value) -> Option<String> {
+    let text = response["result"]["content"]
+        .as_array()?
+        .first()?
+        .get("text")?
+        .as_str()?;
+    let parsed: serde_json::Value = serde_json::from_str(text).ok()?;
+    parsed["execution_id"].as_str().map(|s| s.to_string())
+}
+
+/// Extract fields from a get_execution response.
+/// The response format is: result.content[0].text = '{"execution_id":"...","status":"...","result":"...","heap":"...",...}'
+pub fn extract_execution_info(response: &serde_json::Value) -> Option<serde_json::Value> {
+    let text = response["result"]["content"]
+        .as_array()?
+        .first()?
+        .get("text")?
+        .as_str()?;
+    serde_json::from_str(text).ok()
+}

--- a/server/tests/console_log_e2e.rs
+++ b/server/tests/console_log_e2e.rs
@@ -1,0 +1,459 @@
+/// End-to-end integration tests for the async execution model with console.log
+/// capture and streaming output via sled.
+///
+/// These tests start the actual server in stateless mode with an HTTP port,
+/// then exercise the REST API:
+///   POST /api/exec           → submit code, get execution_id
+///   GET  /api/executions/:id → poll status/result
+///   GET  /api/executions/:id/output → retrieve console output
+///   GET  /api/executions     → list executions
+///   POST /api/executions/:id/cancel → cancel a running execution
+
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::process::Stdio;
+use tokio::process::Command;
+use tokio::time::{sleep, timeout, Duration};
+
+mod common;
+
+// ── Server helper ────────────────────────────────────────────────────────
+
+struct HttpServer {
+    child: Option<tokio::process::Child>,
+    base_url: String,
+}
+
+impl HttpServer {
+    /// Start the server in stateless mode on a random port with the REST API.
+    async fn start() -> Result<Self, Box<dyn std::error::Error>> {
+        let port = find_available_port();
+
+        let child = Command::new(env!("CARGO_BIN_EXE_server"))
+            .args(&["--stateless", "--http-port", &port.to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        // Poll until the server is ready (up to 15s).
+        let client = Client::new();
+        let health_url = format!("{}/api/executions", base_url);
+        for _ in 0..150 {
+            if client
+                .get(&health_url)
+                .timeout(Duration::from_millis(100))
+                .send()
+                .await
+                .is_ok()
+            {
+                return Ok(HttpServer {
+                    child: Some(child),
+                    base_url,
+                });
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        Err("Server did not become ready within 15s".into())
+    }
+
+    async fn stop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            sleep(Duration::from_millis(500)).await;
+        }
+    }
+}
+
+impl Drop for HttpServer {
+    fn drop(&mut self) {
+        if let Some(child) = &mut self.child {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+fn find_available_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Submit code for execution and return the execution_id.
+async fn submit_code(client: &Client, base_url: &str, code: &str) -> String {
+    let resp = client
+        .post(format!("{}/api/exec", base_url))
+        .json(&json!({ "code": code }))
+        .send()
+        .await
+        .expect("POST /api/exec failed");
+    assert_eq!(resp.status(), 202, "Expected 202 Accepted");
+    let body: Value = resp.json().await.expect("Invalid JSON from /api/exec");
+    body["execution_id"]
+        .as_str()
+        .expect("Missing execution_id")
+        .to_string()
+}
+
+/// Poll until an execution reaches a terminal state (completed/failed/timed_out/cancelled).
+/// Returns the final JSON body from GET /api/executions/:id.
+async fn poll_until_done(client: &Client, base_url: &str, id: &str) -> Value {
+    let url = format!("{}/api/executions/{}", base_url, id);
+    for _ in 0..100 {
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .expect("GET execution failed");
+        let body: Value = resp.json().await.expect("Invalid JSON");
+        let status = body["status"].as_str().unwrap_or("");
+        if status != "running" {
+            return body;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    panic!("Execution {} did not finish within 5s", id);
+}
+
+/// Fetch console output for an execution (line-offset mode by default).
+async fn get_output(
+    client: &Client,
+    base_url: &str,
+    id: &str,
+    query: &str,
+) -> Value {
+    let url = format!("{}/api/executions/{}/output?{}", base_url, id, query);
+    let resp = client.get(&url).send().await.expect("GET output failed");
+    resp.json().await.expect("Invalid JSON from output endpoint")
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+/// Test that console.log output is captured and retrievable.
+#[tokio::test]
+async fn test_console_log_basic() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    let id = submit_code(
+        &client,
+        &server.base_url,
+        r#"console.log("hello world"); 42;"#,
+    )
+    .await;
+
+    let result = timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+    assert_eq!(result["status"], "completed", "Execution should complete");
+    assert_eq!(result["result"], "42", "Return value should be 42");
+
+    // Fetch console output
+    let output = get_output(&client, &server.base_url, &id, "").await;
+    let data = output["data"].as_str().expect("output.data should be a string");
+    assert!(
+        data.contains("hello world"),
+        "Console output should contain 'hello world', got: {}",
+        data
+    );
+    assert_eq!(output["total_lines"], 1, "Should have exactly 1 line of output");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test all console methods: log, info, warn, error, debug, trace.
+#[tokio::test]
+async fn test_console_methods() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    let code = r#"
+        console.log("LOG line");
+        console.info("INFO line");
+        console.warn("WARN line");
+        console.error("ERROR line");
+        console.debug("DEBUG line");
+        console.trace("TRACE line");
+        "done";
+    "#;
+
+    let id = submit_code(&client, &server.base_url, code).await;
+    let result = timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+    assert_eq!(result["status"], "completed");
+
+    let output = get_output(&client, &server.base_url, &id, "").await;
+    let data = output["data"].as_str().unwrap();
+
+    // console.log → plain text
+    assert!(data.contains("LOG line"), "Should contain LOG line");
+    // console.info → [INFO] prefix
+    assert!(data.contains("[INFO] INFO line"), "Should contain [INFO] prefix");
+    // console.warn → [WARN] prefix
+    assert!(data.contains("[WARN] WARN line"), "Should contain [WARN] prefix");
+    // console.error → [ERROR] prefix
+    assert!(data.contains("[ERROR] ERROR line"), "Should contain [ERROR] prefix");
+    // console.debug → plain text (same as log)
+    assert!(data.contains("DEBUG line"), "Should contain DEBUG line");
+    // console.trace → plain text (same as log)
+    assert!(data.contains("TRACE line"), "Should contain TRACE line");
+
+    assert_eq!(output["total_lines"], 6, "Should have 6 lines of output");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test console.log with multiple arguments and object formatting.
+#[tokio::test]
+async fn test_console_log_formatting() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    let code = r#"
+        console.log("hello", "world");
+        console.log("num:", 42);
+        console.log("obj:", {a: 1, b: 2});
+        console.log("arr:", [1, 2, 3]);
+        "ok";
+    "#;
+
+    let id = submit_code(&client, &server.base_url, code).await;
+    let result = timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+    assert_eq!(result["status"], "completed");
+
+    let output = get_output(&client, &server.base_url, &id, "").await;
+    let data = output["data"].as_str().unwrap();
+
+    assert!(data.contains("hello world"), "Multiple string args should be space-joined");
+    assert!(data.contains("num: 42"), "Number arg should be stringified");
+    assert!(data.contains(r#""a":1"#), "Object should be JSON-serialized");
+    assert!(data.contains("[1,2,3]"), "Array should be JSON-serialized");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test the async execution lifecycle: submit → running → completed.
+#[tokio::test]
+async fn test_execution_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    // Submit code — response should be 202 with an execution_id
+    let resp = client
+        .post(format!("{}/api/exec", server.base_url))
+        .json(&json!({ "code": "1 + 1" }))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 202);
+    let body: Value = resp.json().await?;
+    let id = body["execution_id"].as_str().expect("Should have execution_id");
+    assert!(!id.is_empty());
+
+    // Poll until done
+    let result = timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, id)).await?;
+    assert_eq!(result["status"], "completed");
+    assert_eq!(result["result"], "2");
+    assert!(result["started_at"].is_string());
+    assert!(result["completed_at"].is_string());
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test listing executions.
+#[tokio::test]
+async fn test_list_executions() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    // Submit two executions
+    let id1 = submit_code(&client, &server.base_url, "1").await;
+    let id2 = submit_code(&client, &server.base_url, "2").await;
+
+    // Wait for both to complete
+    timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id1)).await?;
+    timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id2)).await?;
+
+    // List executions
+    let resp = client
+        .get(format!("{}/api/executions", server.base_url))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await?;
+    let executions = body["executions"].as_array().expect("Should have executions array");
+    assert!(
+        executions.len() >= 2,
+        "Should list at least 2 executions, got {}",
+        executions.len()
+    );
+
+    // Both IDs should appear
+    let ids: Vec<&str> = executions
+        .iter()
+        .filter_map(|e| e["id"].as_str())
+        .collect();
+    assert!(ids.contains(&id1.as_str()), "Should contain first execution");
+    assert!(ids.contains(&id2.as_str()), "Should contain second execution");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test console output pagination (line-offset mode).
+#[tokio::test]
+async fn test_console_output_line_pagination() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    // Generate 10 lines of output
+    let code = r#"
+        for (let i = 1; i <= 10; i++) {
+            console.log("line " + i);
+        }
+        "done";
+    "#;
+
+    let id = submit_code(&client, &server.base_url, code).await;
+    timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+
+    // Fetch first 3 lines
+    let page1 = get_output(&client, &server.base_url, &id, "line_offset=1&line_limit=3").await;
+    assert_eq!(page1["total_lines"], 10, "Should have 10 total lines");
+    assert_eq!(page1["start_line"], 1);
+    assert_eq!(page1["end_line"], 3);
+    assert_eq!(page1["has_more"], true);
+    let data1 = page1["data"].as_str().unwrap();
+    assert!(data1.contains("line 1"), "First page should start with line 1");
+    assert!(data1.contains("line 3"), "First page should include line 3");
+    assert!(!data1.contains("line 4"), "First page should not include line 4");
+
+    // Fetch next page using next_line_offset
+    let next_offset = page1["next_line_offset"].as_u64().unwrap();
+    let page2 = get_output(
+        &client,
+        &server.base_url,
+        &id,
+        &format!("line_offset={}&line_limit=3", next_offset),
+    )
+    .await;
+    assert_eq!(page2["start_line"], 4);
+    let data2 = page2["data"].as_str().unwrap();
+    assert!(data2.contains("line 4"), "Second page should start with line 4");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test console output byte-offset pagination.
+#[tokio::test]
+async fn test_console_output_byte_pagination() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    let code = r#"
+        console.log("aaaa");
+        console.log("bbbb");
+        "ok";
+    "#;
+
+    let id = submit_code(&client, &server.base_url, code).await;
+    timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+
+    // Fetch all output first to know total bytes
+    let full = get_output(&client, &server.base_url, &id, "").await;
+    let total_bytes = full["total_bytes"].as_u64().unwrap();
+    assert!(total_bytes > 0, "Should have some bytes of output");
+
+    // Fetch first 5 bytes via byte-offset mode
+    let page = get_output(&client, &server.base_url, &id, "byte_offset=0&byte_limit=5").await;
+    assert_eq!(page["start_byte"], 0);
+    assert_eq!(page["end_byte"], 5);
+    let data = page["data"].as_str().unwrap();
+    assert_eq!(data.len(), 5, "Should return exactly 5 bytes");
+    assert_eq!(data, "aaaa\n", "First 5 bytes should be 'aaaa\\n'");
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test that a failed execution reports the error correctly.
+#[tokio::test]
+async fn test_execution_failure() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    let id = submit_code(
+        &client,
+        &server.base_url,
+        "throw new Error('boom');",
+    )
+    .await;
+
+    let result = timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+    assert_eq!(result["status"], "failed", "Should be marked as failed");
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("boom"),
+        "Error should mention 'boom', got: {}",
+        error
+    );
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test console output interleaved with computation and a return value.
+#[tokio::test]
+async fn test_console_log_with_return_value() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    let code = r#"
+        console.log("starting computation");
+        const result = Array.from({length: 5}, (_, i) => i + 1).reduce((a, b) => a + b, 0);
+        console.log("result is", result);
+        result;
+    "#;
+
+    let id = submit_code(&client, &server.base_url, code).await;
+    let result = timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+    assert_eq!(result["status"], "completed");
+    assert_eq!(result["result"], "15", "1+2+3+4+5 should equal 15");
+
+    let output = get_output(&client, &server.base_url, &id, "").await;
+    let data = output["data"].as_str().unwrap();
+    assert!(data.contains("starting computation"));
+    assert!(data.contains("result is 15"));
+    assert_eq!(output["total_lines"], 2);
+
+    server.stop().await;
+    Ok(())
+}
+
+/// Test that console output for an execution with no console calls returns empty data.
+#[tokio::test]
+async fn test_no_console_output() -> Result<(), Box<dyn std::error::Error>> {
+    let mut server = HttpServer::start().await?;
+    let client = Client::new();
+
+    let id = submit_code(&client, &server.base_url, "1 + 1").await;
+    let result = timeout(Duration::from_secs(10), poll_until_done(&client, &server.base_url, &id)).await?;
+    assert_eq!(result["status"], "completed");
+    assert_eq!(result["result"], "2");
+
+    let output = get_output(&client, &server.base_url, &id, "").await;
+    assert_eq!(output["total_bytes"], 0, "Should have no console output bytes");
+    assert_eq!(output["total_lines"], 0, "Should have no console output lines");
+
+    server.stop().await;
+    Ok(())
+}

--- a/server/tests/heap_limit.rs
+++ b/server/tests/heap_limit.rs
@@ -36,7 +36,7 @@ fn test_stateless_small_heap_limit_rejects_large_allocation() {
 
     // 5 MB heap limit — too small for a 2M-element string array
     let max_bytes = 5 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle(), &[], max_bytes, None);
+    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(
         result.is_err(),
@@ -50,7 +50,7 @@ fn test_stateless_default_limit_allows_small_code() {
     ensure_v8();
 
     let max_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(SMALL_JS, max_bytes, no_handle(), &[], max_bytes, None);
+    let (result, _oom) = server::engine::execute_stateless(SMALL_JS, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(
         result.is_ok(),
@@ -66,7 +66,7 @@ fn test_stateless_generous_limit_allows_large_allocation() {
 
     // 256 MB — should be plenty for 2M strings
     let max_bytes = 256 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle(), &[], max_bytes, None);
+    let (result, _oom) = server::engine::execute_stateless(MEMORY_HOG_JS, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(
         result.is_ok(),
@@ -82,7 +82,7 @@ fn test_stateful_small_heap_limit_rejects_large_allocation() {
 
     // 5 MB heap limit — too small for a 2M-element string array
     let max_bytes = 5 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle(), &[], max_bytes, None);
+    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(
         result.is_err(),
@@ -96,7 +96,7 @@ fn test_stateful_default_limit_allows_small_code() {
     ensure_v8();
 
     let max_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(SMALL_JS, None, max_bytes, no_handle(), &[], max_bytes, None);
+    let (result, _oom) = server::engine::execute_stateful(SMALL_JS, None, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(
         result.is_ok(),
@@ -114,7 +114,7 @@ fn test_stateful_generous_limit_allows_large_allocation() {
 
     // 256 MB — should be plenty for 2M strings
     let max_bytes = 256 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle(), &[], max_bytes, None);
+    let (result, _oom) = server::engine::execute_stateful(MEMORY_HOG_JS, None, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(
         result.is_ok(),
@@ -133,8 +133,8 @@ fn test_different_limits_produce_different_outcomes() {
     let small_limit = 5 * 1024 * 1024;
     let large_limit = 256 * 1024 * 1024;
 
-    let (small_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, small_limit, no_handle(), &[], small_limit, None);
-    let (large_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, large_limit, no_handle(), &[], large_limit, None);
+    let (small_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, small_limit, no_handle(), &[], small_limit, None, None);
+    let (large_result, _) = server::engine::execute_stateless(MEMORY_HOG_JS, large_limit, no_handle(), &[], large_limit, None, None);
 
     assert!(
         small_result.is_err(),
@@ -177,7 +177,7 @@ fn test_typed_array_oom_does_not_crash_stateless() {
 
     // 8 MB heap — typed array backing stores will exceed this quickly
     let heap_bytes = 8 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateless(TYPED_ARRAY_OOM_JS, heap_bytes, no_handle(), &[], heap_bytes, None);
+    let (result, _oom) = server::engine::execute_stateless(TYPED_ARRAY_OOM_JS, heap_bytes, no_handle(), &[], heap_bytes, None, None);
 
     // We don't care whether it's Ok (the JS catch fired) or Err (V8 killed it) —
     // the critical thing is that we *get here* instead of a process crash.
@@ -196,7 +196,7 @@ fn test_typed_array_oom_does_not_crash_stateful() {
     ensure_v8();
 
     let heap_bytes = 8 * 1024 * 1024;
-    let (result, _oom) = server::engine::execute_stateful(TYPED_ARRAY_OOM_JS, None, heap_bytes, no_handle(), &[], heap_bytes, None);
+    let (result, _oom) = server::engine::execute_stateful(TYPED_ARRAY_OOM_JS, None, heap_bytes, no_handle(), &[], heap_bytes, None, None);
 
     if let Err(ref e) = result {
         assert!(
@@ -236,7 +236,7 @@ fn extreme_oom_subprocess_worker() {
 
     match mode.as_str() {
         "stateless" => {
-            let (result, _) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None);
+            let (result, _) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None, None);
             // If we reach here (V8 didn't abort), exit cleanly.
             if result.is_err() {
                 std::process::exit(0);
@@ -244,7 +244,7 @@ fn extreme_oom_subprocess_worker() {
             std::process::exit(0);
         }
         "stateful" => {
-            let (result, _) = server::engine::execute_stateful(code, None, heap_bytes, no_handle(), &[], heap_bytes, None);
+            let (result, _) = server::engine::execute_stateful(code, None, heap_bytes, no_handle(), &[], heap_bytes, None, None);
             if result.is_err() {
                 std::process::exit(0);
             }
@@ -276,7 +276,7 @@ fn run_extreme_oom_subprocess(mode: &str) {
     // The parent process is still running — V8 global state is intact.
     // Verify by running a simple V8 execution.
     ensure_v8();
-    let (result, _) = server::engine::execute_stateless("1 + 1", 8 * 1024 * 1024, no_handle(), &[], 16 * 1024 * 1024, None);
+    let (result, _) = server::engine::execute_stateless("1 + 1", 8 * 1024 * 1024, no_handle(), &[], 16 * 1024 * 1024, None, None);
     assert!(
         result.is_ok(),
         "Parent process V8 should be unaffected after subprocess OOM, but got: {:?}",

--- a/server/tests/parameter_configs.rs
+++ b/server/tests/parameter_configs.rs
@@ -6,6 +6,7 @@
 
 use std::sync::{Arc, Mutex, Once};
 use server::engine::{Engine, initialize_v8};
+use server::engine::execution::ExecutionRegistry;
 
 static INIT: Once = Once::new();
 
@@ -19,6 +20,34 @@ fn no_handle() -> Arc<Mutex<Option<deno_core::v8::IsolateHandle>>> {
     Arc::new(Mutex::new(None))
 }
 
+fn rand_id() -> u64 {
+    use std::time::SystemTime;
+    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos() as u64
+}
+
+fn make_registry() -> Arc<ExecutionRegistry> {
+    let tmp = std::env::temp_dir().join(format!("mcp-param-test-{}-{}", std::process::id(), rand_id()));
+    Arc::new(ExecutionRegistry::new(tmp.to_str().unwrap()).expect("Failed to create test registry"))
+}
+
+/// Submit code and wait for the result (blocking poll).
+async fn run_and_wait(engine: &Engine, code: &str) -> Result<String, String> {
+    let exec_id = engine.run_js(code.to_string(), None, None, None, None, None).await?;
+    for _ in 0..600 {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        if let Ok(info) = engine.get_execution(&exec_id) {
+            match info.status.as_str() {
+                "completed" => return info.result.ok_or_else(|| "No result".to_string()),
+                "failed" => return Err(info.error.unwrap_or_else(|| "Unknown error".to_string())),
+                "timed_out" => return Err("Timed out".to_string()),
+                "cancelled" => return Err("Cancelled".to_string()),
+                _ => continue,
+            }
+        }
+    }
+    Err("Execution did not complete within timeout".to_string())
+}
+
 // ── Timeout tests (async, using Engine::run_js) ─────────────────────────
 
 /// An infinite loop with a short timeout should return a descriptive timeout error.
@@ -26,11 +55,9 @@ fn no_handle() -> Arc<Mutex<Option<deno_core::v8::IsolateHandle>>> {
 async fn test_timeout_produces_descriptive_error() {
     ensure_v8();
 
-    let engine = Engine::new_stateless(64 * 1024 * 1024, 2, 4);
-    let result = engine.run_js(
-        "while (true) {}".to_string(),
-        None, None, None, None, None,
-    ).await;
+    let engine = Engine::new_stateless(64 * 1024 * 1024, 2, 4)
+        .with_execution_registry(make_registry());
+    let result = run_and_wait(&engine, "while (true) {}").await;
 
     assert!(result.is_err(), "Infinite loop should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -48,11 +75,9 @@ async fn test_timeout_stateful_produces_descriptive_error() {
     let heap_storage = server::engine::heap_storage::AnyHeapStorage::File(
         server::engine::heap_storage::FileHeapStorage::new("/tmp/mcp-v8-test-timeout-stateful"),
     );
-    let engine = Engine::new_stateful(heap_storage, None, None, 64 * 1024 * 1024, 2, 4);
-    let result = engine.run_js(
-        "while (true) {}".to_string(),
-        None, None, None, None, None,
-    ).await;
+    let engine = Engine::new_stateful(heap_storage, None, None, 64 * 1024 * 1024, 2, 4)
+        .with_execution_registry(make_registry());
+    let result = run_and_wait(&engine, "while (true) {}").await;
 
     assert!(result.is_err(), "Infinite loop should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -78,7 +103,7 @@ fn test_oom_produces_descriptive_error_not_crash() {
     "#;
     let heap_bytes = 16 * 1024 * 1024; // 16MB
 
-    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None);
+    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None, None);
 
     assert!(result.is_err(), "Huge allocation with small heap should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -102,7 +127,7 @@ fn test_oom_stateful_produces_descriptive_error_not_crash() {
     "#;
     let heap_bytes = 16 * 1024 * 1024; // 16MB
 
-    let (result, _oom) = server::engine::execute_stateful(code, None, heap_bytes, no_handle(), &[], heap_bytes, None);
+    let (result, _oom) = server::engine::execute_stateful(code, None, heap_bytes, no_handle(), &[], heap_bytes, None, None);
 
     assert!(result.is_err(), "Huge allocation with small heap should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -126,7 +151,7 @@ fn test_fast_computation_succeeds() {
     "#;
     let heap_bytes = 64 * 1024 * 1024;
 
-    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None);
+    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None, None);
 
     assert!(result.is_ok(), "Fast computation should succeed, got: {:?}", result);
     assert_eq!(result.unwrap(), "499999500000");
@@ -139,7 +164,7 @@ fn test_bare_call_default_params() {
 
     let heap_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
 
-    let (result, _oom) = server::engine::execute_stateless("1 + 1", heap_bytes, no_handle(), &[], heap_bytes, None);
+    let (result, _oom) = server::engine::execute_stateless("1 + 1", heap_bytes, no_handle(), &[], heap_bytes, None, None);
 
     assert!(result.is_ok(), "Simple expression should succeed, got: {:?}", result);
     assert_eq!(result.unwrap(), "2");

--- a/server/tests/rss_growth.rs
+++ b/server/tests/rss_growth.rs
@@ -80,7 +80,7 @@ fn test_rss_growth_stateless_no_wasm() {
         iterations,
         || {
             let handle = no_handle();
-            let _ = execute_stateless("1 + 1", heap_bytes, handle, &[], heap_bytes, None);
+            let _ = execute_stateless("1 + 1", heap_bytes, handle, &[], heap_bytes, None, None);
         },
     );
 
@@ -104,7 +104,7 @@ fn test_rss_growth_stateless_with_invalid_wasm() {
                 bytes: vec![0xde, 0xad, 0xbe, 0xef],
                 max_memory_bytes: None,
             }];
-            let _ = execute_stateless("1", heap_bytes, handle, &modules, heap_bytes, None);
+            let _ = execute_stateless("1", heap_bytes, handle, &modules, heap_bytes, None, None);
         },
     );
 
@@ -123,7 +123,7 @@ fn test_rss_growth_stateful_no_wasm() {
         iterations,
         || {
             let handle = no_handle();
-            let _ = execute_stateful("1 + 1", None, heap_bytes, handle, &[], heap_bytes, None);
+            let _ = execute_stateful("1 + 1", None, heap_bytes, handle, &[], heap_bytes, None, None);
         },
     );
 
@@ -142,7 +142,7 @@ fn test_rss_growth_stateless_syntax_error() {
         iterations,
         || {
             let handle = no_handle();
-            let _ = execute_stateless("= mon:= m {", heap_bytes, handle, &[], heap_bytes, None);
+            let _ = execute_stateless("= mon:= m {", heap_bytes, handle, &[], heap_bytes, None, None);
         },
     );
 


### PR DESCRIPTION
## Summary

This PR transforms the V8 execution model from synchronous request-response to asynchronous task-based execution with persistent console output streaming. The `run_js` endpoint now returns an execution ID immediately and runs V8 in a background task, allowing clients to poll status, retrieve console output in real-time, and cancel running executions.

## Key Changes

- **New Execution Registry** (`engine/execution.rs`): In-memory registry tracking all in-flight and completed executions with their status, result, and metadata. Uses `DashMap` for concurrent access and sled for persistent console output storage (one tree per execution).

- **Console Output Capture** (`engine/console.rs`): New Deno extension that intercepts `console.log`, `console.info`, `console.warn`, and `console.error` calls. Output is buffered in-memory and flushed to sled in fixed-size pages (4KB) for efficient WAL-style persistence.

- **Async Execution Model**: `run_js()` now spawns a background task via `tokio::spawn()` and returns an execution ID immediately (202 Accepted). The background task acquires semaphore permits, runs V8 on the blocking pool with timeout enforcement, and updates the registry on completion.

- **Execution Query APIs**: Three new methods added to `Engine`:
  - `get_execution(id)`: Returns status, result, heap, error, and timestamps
  - `get_execution_output(id, ...)`: Paginated console output with dual-mode pagination (line-based or byte-based offsets)
  - `cancel_execution(id)`: Terminates the V8 isolate via `IsolateHandle::terminate_execution()`
  - `list_executions()`: Lists all executions with summaries

- **MCP Service Updates**: Both `McpService` and `StatelessMcpService` now expose:
  - `run_js()`: Returns execution ID
  - `get_execution()`: Query execution status and result
  - `get_execution_output()`: Retrieve paginated console output
  - `cancel_execution()`: Cancel a running execution
  - `list_executions()`: List all executions

- **REST API Updates** (`api.rs`): New endpoints:
  - `POST /api/exec` → returns execution ID (202 Accepted)
  - `GET /api/executions` → list all executions
  - `GET /api/executions/{id}` → get execution status and result
  - `GET /api/executions/{id}/output` → get paginated console output
  - `POST /api/executions/{id}/cancel` → cancel execution

- **Console Output Pagination**: Supports two modes:
  - **Line mode**: `line_offset` + `line_limit` for fetching N lines starting from line M
  - **Byte mode**: `byte_offset` + `byte_limit` for fetching N bytes starting from byte M
  - Both modes return position info in both coordinate systems for cross-referencing

- **Snapshot Handling**: For stateful mode, snapshots are unwrapped before spawning the background task to avoid blocking the async runtime.

## Notable Implementation Details

- Console output is stored in sled with per-execution trees (`ex:{id}`) and reconstructed on-demand by iterating WAL pages
- Execution status transitions: Running → (Completed|Failed|TimedOut|Cancelled)
- Isolate handles are stored in the registry and cleared after execution completes to enable cancellation
- The execution registry is optional and must be configured via `Engine::with_execution_registry()`
- Both stateless and stateful modes support console output and execution tracking
- Documentation updated to reflect async workflow and console output availability

https://claude.ai/code/session_0171hFasNqeMvMYqNfCBznGM