### PR TITLE
Add Docker image for Open Policy Agent server

### DIFF
--- a/Dockerfile.opa
+++ b/Dockerfile.opa
@@ -1,0 +1,7 @@
+FROM alpine:3.19
+RUN wget -O /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static \
+    && chmod +x /usr/local/bin/opa
+COPY policies /policies
+EXPOSE 8181
+ENTRYPOINT ["/usr/local/bin/opa"]
+CMD ["run", "--server", "--addr", "0.0.0.0:8181", "/policies"]


### PR DESCRIPTION
## Summary
This PR adds a Dockerfile to containerize the Open Policy Agent (OPA) as a standalone policy server.

## Key Changes
- Created `Dockerfile.opa` that builds a lightweight Alpine Linux-based image
- Downloads the latest OPA binary for Linux x86_64 architecture
- Copies policy files from a local `policies` directory into the container
- Exposes port 8181 for OPA's HTTP API
- Configures OPA to run in server mode listening on all interfaces

## Implementation Details
- Uses Alpine 3.19 as the base image for minimal image size
- OPA binary is downloaded directly from the official GitHub releases
- The container is configured to serve policies from `/policies` directory
- Server listens on `0.0.0.0:8181` to accept connections from any network interface

https://claude.ai/code/session_01RqNpYughKX8fvDZuzT8QeU