### PR TITLE
Add ES module import support with npm:/jsr:/URL resolution

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -124,7 +124,7 @@ curl http://localhost:8080/mcp
 # Test the plain HTTP API directly
 curl -X POST http://localhost:8080/api/exec \
   -H "Content-Type: application/json" \
-  -d '{"code": "1 + 2"}'
+  -d '{"code": "console.log(1 + 2)"}'
 
 # Use MCP Inspector
 npx @modelcontextprotocol/inspector http://localhost:8080/mcp

--- a/README.md
+++ b/README.md
@@ -202,32 +202,14 @@ mcp-v8 --stateless --sse-port 8081
 **Example:**
 
 ```
-Call run_js with code: "console.log('hello'); 1 + 1;"
+Call run_js with code: "console.log('hello');"
   → { execution_id: "abc-123" }
 
 Call get_execution with execution_id: "abc-123"
-  → { status: "completed", result: "2" }
+  → { status: "completed" }
 
 Call get_execution_output with execution_id: "abc-123"
   → { data: "hello\n", total_lines: 1 }
-```
-
-### Return Values
-
-The **last expression** in your code is the return value, available via `get_execution` once the execution completes:
-
-```javascript
-const result = 1 + 1;
-result;
-// → result: "2"
-```
-
-Objects must be serialized to see their contents:
-
-```javascript
-const obj = { a: 1, b: 2 };
-JSON.stringify(obj);
-// → result: '{"a":1,"b":2}'
 ```
 
 ### Console Output
@@ -375,7 +357,7 @@ claude mcp add mcp-v8 -- mcp-v8 --stateless
 claude mcp add mcp-v8 -t sse https://mcp-js-production.up.railway.app/sse
 ```
 
-Then test by running `claude` and asking: "Run this JavaScript: `[1,2,3].map(x => x * 2)`"
+Then test by running `claude` and asking: "Run this JavaScript: `console.log([1,2,3].map(x => x * 2))`"
 
 ### Cursor
 
@@ -419,11 +401,12 @@ You can also use the hosted version on Railway without installing anything local
 
 ## Example Usage
 
-Ask Claude or Cursor: "Run this JavaScript: `1 + 2`"
+Ask Claude or Cursor: "Run this JavaScript: `console.log(1 + 2)`"
 
 The agent will:
-1. Call `run_js` with `code: "1 + 2"` → receives `execution_id`
-2. Call `get_execution` with the `execution_id` → receives `{ status: "completed", result: "3" }`
+1. Call `run_js` with `code: "console.log(1 + 2)"` → receives `execution_id`
+2. Call `get_execution` with the `execution_id` → receives `{ status: "completed" }`
+3. Call `get_execution_output` with the `execution_id` → receives `{ data: "3\n", total_lines: 1 }`
 
 In stateful mode, `get_execution` also returns a `heap` content hash — pass it back in the next `run_js` call to resume from that state.
 
@@ -711,7 +694,7 @@ You can configure heap storage using the following command line arguments:
 
 While `mcp-v8` provides a powerful and persistent JavaScript execution environment, there are limitations to its runtime.
 
-- **Async execution model**: `run_js` returns immediately with an execution ID. Use `get_execution` to poll for the result and `get_execution_output` to read console output. Each execution runs in a fresh V8 isolate — no state is shared between calls (unless using stateful mode with heap snapshots).
+- **Async execution model**: `run_js` returns immediately with an execution ID. Use `get_execution` to poll for completion and `get_execution_output` to read console output. Each execution runs in a fresh V8 isolate — no state is shared between calls (unless using stateful mode with heap snapshots).
 - **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
 - **`console.log` supported**: `console.log`, `console.info`, `console.warn`, and `console.error` are captured and available via `get_execution_output` with paginated access.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available following the web standard Fetch API. Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access. See [OPA-Gated Fetch](#opa-gated-fetch) for details.

--- a/README.md
+++ b/README.md
@@ -748,17 +748,10 @@ You can configure heap storage using the following command line arguments:
 
 ## Limitations
 
-While `mcp-v8` provides a powerful and persistent JavaScript execution environment, there are limitations to its runtime.
-
-- **Async execution model**: `run_js` returns immediately with an execution ID. Use `get_execution` to poll for completion and `get_execution_output` to read console output. Each execution runs in a fresh V8 isolate — no state is shared between calls (unless using stateful mode with heap snapshots).
-- **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
-- **`console.log` supported**: `console.log`, `console.info`, `console.warn`, and `console.error` are captured and available via `get_execution_output` with paginated access.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available following the web standard Fetch API. Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access. See [OPA-Gated Fetch](#opa-gated-fetch) for details.
 - **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **ES module imports**: You can import npm packages, JSR packages, and URL modules using Deno-style import syntax. Packages are fetched from [esm.sh](https://esm.sh) at runtime — no `npm install` needed. See [Importing Packages](#importing-packages) for details and examples.
 - **No timers**: Functions like `setTimeout` and `setInterval` are not available.
 - **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
-- **WebAssembly**: Both synchronous (`WebAssembly.Module`, `WebAssembly.Instance`, `WebAssembly.validate`) and async (`WebAssembly.compile`, `WebAssembly.instantiate`) APIs are supported.
 - **TypeScript: type removal only**: TypeScript type annotations are stripped before execution. No type checking is performed — invalid types are silently removed, not reported as errors.
 
 ---

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Rust-based Model Context Protocol (MCP) server that exposes a V8 JavaScript ru
 - **V8 JavaScript Execution**: Run arbitrary JavaScript code in a secure, isolated V8 engine.
 - **TypeScript Support**: Run TypeScript code directly — types are stripped before execution using [SWC](https://swc.rs/). This is type removal only, not type checking.
 - **WebAssembly Support**: Compile and run WASM modules using the standard `WebAssembly` JavaScript API (`WebAssembly.Module`, `WebAssembly.Instance`, `WebAssembly.validate`).
+- **ES Module Imports**: Import npm packages, JSR packages, and URL modules using Deno-style `import` syntax. Packages are fetched from [esm.sh](https://esm.sh) at runtime — no `npm install` needed. (e.g., `import { camelCase } from "npm:lodash-es@4.17.21"`)
 - **Content-Addressed Heap Snapshots**: Persist and restore V8 heap state between runs using content-addressed storage, supporting both S3 and local file storage.
 - **Stateless Mode**: Optional mode for fresh executions without heap persistence, ideal for serverless environments.
 - **MCP Protocol**: Implements the Model Context Protocol for seamless tool integration with Claude, Cursor, and other MCP clients.
@@ -410,6 +411,61 @@ The agent will:
 
 In stateful mode, `get_execution` also returns a `heap` content hash — pass it back in the next `run_js` call to resume from that state.
 
+### Importing Packages
+
+You can import npm packages, JSR packages, and URL modules directly in your JavaScript code using ES module `import` syntax. Packages are fetched from [esm.sh](https://esm.sh) at runtime — no `npm install` or pre-installation step is needed.
+
+#### npm Packages
+
+Use the `npm:` prefix followed by the package name and version:
+
+```javascript
+import { camelCase } from "npm:lodash-es@4.17.21";
+camelCase("hello world"); // → "helloWorld"
+```
+
+```javascript
+import dayjs from "npm:dayjs@1.11.13";
+dayjs("2025-01-15").format("MMMM D, YYYY"); // → "January 15, 2025"
+```
+
+#### JSR Packages
+
+Use the `jsr:` prefix for packages from the [JSR registry](https://jsr.io):
+
+```javascript
+import { camelCase } from "jsr:@luca/cases@1.0.0";
+camelCase("hello world"); // → "helloWorld"
+```
+
+#### URL Imports
+
+Import directly from any URL that serves ES modules:
+
+```javascript
+import { pascalCase } from "https://deno.land/x/case/mod.ts";
+pascalCase("hello world"); // → "HelloWorld"
+```
+
+#### How It Works
+
+- **`npm:` specifiers** are rewritten to `https://esm.sh/<package>` URLs
+- **`jsr:` specifiers** are rewritten to `https://esm.sh/jsr/<package>` URLs
+- **`https://` and `http://` URLs** are fetched directly
+- **Relative imports** (e.g., `./utils.js`) resolve against the parent module's URL
+- **TypeScript modules** (`.ts`, `.tsx`) fetched from URLs are automatically type-stripped before execution
+
+#### Tips
+
+- **Always pin versions** (e.g., `npm:lodash-es@4.17.21`) for reproducible results
+- Only packages that ship as **ES modules** are supported — CommonJS-only packages won't work directly, but esm.sh converts many of them automatically
+- Imports are **fetched over the network** at runtime, so the first execution may be slower while modules are downloaded
+- Top-level `await` is supported, so you can use `import()` dynamically as well:
+  ```javascript
+  const { default: _ } = await import("npm:lodash-es@4.17.21");
+  _.chunk([1, 2, 3, 4, 5], 2); // → [[1, 2], [3, 4], [5]]
+  ```
+
 ### WebAssembly
 
 You can compile and run WebAssembly modules using the standard `WebAssembly` JavaScript API:
@@ -699,7 +755,7 @@ While `mcp-v8` provides a powerful and persistent JavaScript execution environme
 - **`console.log` supported**: `console.log`, `console.info`, `console.warn`, and `console.error` are captured and available via `get_execution_output` with paginated access.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available following the web standard Fetch API. Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access. See [OPA-Gated Fetch](#opa-gated-fetch) for details.
 - **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **No `npm install` or external packages**: You cannot install or import npm packages. Only standard JavaScript (ECMAScript) built-ins are available.
+- **ES module imports**: You can import npm packages, JSR packages, and URL modules using Deno-style import syntax. Packages are fetched from [esm.sh](https://esm.sh) at runtime — no `npm install` needed. See [Importing Packages](#importing-packages) for details and examples.
 - **No timers**: Functions like `setTimeout` and `setInterval` are not available.
 - **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
 - **WebAssembly**: Both synchronous (`WebAssembly.Module`, `WebAssembly.Instance`, `WebAssembly.validate`) and async (`WebAssembly.compile`, `WebAssembly.instantiate`) APIs are supported.

--- a/server/src/engine/module_loader.rs
+++ b/server/src/engine/module_loader.rs
@@ -1,0 +1,145 @@
+use deno_core::ModuleLoadOptions;
+use deno_core::ModuleLoadReferrer;
+use deno_core::ModuleLoadResponse;
+use deno_core::ModuleLoader;
+use deno_core::ModuleSource;
+use deno_core::ModuleSourceCode;
+use deno_core::ModuleSpecifier;
+use deno_core::ModuleType;
+use deno_core::ResolutionKind;
+use deno_core::resolve_import;
+use deno_core::FastString;
+use deno_error::JsErrorBox;
+use futures::FutureExt;
+
+/// Module loader that resolves `npm:`, `jsr:`, and URL imports by fetching
+/// them from the network. NPM and JSR specifiers are rewritten to esm.sh
+/// URLs so that packages are served as standard ES modules.
+pub struct NetworkModuleLoader {
+    client: reqwest::Client,
+}
+
+impl NetworkModuleLoader {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl ModuleLoader for NetworkModuleLoader {
+    fn resolve(
+        &self,
+        specifier: &str,
+        referrer: &str,
+        _kind: ResolutionKind,
+    ) -> Result<ModuleSpecifier, JsErrorBox> {
+        // npm:cowsay@1.6.0 → https://esm.sh/cowsay@1.6.0
+        if let Some(rest) = specifier.strip_prefix("npm:") {
+            let url = format!("https://esm.sh/{}", rest);
+            return ModuleSpecifier::parse(&url)
+                .map_err(|e| JsErrorBox::generic(format!("Bad npm specifier '{}': {}", specifier, e)));
+        }
+
+        // jsr:@luca/cases@1.0.0 → https://esm.sh/jsr/@luca/cases@1.0.0
+        if let Some(rest) = specifier.strip_prefix("jsr:") {
+            let url = format!("https://esm.sh/jsr/{}", rest);
+            return ModuleSpecifier::parse(&url)
+                .map_err(|e| JsErrorBox::generic(format!("Bad jsr specifier '{}': {}", specifier, e)));
+        }
+
+        // Absolute URLs pass through directly.
+        if specifier.starts_with("https://") || specifier.starts_with("http://") {
+            return ModuleSpecifier::parse(specifier)
+                .map_err(|e| JsErrorBox::generic(format!("Bad URL '{}': {}", specifier, e)));
+        }
+
+        // Relative specifiers (./foo, ../bar) resolve against the referrer.
+        resolve_import(specifier, referrer).map_err(JsErrorBox::from_err)
+    }
+
+    fn load(
+        &self,
+        module_specifier: &ModuleSpecifier,
+        _maybe_referrer: Option<&ModuleLoadReferrer>,
+        _options: ModuleLoadOptions,
+    ) -> ModuleLoadResponse {
+        let scheme = module_specifier.scheme();
+        if scheme != "https" && scheme != "http" {
+            return ModuleLoadResponse::Sync(Err(JsErrorBox::generic(
+                format!(
+                    "Cannot load module '{}': only https/http modules are supported",
+                    module_specifier
+                ),
+            )));
+        }
+
+        let client = self.client.clone();
+        let specifier = module_specifier.clone();
+        let fut = async move {
+            let resp = client
+                .get(specifier.as_str())
+                .send()
+                .await
+                .map_err(|e| {
+                    JsErrorBox::generic(format!(
+                        "Failed to fetch module '{}': {}",
+                        specifier, e
+                    ))
+                })?;
+
+            if !resp.status().is_success() {
+                return Err(JsErrorBox::generic(format!(
+                    "Failed to fetch module '{}': HTTP {}",
+                    specifier,
+                    resp.status()
+                )));
+            }
+
+            let final_url = resp.url().clone();
+            let text = resp.text().await.map_err(|e| {
+                JsErrorBox::generic(format!(
+                    "Failed to read module '{}': {}",
+                    specifier, e
+                ))
+            })?;
+
+            // Strip TypeScript types for .ts/.tsx URLs.
+            let url_path = final_url.path();
+            let code = if url_path.ends_with(".ts") || url_path.ends_with(".tsx") {
+                crate::engine::strip_typescript_types(&text).map_err(|e| {
+                    JsErrorBox::generic(format!(
+                        "Failed to transpile '{}': {}",
+                        specifier, e
+                    ))
+                })?
+            } else {
+                text
+            };
+
+            // If the server redirected (e.g. esm.sh version resolution), record
+            // the final URL so that relative imports within the module resolve
+            // against the correct base.
+            let source = if final_url.as_str() != specifier.as_str() {
+                ModuleSource::new_with_redirect(
+                    ModuleType::JavaScript,
+                    ModuleSourceCode::String(FastString::from(code)),
+                    &specifier,
+                    &final_url,
+                    None,
+                )
+            } else {
+                ModuleSource::new(
+                    ModuleType::JavaScript,
+                    ModuleSourceCode::String(FastString::from(code)),
+                    &specifier,
+                    None,
+                )
+            };
+
+            Ok(source)
+        };
+
+        ModuleLoadResponse::Async(fut.boxed_local())
+    }
+}

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -73,13 +73,8 @@ Always pin versions for reproducible results. Dynamic `import()` is also support
 
 ## Limitations
 
-- **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
 - **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **ES module imports**: You can import npm packages, JSR packages, and URL modules using Deno-style import syntax. Packages are fetched from esm.sh at runtime. Examples:
-  - `import { camelCase } from "npm:lodash-es@4.17.21";`
-  - `import { camelCase } from "jsr:@luca/cases@1.0.0";`
-  - `import { pascalCase } from "https://deno.land/x/case/mod.ts";`
 - **No timers**: Functions like `setTimeout` and `setInterval` are not available.
 - **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
 

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -66,7 +66,10 @@ async/await is supported. The runtime resolves top-level Promises automatically.
 - **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
 - **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **No `npm install` or external packages**: You cannot install or import npm packages. Only standard JavaScript (ECMAScript) built-ins are available.
+- **ES module imports**: You can import npm packages, JSR packages, and URL modules using Deno-style import syntax. Packages are fetched from esm.sh at runtime. Examples:
+  - `import { camelCase } from "npm:lodash-es@4.17.21";`
+  - `import { camelCase } from "jsr:@luca/cases@1.0.0";`
+  - `import { pascalCase } from "https://deno.land/x/case/mod.ts";`
 - **No timers**: Functions like `setTimeout` and `setInterval` are not available.
 - **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
 

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -61,6 +61,16 @@ After execution completes, `get_execution` will return `result: '{"a":1,"b":2}'`
 
 async/await is supported. The runtime resolves top-level Promises automatically.
 
+## Importing Packages
+
+You can import npm packages, JSR packages, and URL modules using ES module `import` syntax. Packages are fetched from esm.sh at runtime — no installation needed.
+
+- **npm**: `import { camelCase } from "npm:lodash-es@4.17.21";`
+- **jsr**: `import { camelCase } from "jsr:@luca/cases@1.0.0";`
+- **URL**: `import { pascalCase } from "https://deno.land/x/case/mod.ts";`
+
+Always pin versions for reproducible results. Dynamic `import()` is also supported with top-level `await`.
+
 ## Limitations
 
 - **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.

--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -70,13 +70,8 @@ Always pin versions for reproducible results. Dynamic `import()` is also support
 
 ## Limitations
 
-- **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
 - **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **ES module imports**: You can import npm packages, JSR packages, and URL modules using Deno-style import syntax. Packages are fetched from esm.sh at runtime. Examples:
-  - `import { camelCase } from "npm:lodash-es@4.17.21";`
-  - `import { camelCase } from "jsr:@luca/cases@1.0.0";`
-  - `import { pascalCase } from "https://deno.land/x/case/mod.ts";`
 - **No timers**: Functions like `setTimeout` and `setInterval` are not available.
 - **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
 

--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -63,7 +63,10 @@ async/await is supported. The runtime resolves top-level Promises automatically.
 - **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available. `fetch()` follows the web standard Fetch API — it returns a Promise that resolves to a Response object. Use `await` to get the response: `const resp = await fetch(url)`. The response object has `.ok`, `.status`, `.statusText`, `.url`, `.headers.get(name)`, `.text()`, and `.json()` methods (`.text()` and `.json()` also return Promises). Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access.
 - **No file system access**: The runtime does not provide access to the local file system or environment variables.
-- **No `npm install` or external packages**: You cannot install or import npm packages. Only standard JavaScript (ECMAScript) built-ins are available.
+- **ES module imports**: You can import npm packages, JSR packages, and URL modules using Deno-style import syntax. Packages are fetched from esm.sh at runtime. Examples:
+  - `import { camelCase } from "npm:lodash-es@4.17.21";`
+  - `import { camelCase } from "jsr:@luca/cases@1.0.0";`
+  - `import { pascalCase } from "https://deno.land/x/case/mod.ts";`
 - **No timers**: Functions like `setTimeout` and `setInterval` are not available.
 - **No DOM or browser APIs**: This is not a browser environment; there is no access to `window`, `document`, or other browser-specific objects.
 

--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -58,6 +58,16 @@ After execution completes, `get_execution` will return `result: '{"a":1,"b":2}'`
 
 async/await is supported. The runtime resolves top-level Promises automatically.
 
+## Importing Packages
+
+You can import npm packages, JSR packages, and URL modules using ES module `import` syntax. Packages are fetched from esm.sh at runtime — no installation needed.
+
+- **npm**: `import { camelCase } from "npm:lodash-es@4.17.21";`
+- **jsr**: `import { camelCase } from "jsr:@luca/cases@1.0.0";`
+- **URL**: `import { pascalCase } from "https://deno.land/x/case/mod.ts";`
+
+Always pin versions for reproducible results. Dynamic `import()` is also supported with top-level `await`.
+
 ## Limitations
 
 - **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.

--- a/server/tests/module_imports.rs
+++ b/server/tests/module_imports.rs
@@ -1,0 +1,416 @@
+/// Tests for ES module import support — verifies that `npm:`, `jsr:`, and
+/// URL imports are resolved via the network module loader and executed.
+///
+/// Network-dependent tests are marked `#[ignore]` because they require
+/// unrestricted HTTP access to esm.sh. Run them with:
+///   cargo test --test module_imports -- --ignored
+
+use std::sync::{Arc, Once};
+use server::engine::{initialize_v8, has_module_syntax, prepare_module_result, Engine};
+use server::engine::execution::ExecutionRegistry;
+
+// ── has_module_syntax unit tests ────────────────────────────────────────
+
+#[test]
+fn test_detect_import_declaration() {
+    assert!(has_module_syntax(r#"import { foo } from "bar";"#));
+    assert!(has_module_syntax(r#"import foo from "bar";"#));
+    assert!(has_module_syntax(r#"import "side-effect";"#));
+    assert!(has_module_syntax(r#"import{foo}from"bar";"#));
+}
+
+#[test]
+fn test_detect_export_declaration() {
+    assert!(has_module_syntax("export const foo = 1;"));
+    assert!(has_module_syntax("export default function() {}"));
+    assert!(has_module_syntax(r#"export { foo } from "bar";"#));
+    assert!(has_module_syntax(r#"export* from "bar";"#));
+}
+
+#[test]
+fn test_no_module_syntax_in_plain_js() {
+    assert!(!has_module_syntax("const x = 1 + 2;"));
+    assert!(!has_module_syntax("function foo() { return 42; }"));
+    assert!(!has_module_syntax(r#"const s = "import is a keyword";"#));
+}
+
+#[test]
+fn test_dynamic_import_not_detected() {
+    // dynamic import() is an expression, not a declaration
+    assert!(!has_module_syntax(r#"import("./foo.js");"#));
+    assert!(!has_module_syntax(r#"const m = import("./foo.js");"#));
+}
+
+#[test]
+fn test_npm_specifier_detected() {
+    assert!(has_module_syntax(
+        r#"import { camelCase } from "npm:lodash-es@4.17.21";"#
+    ));
+}
+
+#[test]
+fn test_jsr_specifier_detected() {
+    assert!(has_module_syntax(
+        r#"import { camelCase } from "jsr:@luca/cases@1.0.0";"#
+    ));
+}
+
+// ── prepare_module_result unit tests ────────────────────────────────────
+
+#[test]
+fn test_prepare_wraps_last_expression() {
+    let code = "import { foo } from \"bar\";\nconst x = foo();\nx;";
+    let result = prepare_module_result(code);
+    assert!(
+        result.contains("globalThis.__result__"),
+        "Should wrap last expression: {}",
+        result
+    );
+    assert!(
+        result.contains("globalThis.__result__ = (x)"),
+        "Should capture expression 'x': {}",
+        result
+    );
+}
+
+#[test]
+fn test_prepare_does_not_wrap_declaration() {
+    let code = "import { foo } from \"bar\";\nconst x = foo();";
+    let result = prepare_module_result(code);
+    assert!(
+        !result.contains("globalThis.__result__"),
+        "Should not wrap const declaration: {}",
+        result
+    );
+}
+
+#[test]
+fn test_prepare_does_not_wrap_import() {
+    let code = r#"import { foo } from "bar";"#;
+    let result = prepare_module_result(code);
+    assert!(
+        !result.contains("globalThis.__result__"),
+        "Should not wrap import: {}",
+        result
+    );
+}
+
+#[test]
+fn test_prepare_strips_trailing_semicolon() {
+    let code = "import { x } from \"m\";\nx + 1;";
+    let result = prepare_module_result(code);
+    assert!(
+        result.contains("globalThis.__result__ = (x + 1)"),
+        "Should strip semicolon: {}",
+        result
+    );
+}
+
+// ── Module specifier resolution unit tests ──────────────────────────────
+
+#[test]
+fn test_npm_specifier_resolves() {
+    use deno_core::ResolutionKind;
+    use server::engine::module_loader::NetworkModuleLoader;
+    use deno_core::ModuleLoader;
+
+    let loader = NetworkModuleLoader::new();
+    let result = loader.resolve(
+        "npm:cowsay@1.6.0",
+        "file:///main.js",
+        ResolutionKind::Import,
+    );
+    assert!(result.is_ok(), "npm specifier should resolve: {:?}", result);
+    assert_eq!(result.unwrap().as_str(), "https://esm.sh/cowsay@1.6.0");
+}
+
+#[test]
+fn test_jsr_specifier_resolves() {
+    use deno_core::ResolutionKind;
+    use server::engine::module_loader::NetworkModuleLoader;
+    use deno_core::ModuleLoader;
+
+    let loader = NetworkModuleLoader::new();
+    let result = loader.resolve(
+        "jsr:@luca/cases@1.0.0",
+        "file:///main.js",
+        ResolutionKind::Import,
+    );
+    assert!(result.is_ok(), "jsr specifier should resolve: {:?}", result);
+    assert_eq!(
+        result.unwrap().as_str(),
+        "https://esm.sh/jsr/@luca/cases@1.0.0"
+    );
+}
+
+#[test]
+fn test_url_specifier_resolves() {
+    use deno_core::ResolutionKind;
+    use server::engine::module_loader::NetworkModuleLoader;
+    use deno_core::ModuleLoader;
+
+    let loader = NetworkModuleLoader::new();
+    let result = loader.resolve(
+        "https://deno.land/x/case/mod.ts",
+        "file:///main.js",
+        ResolutionKind::Import,
+    );
+    assert!(result.is_ok(), "URL specifier should resolve: {:?}", result);
+    assert_eq!(
+        result.unwrap().as_str(),
+        "https://deno.land/x/case/mod.ts"
+    );
+}
+
+#[test]
+fn test_relative_specifier_resolves() {
+    use deno_core::ResolutionKind;
+    use server::engine::module_loader::NetworkModuleLoader;
+    use deno_core::ModuleLoader;
+
+    let loader = NetworkModuleLoader::new();
+    let result = loader.resolve(
+        "./utils.js",
+        "https://esm.sh/cowsay@1.6.0/index.js",
+        ResolutionKind::Import,
+    );
+    assert!(
+        result.is_ok(),
+        "Relative specifier should resolve: {:?}",
+        result
+    );
+    assert_eq!(
+        result.unwrap().as_str(),
+        "https://esm.sh/cowsay@1.6.0/utils.js"
+    );
+}
+
+static INIT: Once = Once::new();
+
+fn ensure_v8() {
+    INIT.call_once(|| {
+        initialize_v8();
+    });
+}
+
+fn create_test_engine() -> Engine {
+    let tmp = std::env::temp_dir().join(format!(
+        "mcp-module-test-{}-{}",
+        std::process::id(),
+        rand_id()
+    ));
+    let registry =
+        ExecutionRegistry::new(tmp.to_str().unwrap()).expect("Failed to create test registry");
+    Engine::new_stateless(16 * 1024 * 1024, 60, 4)
+        .with_execution_registry(Arc::new(registry))
+}
+
+fn rand_id() -> u64 {
+    use std::time::SystemTime;
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
+async fn run_and_wait(engine: &Engine, code: &str) -> Result<String, String> {
+    let exec_id = engine
+        .run_js(code.to_string(), None, None, None, Some(60), None)
+        .await?;
+    for _ in 0..1200 {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        if let Ok(info) = engine.get_execution(&exec_id) {
+            match info.status.as_str() {
+                "completed" => return info.result.ok_or_else(|| "No result".to_string()),
+                "failed" => {
+                    return Err(info.error.unwrap_or_else(|| "Unknown error".to_string()));
+                }
+                "timed_out" => return Err("Timed out".to_string()),
+                "cancelled" => return Err("Cancelled".to_string()),
+                _ => continue,
+            }
+        }
+    }
+    Err("Execution did not complete within timeout".to_string())
+}
+
+// ── Plain JS unaffected ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_plain_js_unaffected_by_module_support() {
+    ensure_v8();
+    let engine = create_test_engine();
+
+    let result = run_and_wait(&engine, "1 + 2;").await;
+    assert!(result.is_ok(), "Plain JS should still work: {:?}", result);
+    assert_eq!(result.unwrap(), "3");
+}
+
+#[tokio::test]
+async fn test_plain_js_with_dynamic_import_keyword() {
+    // dynamic import() is an expression, not module syntax
+    ensure_v8();
+    let engine = create_test_engine();
+
+    // The word "import" in a string should not trigger module mode.
+    let result = run_and_wait(&engine, r#"const x = "import foo"; x;"#).await;
+    assert!(result.is_ok(), "String with 'import' should work: {:?}", result);
+    assert_eq!(result.unwrap(), "import foo");
+}
+
+// ── npm imports (network required) ──────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_npm_import_lodash_es() {
+    ensure_v8();
+    let engine = create_test_engine();
+
+    let code = r#"
+import camelCase from "npm:lodash-es@4.17.21/camelCase";
+globalThis.__result__ = camelCase("hello_world");
+"#;
+
+    let result = run_and_wait(&engine, code).await;
+    assert!(
+        result.is_ok(),
+        "npm lodash-es import should succeed, got: {:?}",
+        result
+    );
+    assert_eq!(result.unwrap(), "helloWorld");
+}
+
+// ── jsr imports (network required) ──────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_jsr_import_cases() {
+    ensure_v8();
+    let engine = create_test_engine();
+
+    let code = r#"
+import { camelCase } from "jsr:@luca/cases@1.0.0";
+camelCase("hello_world");
+"#;
+
+    let result = run_and_wait(&engine, code).await;
+    assert!(
+        result.is_ok(),
+        "jsr @luca/cases import should succeed, got: {:?}",
+        result
+    );
+    assert_eq!(result.unwrap(), "helloWorld");
+}
+
+// ── URL imports (network required) ──────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_url_import() {
+    ensure_v8();
+    let engine = create_test_engine();
+
+    let code = r#"
+import { camelCase } from "https://esm.sh/jsr/@luca/cases@1.0.0";
+camelCase("foo_bar");
+"#;
+
+    let result = run_and_wait(&engine, code).await;
+    assert!(
+        result.is_ok(),
+        "URL import should succeed, got: {:?}",
+        result
+    );
+    assert_eq!(result.unwrap(), "fooBar");
+}
+
+// ── Module with console output (network required) ───────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_module_console_log() {
+    ensure_v8();
+    let engine = create_test_engine();
+
+    let code = r#"
+import camelCase from "npm:lodash-es@4.17.21/camelCase";
+const result = camelCase("foo_bar_baz");
+console.log("Result:", result);
+result;
+"#;
+
+    let exec_id = engine
+        .run_js(code.to_string(), None, None, None, Some(60), None)
+        .await
+        .expect("run_js should succeed");
+
+    for _ in 0..1200 {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        if let Ok(info) = engine.get_execution(&exec_id) {
+            if info.status == "completed" {
+                assert_eq!(info.result.as_deref(), Some("fooBarBaz"));
+                let output = engine
+                    .get_execution_output(&exec_id, None, None, None, None)
+                    .expect("should get output");
+                assert!(
+                    output.data.contains("fooBarBaz"),
+                    "Console output should contain camelCased string, got: {}",
+                    output.data
+                );
+                return;
+            } else if info.status == "failed" || info.status == "timed_out" {
+                panic!(
+                    "Execution failed: {:?}",
+                    info.error.unwrap_or_else(|| info.status.clone())
+                );
+            }
+        }
+    }
+    panic!("Execution did not complete within timeout");
+}
+
+// ── npm cowsay (network required) ───────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_npm_cowsay() {
+    ensure_v8();
+    let engine = create_test_engine();
+
+    let code = r#"
+import { say } from "npm:cowsay@1.6.0";
+const result = say({ text: "Hello from mcp-js!" });
+console.log(result);
+typeof result;
+"#;
+
+    let result = run_and_wait(&engine, code).await;
+    assert!(
+        result.is_ok(),
+        "npm cowsay import should succeed, got: {:?}",
+        result
+    );
+    assert_eq!(result.unwrap(), "string");
+}
+
+// ── Deno-style URL import of TypeScript (network required) ──────────────
+
+#[tokio::test]
+#[ignore]
+async fn test_url_import_typescript() {
+    ensure_v8();
+    let engine = create_test_engine();
+
+    let code = r#"
+import { pascalCase } from "https://deno.land/x/case/mod.ts";
+pascalCase("hello_world");
+"#;
+
+    let result = run_and_wait(&engine, code).await;
+    assert!(
+        result.is_ok(),
+        "URL import of TypeScript should succeed, got: {:?}",
+        result
+    );
+    assert_eq!(result.unwrap(), "HelloWorld");
+}


### PR DESCRIPTION
## Summary
This PR adds support for executing JavaScript code as ES modules, enabling `import` and `export` declarations with automatic resolution of `npm:`, `jsr:`, and URL specifiers. Code containing module syntax is now detected and executed via a network-based module loader that fetches packages from esm.sh and other CDNs.

## Key Changes

- **Module syntax detection** (`has_module_syntax`): Detects ES module declarations (`import`/`export`) in code to determine execution mode. Correctly excludes dynamic `import()` expressions which are not module syntax.

- **Module result preparation** (`prepare_module_result`): Wraps the last expression statement in module code with `globalThis.__result__` assignment, allowing the result to be captured and returned after module evaluation.

- **Module execution** (`execute_module`): New execution path that loads code as an ES module using deno_core's module system, runs the event loop to resolve imports, and extracts the captured result.

- **NetworkModuleLoader**: New module loader implementation that:
  - Resolves `npm:` specifiers to esm.sh URLs (e.g., `npm:lodash-es@4.17.21` → `https://esm.sh/lodash-es@4.17.21`)
  - Resolves `jsr:` specifiers to esm.sh JSR gateway URLs (e.g., `jsr:@luca/cases@1.0.0` → `https://esm.sh/jsr/@luca/cases@1.0.0`)
  - Passes through absolute HTTP/HTTPS URLs unchanged
  - Resolves relative imports against the referrer URL
  - Fetches module code over HTTP and automatically strips TypeScript types from `.ts`/`.tsx` files
  - Handles HTTP redirects (e.g., version resolution by esm.sh)

- **Runtime integration**: Both stateless and stateful execution paths now:
  - Detect module syntax in input code
  - Conditionally create and attach the NetworkModuleLoader
  - Route to `execute_module` for module code or `execute_and_stringify` for classic scripts

- **Comprehensive test suite** (`module_imports.rs`): 
  - Unit tests for module syntax detection and result preparation
  - Unit tests for specifier resolution (npm, jsr, URL, relative)
  - Integration tests for plain JS (ensuring backward compatibility)
  - Network-dependent tests (marked `#[ignore]`) for real npm/jsr/URL imports

## Implementation Details

- Module syntax detection uses simple line-by-line prefix matching on trimmed lines, which is efficient and works correctly after TypeScript stripping by SWC.
- Result wrapping only applies to bare expression statements, skipping declarations, imports, exports, and control flow statements.
- The module loader uses reqwest for HTTP requests and respects HTTP redirects to support CDN version resolution.
- TypeScript files are automatically transpiled using the existing `strip_typescript_types` function.
- Plain JavaScript code without module syntax continues to execute via the classic script path, ensuring backward compatibility.

https://claude.ai/code/session_01SXwZ558YY6GSdxeTKLzH1i