### PR TITLE
Run OPA container with non-root opa user

### DIFF
--- a/Dockerfile.opa
+++ b/Dockerfile.opa
@@ -1,7 +1,9 @@
 FROM alpine:3.19
 RUN wget -O /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/latest/download/opa_linux_amd64_static \
     && chmod +x /usr/local/bin/opa
-COPY policies /policies
+RUN addgroup -S opa && adduser -S opa -G opa
+COPY --chown=opa:opa policies /policies
+USER opa
 EXPOSE 8181
 ENTRYPOINT ["/usr/local/bin/opa"]
 CMD ["run", "--server", "--addr", "0.0.0.0:8181", "/policies"]


### PR DESCRIPTION
## Summary
This change improves the security posture of the OPA Docker image by running the container with a non-root user instead of the default root user.

## Key Changes
- Created a dedicated `opa` user and group in the container
- Updated the COPY instruction to set proper ownership of the policies directory to the `opa` user
- Set the container to run as the `opa` user via the USER directive

## Implementation Details
The changes follow Docker security best practices by:
- Using `addgroup` and `adduser` to create a system user (`-S` flag) with minimal privileges
- Ensuring the copied policies directory is owned by the `opa` user using `--chown=opa:opa`
- Switching to the non-root user before the ENTRYPOINT, so OPA runs with reduced privileges

This prevents potential security vulnerabilities where a compromised OPA process could be exploited to gain root access to the container.

https://claude.ai/code/session_011L5RXjbR9amcp46da7wk4U