### PR TITLE
Refactor execution model to use console output instead of return values

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -124,7 +124,7 @@ curl http://localhost:8080/mcp
 # Test the plain HTTP API directly
 curl -X POST http://localhost:8080/api/exec \
   -H "Content-Type: application/json" \
-  -d '{"code": "1 + 2"}'
+  -d '{"code": "console.log(1 + 2)"}'
 
 # Use MCP Inspector
 npx @modelcontextprotocol/inspector http://localhost:8080/mcp

--- a/README.md
+++ b/README.md
@@ -202,32 +202,14 @@ mcp-v8 --stateless --sse-port 8081
 **Example:**
 
 ```
-Call run_js with code: "console.log('hello'); 1 + 1;"
+Call run_js with code: "console.log('hello');"
   → { execution_id: "abc-123" }
 
 Call get_execution with execution_id: "abc-123"
-  → { status: "completed", result: "2" }
+  → { status: "completed" }
 
 Call get_execution_output with execution_id: "abc-123"
   → { data: "hello\n", total_lines: 1 }
-```
-
-### Return Values
-
-The **last expression** in your code is the return value, available via `get_execution` once the execution completes:
-
-```javascript
-const result = 1 + 1;
-result;
-// → result: "2"
-```
-
-Objects must be serialized to see their contents:
-
-```javascript
-const obj = { a: 1, b: 2 };
-JSON.stringify(obj);
-// → result: '{"a":1,"b":2}'
 ```
 
 ### Console Output
@@ -375,7 +357,7 @@ claude mcp add mcp-v8 -- mcp-v8 --stateless
 claude mcp add mcp-v8 -t sse https://mcp-js-production.up.railway.app/sse
 ```
 
-Then test by running `claude` and asking: "Run this JavaScript: `[1,2,3].map(x => x * 2)`"
+Then test by running `claude` and asking: "Run this JavaScript: `console.log([1,2,3].map(x => x * 2))`"
 
 ### Cursor
 
@@ -419,11 +401,12 @@ You can also use the hosted version on Railway without installing anything local
 
 ## Example Usage
 
-Ask Claude or Cursor: "Run this JavaScript: `1 + 2`"
+Ask Claude or Cursor: "Run this JavaScript: `console.log(1 + 2)`"
 
 The agent will:
-1. Call `run_js` with `code: "1 + 2"` → receives `execution_id`
-2. Call `get_execution` with the `execution_id` → receives `{ status: "completed", result: "3" }`
+1. Call `run_js` with `code: "console.log(1 + 2)"` → receives `execution_id`
+2. Call `get_execution` with the `execution_id` → receives `{ status: "completed" }`
+3. Call `get_execution_output` with the `execution_id` → receives `{ data: "3\n", total_lines: 1 }`
 
 In stateful mode, `get_execution` also returns a `heap` content hash — pass it back in the next `run_js` call to resume from that state.
 
@@ -711,7 +694,7 @@ You can configure heap storage using the following command line arguments:
 
 While `mcp-v8` provides a powerful and persistent JavaScript execution environment, there are limitations to its runtime.
 
-- **Async execution model**: `run_js` returns immediately with an execution ID. Use `get_execution` to poll for the result and `get_execution_output` to read console output. Each execution runs in a fresh V8 isolate — no state is shared between calls (unless using stateful mode with heap snapshots).
+- **Async execution model**: `run_js` returns immediately with an execution ID. Use `get_execution` to poll for completion and `get_execution_output` to read console output. Each execution runs in a fresh V8 isolate — no state is shared between calls (unless using stateful mode with heap snapshots).
 - **`async`/`await` and Promises**: Fully supported. If your code returns a Promise, the runtime resolves it automatically.
 - **`console.log` supported**: `console.log`, `console.info`, `console.warn`, and `console.error` are captured and available via `get_execution_output` with paginated access.
 - **No `fetch` or network access by default**: When the server is started with `--opa-url`, a `fetch(url, opts?)` function becomes available following the web standard Fetch API. Each request is checked against an OPA policy before execution. Without `--opa-url`, there is no network access. See [OPA-Gated Fetch](#opa-gated-fetch) for details.


### PR DESCRIPTION
## Summary
This PR refactors the execution model to rely on console output (`console.log`) for retrieving results instead of implicit return values. The `get_execution` endpoint no longer returns a `result` field, and users must use `get_execution_output` to read console output.

## Key Changes

- **Test Updates**: Modified `test_url_import_typescript` to use `console.log()` for output and poll `get_execution` with `get_execution_output` to verify results instead of checking a return value
- **Documentation Updates**: 
  - Removed "Return Values" section from README explaining implicit return value behavior
  - Updated all examples to use `console.log()` for output (e.g., `"1 + 2"` → `"console.log(1 + 2)"`)
  - Updated example workflows to show the three-step process: `run_js` → `get_execution` (check status) → `get_execution_output` (read output)
  - Clarified that `get_execution` returns status only, not results
  - Updated Docker example to use `console.log(1 + 2)` instead of `1 + 2`
  - Updated limitations section to reflect polling for completion rather than results

## Implementation Details

The test now demonstrates the proper async polling pattern:
1. Call `run_js` to start execution
2. Poll `get_execution` every 100ms (up to 120 seconds) to check status
3. When status is "completed", call `get_execution_output` to retrieve console output
4. Verify output contains expected results

This change simplifies the execution model by making console output the primary mechanism for retrieving results, aligning with standard JavaScript practices.

https://claude.ai/code/session_01Ek61tt8rYhX28kjdL2Awga