### PR TITLE
Simplify StatelessMcpService to synchronous shell mode

### DIFF
--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -1,6 +1,6 @@
 run javascript or typescript code in v8
 
-Submits code for **async execution** — returns an execution ID immediately. V8 runs in the background. Use `get_execution` to poll status and result, `get_execution_output` to read console output, and `cancel_execution` to stop a running execution.
+Executes code and returns the console output directly. Each call runs in a fresh V8 isolate — no state is carried between calls.
 
 TypeScript support is type removal only — types are stripped before execution, not checked. Invalid types will be silently removed, not reported as errors.
 
@@ -10,51 +10,28 @@ params:
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 
 returns:
-- execution_id: UUID of the submitted execution. Use with get_execution, get_execution_output, and cancel_execution.
-
-## Workflow
-
-1. Call `run_js(code)` → get `execution_id`
-2. Call `get_execution(execution_id)` → check `status` (running/completed/failed/cancelled/timed_out)
-3. Call `get_execution_output(execution_id)` → read console output (paginated)
-4. When status is "completed", `get_execution` returns the `result` (final expression value)
+- output: console output from the execution (everything printed via console.log, console.info, console.warn, console.error)
+- error: error message if the execution failed, timed out, or was cancelled
 
 ## Console Output
 
-`console.log`, `console.info`, `console.warn`, and `console.error` are fully supported. Output is streamed to persistent storage during execution and can be queried in real-time using `get_execution_output`.
-
-Console output supports two pagination modes:
-- **Line mode**: `line_offset` + `line_limit` — fetch N lines starting from line M
-- **Byte mode**: `byte_offset` + `byte_limit` — fetch N bytes starting from byte M
-
-Both modes return position info in both coordinate systems for cross-referencing. Use `next_line_offset` or `next_byte_offset` from a previous response to resume reading.
-
-## Return Values
-
-The final expression value (the last evaluated expression in your code) is available via `get_execution` once the execution completes. To return results, ensure the value you want is the last line of your code.
+Use `console.log()` to produce output. `console.info`, `console.warn`, and `console.error` are also supported (with `[INFO]`, `[WARN]`, `[ERROR]` prefixes respectively).
 
 eg:
 
 ```js
 const result = 1 + 1;
-result;
+console.log(result);
 ```
 
-After execution completes, `get_execution` will return `result: "2"`.
-
-You must also jsonify an object, and return it as a string to see its content.
-
-eg:
+Returns `output: "2"`.
 
 ```js
-const obj = {
-  a: 1,
-  b: 2,
-};
-JSON.stringify(obj);
+const obj = { a: 1, b: 2 };
+console.log(JSON.stringify(obj));
 ```
 
-After execution completes, `get_execution` will return `result: '{"a":1,"b":2}'`.
+Returns `output: '{"a":1,"b":2}'`.
 
 async/await is supported. The runtime resolves top-level Promises automatically.
 

--- a/server/tests/stateless_shell.rs
+++ b/server/tests/stateless_shell.rs
@@ -1,0 +1,114 @@
+/// Tests for stateless shell mode — verifies that `StatelessMcpService::run_js`
+/// executes code and returns console output directly (no execution IDs exposed).
+
+use std::sync::{Arc, Once};
+use server::engine::{initialize_v8, Engine};
+use server::engine::execution::ExecutionRegistry;
+use server::mcp::StatelessMcpService;
+
+static INIT: Once = Once::new();
+
+fn ensure_v8() {
+    INIT.call_once(|| {
+        initialize_v8();
+    });
+}
+
+fn rand_id() -> u64 {
+    use std::time::SystemTime;
+    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos() as u64
+}
+
+/// Create a stateless engine with an execution registry for async tests.
+fn create_test_engine() -> Engine {
+    let tmp = std::env::temp_dir().join(format!("mcp-stateless-shell-test-{}-{}", std::process::id(), rand_id()));
+    let registry = ExecutionRegistry::new(tmp.to_str().unwrap()).expect("Failed to create test registry");
+    Engine::new_stateless(8 * 1024 * 1024, 30, 4)
+        .with_execution_registry(Arc::new(registry))
+}
+
+use server::mcp::StatelessRunJsResponse;
+
+/// Extract the JSON value from a StatelessRunJsResponse.
+fn parse_response(resp: StatelessRunJsResponse) -> serde_json::Value {
+    resp.value
+}
+
+#[tokio::test]
+async fn test_stateless_shell_console_log() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine);
+
+    let resp = service.run_js("console.log('hello world')".to_string(), None, None).await;
+    let value = parse_response(resp);
+
+    assert!(value["error"].is_null(), "Should not have error: {:?}", value);
+    let output = value["output"].as_str().expect("Should have output field");
+    assert!(output.contains("hello world"), "Output should contain 'hello world', got: {}", output);
+}
+
+#[tokio::test]
+async fn test_stateless_shell_multiple_console_logs() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine);
+
+    let code = r#"
+        console.log("line 1");
+        console.log("line 2");
+        console.log("line 3");
+    "#;
+
+    let resp = service.run_js(code.to_string(), None, None).await;
+    let value = parse_response(resp);
+
+    let output = value["output"].as_str().expect("Should have output");
+    assert!(output.contains("line 1"), "Should contain line 1");
+    assert!(output.contains("line 2"), "Should contain line 2");
+    assert!(output.contains("line 3"), "Should contain line 3");
+}
+
+#[tokio::test]
+async fn test_stateless_shell_error_handling() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine);
+
+    let resp = service.run_js("throw new Error('boom')".to_string(), None, None).await;
+    let value = parse_response(resp);
+
+    assert!(!value["error"].is_null(), "Should have error field: {:?}", value);
+    let error = value["error"].as_str().unwrap_or("");
+    assert!(error.contains("boom"), "Error should mention 'boom', got: {}", error);
+}
+
+#[tokio::test]
+async fn test_stateless_shell_no_execution_id_exposed() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine);
+
+    let resp = service.run_js("console.log('test')".to_string(), None, None).await;
+    let value = parse_response(resp);
+
+    assert!(value["execution_id"].is_null(), "Should not expose execution_id: {:?}", value);
+}
+
+#[tokio::test]
+async fn test_stateless_shell_computation_with_output() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine);
+
+    let code = r#"
+        const sum = [1, 2, 3, 4, 5].reduce((a, b) => a + b, 0);
+        console.log("sum is", sum);
+    "#;
+
+    let resp = service.run_js(code.to_string(), None, None).await;
+    let value = parse_response(resp);
+
+    let output = value["output"].as_str().expect("Should have output");
+    assert!(output.contains("sum is 15"), "Output should contain 'sum is 15', got: {}", output);
+}


### PR DESCRIPTION
## Summary

Refactored `StatelessMcpService` from an async execution model (exposing execution IDs and requiring polling) to a synchronous shell mode that executes code and returns console output directly. This simplifies the API surface and eliminates the need for callers to manage execution lifecycle.

## Key Changes

- **Removed execution management tools**: Deleted `get_execution`, `get_execution_output`, `cancel_execution`, and `list_executions` methods from `StatelessMcpService`
- **Simplified `run_js` method**: Now blocks until execution completes (with 5-minute timeout), polls for terminal state, collects all console output, and returns it directly in the response
- **New response type**: Introduced `StatelessRunJsResponse` with `IntoContents` trait implementation to properly serialize JSON responses
- **Updated documentation**: Modified `run_js_tool_stateless.md` to reflect the new synchronous behavior and simplified return format (output + optional error, no execution_id)
- **Added comprehensive tests**: Created `stateless_shell.rs` test suite covering console output, error handling, multiple logs, and verification that execution IDs are not exposed

## Implementation Details

- The `run_js` method now internally polls the execution engine at 50ms intervals (max 6000 polls = 5 minutes) until reaching a terminal state (completed/failed/timed_out/cancelled)
- Console output is collected in full using `get_execution_output` with `line_limit: u64::MAX`
- Response includes `output` field with all console logs and optional `error` field if execution failed
- Each call runs in a fresh V8 isolate with automatic session isolation
- Updated server info description to "stateless shell mode"

https://claude.ai/code/session_01BHKdZKuVsjUJMy2XUyoYfD