### PR TITLE
Remove DEFAULT_HEAP_MEMORY_MAX_MB constant and inline heap limit

### DIFF
--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -41,7 +41,6 @@ use crate::engine::heap_tags::{HeapTagStore, HeapTagEntry};
 use crate::engine::session_log::{SessionLog, SessionLogEntry};
 use wasmparser::Validator;
 
-pub const DEFAULT_HEAP_MEMORY_MAX_MB: usize = 8;
 pub const DEFAULT_EXECUTION_TIMEOUT_SECS: u64 = 30;
 /// Default maximum native memory (bytes) a WASM module may declare when no
 /// per-module limit is set. 16 MiB.

--- a/server/tests/heap_limit.rs
+++ b/server/tests/heap_limit.rs
@@ -49,7 +49,7 @@ fn test_stateless_small_heap_limit_rejects_large_allocation() {
 fn test_stateless_default_limit_allows_small_code() {
     ensure_v8();
 
-    let max_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
+    let max_bytes = 8 * 1024 * 1024;
     let (result, _oom) = server::engine::execute_stateless(SMALL_JS, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(
@@ -95,7 +95,7 @@ fn test_stateful_small_heap_limit_rejects_large_allocation() {
 fn test_stateful_default_limit_allows_small_code() {
     ensure_v8();
 
-    let max_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
+    let max_bytes = 8 * 1024 * 1024;
     let (result, _oom) = server::engine::execute_stateful(SMALL_JS, None, max_bytes, no_handle(), &[], max_bytes, None, None);
 
     assert!(

--- a/server/tests/parameter_configs.rs
+++ b/server/tests/parameter_configs.rs
@@ -162,7 +162,7 @@ fn test_fast_computation_succeeds() {
 fn test_bare_call_default_params() {
     ensure_v8();
 
-    let heap_bytes = server::engine::DEFAULT_HEAP_MEMORY_MAX_MB * 1024 * 1024;
+    let heap_bytes = 8 * 1024 * 1024;
 
     let (result, _oom) = server::engine::execute_stateless("1 + 1", heap_bytes, no_handle(), &[], heap_bytes, None, None);
 


### PR DESCRIPTION
## Summary
This PR removes the `DEFAULT_HEAP_MEMORY_MAX_MB` constant from the engine module and replaces all usages with the hardcoded value of `8 * 1024 * 1024` bytes (8 MiB).

## Key Changes
- Removed the `DEFAULT_HEAP_MEMORY_MAX_MB` constant definition from `server/src/engine/mod.rs`
- Updated test files to use the explicit heap limit value instead of the constant:
  - `server/tests/heap_limit.rs`: Updated 2 test functions
  - `server/tests/parameter_configs.rs`: Updated 1 test function

## Implementation Details
The constant was only used in test code to specify heap memory limits. By removing the constant and inlining the value, the codebase eliminates an unnecessary level of indirection while maintaining the same default heap limit of 8 MiB. This makes the actual limit value more explicit and visible in the test code.

https://claude.ai/code/session_01Ke1nkd1XDrzLLEbiRaCUxC