### PR TITLE
Add OPA policy support for filesystem and module imports

### DIFF
--- a/.github/workflows/nixos-integration-test.yml
+++ b/.github/workflows/nixos-integration-test.yml
@@ -22,6 +22,10 @@ jobs:
             check: load-balancing-test
           - name: Fetch OPA Integration Test
             check: fetch-opa-test
+          - name: Filesystem OPA Integration Test
+            check: fs-opa-test
+          - name: Module Policy Integration Test
+            check: module-policy-test
 
     steps:
       - name: Checkout code

--- a/flake.nix
+++ b/flake.nix
@@ -143,6 +143,14 @@
             inherit pkgs;
             mcp-js = self.packages.x86_64-linux.default;
           });
+          fs-opa-test = pkgs.nixosTest (import ./tests/nixos/fs-opa.nix {
+            inherit pkgs;
+            mcp-js = self.packages.x86_64-linux.default;
+          });
+          module-policy-test = pkgs.nixosTest (import ./tests/nixos/module-policy.nix {
+            inherit pkgs;
+            mcp-js = self.packages.x86_64-linux.default;
+          });
         };
     };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -106,6 +106,24 @@ in
       default = "mcp/fetch";
       description = "OPA policy path for fetch requests (appended to /v1/data/).";
     };
+
+    opaFsPolicy = lib.mkOption {
+      type = lib.types.str;
+      default = "mcp/fs";
+      description = "OPA policy path for filesystem operations (appended to /v1/data/).";
+    };
+
+    allowExternalModules = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Allow external module imports (npm:, jsr:, URL).";
+    };
+
+    opaModulePolicy = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "OPA policy path for module import auditing (appended to /v1/data/).";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -162,9 +180,17 @@ in
               cfg.opaUrl
               "--opa-fetch-policy"
               cfg.opaFetchPolicy
+              "--opa-fs-policy"
+              cfg.opaFsPolicy
             ];
+
+            moduleArgs = lib.optionals cfg.allowExternalModules [ "--allow-external-modules" ]
+              ++ lib.optionals (cfg.opaModulePolicy != null) [
+                "--opa-module-policy"
+                cfg.opaModulePolicy
+              ];
           in
-          lib.concatStringsSep " " (baseArgs ++ storageArgs ++ peerArgs ++ statelessArgs ++ advertiseArgs ++ joinArgs ++ opaArgs);
+          lib.concatStringsSep " " (baseArgs ++ storageArgs ++ peerArgs ++ statelessArgs ++ advertiseArgs ++ joinArgs ++ opaArgs ++ moduleArgs);
 
         Restart = "on-failure";
         RestartSec = "2s";

--- a/tests/nixos/fs-opa.nix
+++ b/tests/nixos/fs-opa.nix
@@ -1,0 +1,466 @@
+{ pkgs, mcp-js, ... }:
+
+let
+  # ── Rego policy ──────────────────────────────────────────────────────
+  #
+  # Allow filesystem operations only under /tmp/.
+  # Deny everything else. Dual-path ops (rename, copyFile) require both
+  # source and destination under /tmp/.
+
+  fsPolicy = pkgs.writeText "fs-policy.rego" ''
+    package mcp.fs
+
+    default allow = false
+
+    allow if {
+        input.operation == "readFile"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "readdir"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "stat"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "exists"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "writeFile"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "appendFile"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "mkdir"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "rm"
+        path_allowed
+        not path_denied
+    }
+    allow if {
+        input.operation == "rename"
+        path_allowed
+        destination_allowed
+        not path_denied
+        not destination_denied
+    }
+    allow if {
+        input.operation == "copyFile"
+        path_allowed
+        destination_allowed
+        not path_denied
+        not destination_denied
+    }
+
+    allowed_prefixes := { "/tmp/" }
+
+    path_allowed if {
+        some prefix in allowed_prefixes
+        startswith(input.path, prefix)
+    }
+    path_allowed if {
+        input.path == "/tmp"
+    }
+
+    destination_allowed if {
+        some prefix in allowed_prefixes
+        startswith(input.destination, prefix)
+    }
+
+    denied_prefixes := set()
+
+    path_denied if {
+        some prefix in denied_prefixes
+        startswith(input.path, prefix)
+    }
+    destination_denied if {
+        some prefix in denied_prefixes
+        startswith(input.destination, prefix)
+    }
+  '';
+
+  # Minimal fetch policy (required since --opa-url enables fetch too)
+  fetchPolicy = pkgs.writeText "fetch-policy.rego" ''
+    package mcp.fetch
+    default allow = false
+  '';
+in
+
+{
+  name = "mcp-js-fs-opa";
+
+  nodes = {
+    machine = { ... }: {
+      imports = [ ../../nix/module.nix ];
+
+      # ── mcp-js server (stateless, with OPA) ──────────────────────────
+      services.mcp-js = {
+        enable = true;
+        package = mcp-js;
+        nodeId = "test";
+        stateless = true;
+        httpPort = 3000;
+        opaUrl = "http://localhost:8181";
+      };
+
+      # ── OPA server ───────────────────────────────────────────────────
+      systemd.services.opa = {
+        description = "Open Policy Agent";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.open-policy-agent}/bin/opa run --server --addr :8181 ${fsPolicy} ${fetchPolicy}";
+          Restart = "on-failure";
+          DynamicUser = true;
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [ 3000 8181 ];
+    };
+  };
+
+  testScript = ''
+    import json
+    import shlex
+    import time
+
+    machine.start()
+    machine.wait_for_unit("opa.service")
+    machine.wait_for_unit("mcp-js.service")
+    machine.wait_for_open_port(3000)
+    machine.wait_for_open_port(8181)
+
+    def exec_js(code):
+        """Execute JS code via mcp-js async /api/exec endpoint.
+
+        Returns a dict with keys: status, output (result or error message).
+        """
+        body = json.dumps({"code": code})
+        raw = machine.succeed(
+            "curl -s -X POST http://localhost:3000/api/exec "
+            "-H 'Content-Type: application/json' "
+            "-d " + shlex.quote(body)
+        )
+        submit_resp = json.loads(raw)
+        exec_id = submit_resp["execution_id"]
+
+        for _ in range(60):
+            status_raw = machine.succeed(
+                "curl -s http://localhost:3000/api/executions/" + exec_id
+            )
+            status_resp = json.loads(status_raw)
+            status = status_resp.get("status", "")
+            if status in ("Completed", "completed"):
+                return {
+                    "status": "completed",
+                    "output": status_resp.get("result", ""),
+                    "exec_id": exec_id,
+                }
+            if status in ("Failed", "failed", "TimedOut", "Cancelled",
+                          "timed_out", "cancelled"):
+                return {
+                    "status": "failed",
+                    "output": "Error: " + status_resp.get("error", status),
+                    "exec_id": exec_id,
+                }
+            time.sleep(0.5)
+
+        raise Exception("Execution " + exec_id + " did not complete within 30s")
+
+    def get_console(exec_id):
+        """Fetch console output for an execution."""
+        raw = machine.succeed(
+            "curl -s http://localhost:3000/api/executions/" + exec_id + "/output"
+        )
+        resp = json.loads(raw)
+        lines = resp.get("lines", [])
+        return "\n".join(line.get("text", "") for line in lines)
+
+    # ════════════════════════════════════════════════════════════════════
+    # Allowed operations (paths under /tmp/)
+    # ════════════════════════════════════════════════════════════════════
+
+    with subtest("should write and read a file under /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/test.txt", "hello world");
+                const data = await fs.readFile("/tmp/test.txt");
+                console.log(data);
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        assert "hello world" in console, \
+            "Expected 'hello world' in console output, got: " + console
+
+    with subtest("should mkdir and stat a directory under /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.mkdir("/tmp/testdir", { recursive: true });
+                const info = await fs.stat("/tmp/testdir");
+                console.log(JSON.stringify(info));
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        info = json.loads(console.strip())
+        assert info["isDirectory"] == True, \
+            "Expected isDirectory=true, got: " + console
+
+    with subtest("should readdir /tmp"):
+        result = exec_js("""
+            (async () => {
+                const entries = await fs.readdir("/tmp");
+                console.log(JSON.stringify(Array.isArray(entries)));
+                console.log(JSON.stringify(entries.length > 0));
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        assert "true" in console, \
+            "Expected readdir to return a non-empty array, got: " + console
+
+    with subtest("should appendFile and verify content"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/append.txt", "hello");
+                await fs.appendFile("/tmp/append.txt", " world");
+                const data = await fs.readFile("/tmp/append.txt");
+                console.log(data);
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        assert "hello world" in console, \
+            "Expected 'hello world', got: " + console
+
+    with subtest("should check exists (true and false)"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/exists-test.txt", "x");
+                const e1 = await fs.exists("/tmp/exists-test.txt");
+                const e2 = await fs.exists("/tmp/nonexistent-xyz.txt");
+                console.log(JSON.stringify({ exists: e1, notExists: e2 }));
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        data = json.loads(console.strip())
+        assert data["exists"] == True, "Expected exists=true, got: " + console
+        assert data["notExists"] == False, "Expected notExists=false, got: " + console
+
+    with subtest("should rename within /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/rename-src.txt", "rename-data");
+                await fs.rename("/tmp/rename-src.txt", "/tmp/rename-dst.txt");
+                const data = await fs.readFile("/tmp/rename-dst.txt");
+                const srcGone = !(await fs.exists("/tmp/rename-src.txt"));
+                console.log(JSON.stringify({ data, srcGone }));
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        data = json.loads(console.strip())
+        assert data["data"] == "rename-data", \
+            "Expected 'rename-data', got: " + console
+        assert data["srcGone"] == True, \
+            "Expected source to be gone, got: " + console
+
+    with subtest("should copyFile within /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/copy-src.txt", "copy-data");
+                await fs.copyFile("/tmp/copy-src.txt", "/tmp/copy-dst.txt");
+                const data = await fs.readFile("/tmp/copy-dst.txt");
+                const srcExists = await fs.exists("/tmp/copy-src.txt");
+                console.log(JSON.stringify({ data, srcExists }));
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        data = json.loads(console.strip())
+        assert data["data"] == "copy-data", \
+            "Expected 'copy-data', got: " + console
+        assert data["srcExists"] == True, \
+            "Expected source to still exist, got: " + console
+
+    with subtest("should rm a file under /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/rm-test.txt", "delete me");
+                const before = await fs.exists("/tmp/rm-test.txt");
+                await fs.rm("/tmp/rm-test.txt");
+                const after = await fs.exists("/tmp/rm-test.txt");
+                console.log(JSON.stringify({ before, after }));
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        data = json.loads(console.strip())
+        assert data["before"] == True, "Expected before=true, got: " + console
+        assert data["after"] == False, "Expected after=false, got: " + console
+
+    with subtest("should write and read binary data (Uint8Array)"):
+        result = exec_js("""
+            (async () => {
+                const bytes = new Uint8Array([0, 1, 2, 255, 128, 64]);
+                await fs.writeFile("/tmp/binary.bin", bytes);
+                const result = await fs.readFile("/tmp/binary.bin", "buffer");
+                console.log(JSON.stringify({
+                    isUint8: result instanceof Uint8Array,
+                    len: result.length,
+                    vals: [result[0], result[1], result[2], result[3], result[4], result[5]]
+                }));
+            })()
+        """)
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        console = get_console(result["exec_id"])
+        data = json.loads(console.strip())
+        assert data["isUint8"] == True, "Expected Uint8Array, got: " + console
+        assert data["len"] == 6, "Expected length 6, got: " + console
+        assert data["vals"] == [0, 1, 2, 255, 128, 64], \
+            "Expected [0,1,2,255,128,64], got: " + console
+
+    # ════════════════════════════════════════════════════════════════════
+    # Denied operations (paths outside /tmp/)
+    # ════════════════════════════════════════════════════════════════════
+
+    with subtest("should deny readFile outside /tmp"):
+        result = exec_js("""
+            (async () => { await fs.readFile("/etc/passwd"); })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny writeFile outside /tmp"):
+        result = exec_js("""
+            (async () => { await fs.writeFile("/etc/evil", "x"); })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny readdir outside /tmp"):
+        result = exec_js("""
+            (async () => { await fs.readdir("/home"); })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny stat outside /tmp"):
+        result = exec_js("""
+            (async () => { await fs.stat("/etc/hostname"); })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny mkdir outside /tmp"):
+        result = exec_js("""
+            (async () => { await fs.mkdir("/var/evildir"); })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny exists outside /tmp"):
+        result = exec_js("""
+            (async () => { await fs.exists("/root/.bashrc"); })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny rm outside /tmp"):
+        result = exec_js("""
+            (async () => { await fs.rm("/bin/sh"); })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    # ════════════════════════════════════════════════════════════════════
+    # Dual-path operations boundary
+    # ════════════════════════════════════════════════════════════════════
+
+    with subtest("should deny rename when destination is outside /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/rename-escape.txt", "data");
+                await fs.rename("/tmp/rename-escape.txt", "/etc/rename-escape.txt");
+            })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny copyFile when destination is outside /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/copy-escape.txt", "data");
+                await fs.copyFile("/tmp/copy-escape.txt", "/etc/copy-escape.txt");
+            })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny rename when source is outside /tmp"):
+        result = exec_js("""
+            (async () => {
+                await fs.rename("/etc/hostname", "/tmp/stolen-hostname");
+            })()
+        """)
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"], \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    # ════════════════════════════════════════════════════════════════════
+    # Sanity
+    # ════════════════════════════════════════════════════════════════════
+
+    with subtest("should still execute plain JS when fs policy is active"):
+        result = exec_js("1 + 2")
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        assert result["output"] == "3", \
+            "Expected '3', got: " + result["output"]
+  '';
+}

--- a/tests/nixos/module-policy.nix
+++ b/tests/nixos/module-policy.nix
@@ -1,0 +1,259 @@
+{ pkgs, mcp-js, ... }:
+
+let
+  # ── Rego policy for module imports ──────────────────────────────────
+  #
+  # Allow specific npm/jsr/URL packages through esm.sh.
+  # Deny everything else.
+
+  modulePolicy = pkgs.writeText "module-policy.rego" ''
+    package mcp.modules
+
+    default allow = false
+
+    allow if {
+        input.specifier_type == "npm"
+        npm_package_allowed
+    }
+    allow if {
+        input.specifier_type == "jsr"
+        jsr_package_allowed
+    }
+    allow if {
+        input.specifier_type == "url"
+        url_host_allowed
+    }
+
+    allowed_npm_packages := {
+        "lodash-es",
+        "uuid",
+        "date-fns",
+        "zod",
+    }
+
+    npm_package_allowed if {
+        input.url_parsed.host == "esm.sh"
+        some pkg in allowed_npm_packages
+        startswith(input.url_parsed.path, sprintf("/%s", [pkg]))
+    }
+
+    allowed_jsr_packages := {
+        "@luca/cases",
+        "@std/path",
+    }
+
+    jsr_package_allowed if {
+        input.url_parsed.host == "esm.sh"
+        some pkg in allowed_jsr_packages
+        startswith(input.url_parsed.path, sprintf("/jsr/%s", [pkg]))
+    }
+
+    allowed_url_hosts := {
+        "esm.sh",
+        "cdn.jsdelivr.net",
+        "unpkg.com",
+    }
+
+    url_host_allowed if {
+        allowed_url_hosts[input.url_parsed.host]
+    }
+
+    allowed_url_suffixes := {
+        ".esm.sh",
+    }
+
+    url_host_allowed if {
+        some suffix in allowed_url_suffixes
+        endswith(input.url_parsed.host, suffix)
+    }
+  '';
+
+  # Minimal fetch policy (required since --opa-url enables fetch too)
+  fetchPolicy = pkgs.writeText "fetch-policy.rego" ''
+    package mcp.fetch
+    default allow = false
+  '';
+
+  # Minimal fs policy
+  fsPolicy = pkgs.writeText "fs-policy.rego" ''
+    package mcp.fs
+    default allow = false
+  '';
+in
+
+{
+  name = "mcp-js-module-policy";
+
+  nodes = {
+    machine = { ... }: {
+
+      # ── OPA server ───────────────────────────────────────────────────
+      systemd.services.opa = {
+        description = "Open Policy Agent";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.open-policy-agent}/bin/opa run --server --addr :8181 ${modulePolicy} ${fetchPolicy} ${fsPolicy}";
+          Restart = "on-failure";
+          DynamicUser = true;
+        };
+      };
+
+      # ── mcp-default: external modules DISABLED ──────────────────────
+      # No --allow-external-modules, no --opa-url
+      systemd.services.mcp-default = {
+        description = "MCP JS Server (modules disabled)";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${mcp-js}/bin/server --node-id default --stateless --http-port 3001";
+          Restart = "on-failure";
+          DynamicUser = true;
+        };
+      };
+
+      # ── mcp-opa-policy: external modules ENABLED with OPA policy ────
+      systemd.services.mcp-opa-policy = {
+        description = "MCP JS Server (modules + OPA policy)";
+        after = [ "network.target" "opa.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = "${mcp-js}/bin/server --node-id opa-policy --stateless --http-port 3002 --allow-external-modules --opa-url http://localhost:8181 --opa-module-policy mcp/modules";
+          Restart = "on-failure";
+          DynamicUser = true;
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [ 3001 3002 8181 ];
+    };
+  };
+
+  testScript = ''
+    import json
+    import shlex
+    import time
+
+    machine.start()
+    machine.wait_for_unit("opa.service")
+    machine.wait_for_unit("mcp-default.service")
+    machine.wait_for_unit("mcp-opa-policy.service")
+    machine.wait_for_open_port(3001)
+    machine.wait_for_open_port(3002)
+    machine.wait_for_open_port(8181)
+
+    def exec_js(base_url, code):
+        """Execute JS code against a specific mcp-js instance.
+
+        Returns a dict with keys: status, output (result or error).
+        """
+        body = json.dumps({"code": code})
+        raw = machine.succeed(
+            "curl -s -X POST " + base_url + "/api/exec "
+            "-H 'Content-Type: application/json' "
+            "-d " + shlex.quote(body)
+        )
+        submit_resp = json.loads(raw)
+        exec_id = submit_resp["execution_id"]
+
+        for _ in range(60):
+            status_raw = machine.succeed(
+                "curl -s " + base_url + "/api/executions/" + exec_id
+            )
+            status_resp = json.loads(status_raw)
+            status = status_resp.get("status", "")
+            if status in ("Completed", "completed"):
+                return {
+                    "status": "completed",
+                    "output": status_resp.get("result", ""),
+                }
+            if status in ("Failed", "failed", "TimedOut", "Cancelled",
+                          "timed_out", "cancelled"):
+                return {
+                    "status": "failed",
+                    "output": status_resp.get("error", status),
+                }
+            time.sleep(0.5)
+
+        raise Exception("Execution " + exec_id + " did not complete within 30s")
+
+    DEFAULT_URL = "http://localhost:3001"
+    OPA_URL = "http://localhost:3002"
+
+    # ════════════════════════════════════════════════════════════════════
+    # Tests on mcp-default (external modules DISABLED)
+    # ════════════════════════════════════════════════════════════════════
+
+    with subtest("should block npm import on default server"):
+        result = exec_js(DEFAULT_URL,
+            'import { camelCase } from "npm:lodash-es@4.17.21"; camelCase("hello_world");')
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "external module imports are disabled" in result["output"].lower(), \
+            "Expected 'external module imports are disabled', got: " + result["output"]
+
+    with subtest("should block jsr import on default server"):
+        result = exec_js(DEFAULT_URL,
+            'import { camelCase } from "jsr:@luca/cases@1.0.0"; camelCase("hello_world");')
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "external module imports are disabled" in result["output"].lower(), \
+            "Expected 'external module imports are disabled', got: " + result["output"]
+
+    with subtest("should block https URL import on default server"):
+        result = exec_js(DEFAULT_URL,
+            'import { camelCase } from "https://esm.sh/lodash-es@4.17.21"; camelCase("hello_world");')
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "external module imports are disabled" in result["output"].lower(), \
+            "Expected 'external module imports are disabled', got: " + result["output"]
+
+    with subtest("should execute plain JS on default server"):
+        result = exec_js(DEFAULT_URL, "1 + 2;")
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        assert result["output"] == "3", \
+            "Expected '3', got: " + result["output"]
+
+    # ════════════════════════════════════════════════════════════════════
+    # Tests on mcp-opa-policy (external modules + OPA policy)
+    # ════════════════════════════════════════════════════════════════════
+
+    with subtest("should allow whitelisted npm package (lodash-es)"):
+        result = exec_js(OPA_URL,
+            'import camelCase from "npm:lodash-es@4.17.21/camelCase"; console.log(camelCase("hello_world"));')
+        # If the package is successfully fetched, status=completed.
+        # If there's a network issue fetching from esm.sh, status=failed but
+        # the error should NOT be "denied by policy".
+        if result["status"] == "completed":
+            print("Whitelisted npm import succeeded")
+        elif result["status"] == "failed":
+            assert "denied by policy" not in result["output"], \
+                "Whitelisted npm package should NOT be denied by policy, got: " + result["output"]
+            print("Whitelisted npm import failed (network), but not by policy: " + result["output"])
+        else:
+            raise AssertionError("Unexpected status: " + str(result))
+
+    with subtest("should deny non-whitelisted npm package"):
+        result = exec_js(OPA_URL,
+            'import evil from "npm:evil-package@1.0.0"; evil();')
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"].lower(), \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should deny non-whitelisted URL host"):
+        result = exec_js(OPA_URL,
+            'import foo from "https://evil.example.com/malware.js"; foo();')
+        assert result["status"] == "failed", \
+            "Expected failed, got: " + str(result)
+        assert "denied by policy" in result["output"].lower(), \
+            "Expected 'denied by policy', got: " + result["output"]
+
+    with subtest("should execute plain JS on OPA policy server"):
+        result = exec_js(OPA_URL, "1 + 2;")
+        assert result["status"] == "completed", \
+            "Expected completed, got: " + str(result)
+        assert result["output"] == "3", \
+            "Expected '3', got: " + result["output"]
+  '';
+}


### PR DESCRIPTION
## Summary
This PR extends the mcp-js server with Open Policy Agent (OPA) integration for fine-grained access control over filesystem operations and external module imports. It adds two new policy enforcement mechanisms and comprehensive integration tests.

## Key Changes

- **Filesystem OPA Policy Support**: Added `--opa-fs-policy` flag and `opaFsPolicy` module option to enforce access control on filesystem operations (read, write, mkdir, rename, copyFile, etc.). The policy can restrict operations to specific paths (e.g., only `/tmp/`).

- **Module Import Policy Support**: Added `--allow-external-modules` flag and `--opa-module-policy` flag to control external module imports (npm, jsr, URL). When enabled with an OPA policy, modules can be whitelisted by package name or host.

- **NixOS Module Updates**: Extended `nix/module.nix` with three new configuration options:
  - `opaFsPolicy`: Path to OPA policy for filesystem operations (default: `mcp/fs`)
  - `allowExternalModules`: Boolean to enable external module imports (default: false)
  - `opaModulePolicy`: Optional OPA policy path for module auditing

- **Comprehensive Integration Tests**:
  - `tests/nixos/fs-opa.nix`: Tests filesystem policy enforcement with 20+ test cases covering allowed operations (read, write, mkdir, rename, copyFile, rm) and denied operations (paths outside `/tmp/`, dual-path boundary violations)
  - `tests/nixos/module-policy.nix`: Tests module import policy with separate OPA and non-OPA servers, validating package whitelisting and denial of non-whitelisted imports

- **CI Integration**: Added two new NixOS integration tests to the GitHub Actions workflow (`fs-opa-test` and `module-policy-test`)

## Implementation Details

- Filesystem policy uses Rego rules to validate operation types and path prefixes, with separate rules for single-path and dual-path operations
- Module policy validates npm packages, jsr packages, and URL hosts against whitelists via esm.sh
- Both test suites use OPA server running alongside mcp-js instances with async execution polling via HTTP API
- Tests verify both positive cases (allowed operations) and negative cases (policy denials with "denied by policy" error messages)

https://claude.ai/code/session_01G4tjJvbubpc21nfZTgo2Tq