### PR TITLE
Refactor execute_stateless/execute_stateful to use ExecutionConfig builder

### DIFF
--- a/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use server::engine::WasmModule;
+use server::engine::{ExecutionConfig, WasmModule};
 use std::sync::{Arc, Mutex, Once};
 
 static INIT: Once = Once::new();
@@ -72,5 +72,8 @@ fuzz_target!(|input: StatefulInput| {
     let max_bytes = 8 * 1024 * 1024;
     let wasm_default = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateful(&input.code, raw_snapshot, max_bytes, handle, &modules, wasm_default, None, None, None);
+    let _ = server::engine::execute_stateful(&input.code, raw_snapshot, ExecutionConfig::new(max_bytes)
+        .isolate_handle(handle)
+        .wasm_modules(&modules)
+        .wasm_default_max_bytes(wasm_default));
 });

--- a/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use server::engine::WasmModule;
+use server::engine::{ExecutionConfig, WasmModule};
 use std::sync::{Arc, Mutex, Once};
 
 static INIT: Once = Once::new();
@@ -59,5 +59,8 @@ fuzz_target!(|input: StatelessInput| {
     let max_bytes = 8 * 1024 * 1024;
     let wasm_default = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateless(&input.code, max_bytes, handle, &modules, wasm_default, None, None, None);
+    let _ = server::engine::execute_stateless(&input.code, ExecutionConfig::new(max_bytes)
+        .isolate_handle(handle)
+        .wasm_modules(&modules)
+        .wasm_default_max_bytes(wasm_default));
 });

--- a/server/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
+++ b/server/fuzz/fuzz_targets/fuzz_snapshot_deserialization.rs
@@ -1,5 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use server::engine::ExecutionConfig;
 use std::sync::{Arc, Mutex, Once};
 
 static INIT: Once = Once::new();
@@ -39,5 +40,7 @@ fuzz_target!(|data: &[u8]| {
     let max_bytes = 64 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
     let wasm_default = 16 * 1024 * 1024;
-    let _ = server::engine::execute_stateful("1", raw_snapshot, max_bytes, handle, &[], wasm_default, None, None, None);
+    let _ = server::engine::execute_stateful("1", raw_snapshot, ExecutionConfig::new(max_bytes)
+        .isolate_handle(handle)
+        .wasm_default_max_bytes(wasm_default));
 });

--- a/server/fuzz/fuzz_targets/fuzz_wasm_compile.rs
+++ b/server/fuzz/fuzz_targets/fuzz_wasm_compile.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use server::engine::WasmModule;
+use server::engine::{ExecutionConfig, WasmModule};
 use std::sync::{Arc, Mutex, Once};
 
 static INIT: Once = Once::new();
@@ -43,5 +43,8 @@ fuzz_target!(|data: &[u8]| {
     let max_bytes = 64 * 1024 * 1024;
     let wasm_default = 8 * 1024 * 1024;
     let handle = Arc::new(Mutex::new(None));
-    let _ = server::engine::execute_stateless("1", max_bytes, handle, &modules, wasm_default, None, None, None);
+    let _ = server::engine::execute_stateless("1", ExecutionConfig::new(max_bytes)
+        .isolate_handle(handle)
+        .wasm_modules(&modules)
+        .wasm_default_max_bytes(wasm_default));
 });

--- a/server/tests/parameter_configs.rs
+++ b/server/tests/parameter_configs.rs
@@ -4,8 +4,8 @@
 /// tokio::select! timeout). OOM tests call execute_stateless/execute_stateful
 /// directly since they don't need timeout management.
 
-use std::sync::{Arc, Mutex, Once};
-use server::engine::{Engine, initialize_v8};
+use std::sync::{Arc, Once};
+use server::engine::{Engine, ExecutionConfig, initialize_v8};
 use server::engine::execution::ExecutionRegistry;
 
 static INIT: Once = Once::new();
@@ -14,10 +14,6 @@ fn ensure_v8() {
     INIT.call_once(|| {
         initialize_v8();
     });
-}
-
-fn no_handle() -> Arc<Mutex<Option<deno_core::v8::IsolateHandle>>> {
-    Arc::new(Mutex::new(None))
 }
 
 fn rand_id() -> u64 {
@@ -103,7 +99,7 @@ fn test_oom_produces_descriptive_error_not_crash() {
     "#;
     let heap_bytes = 16 * 1024 * 1024; // 16MB
 
-    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None, None, None);
+    let (result, _oom) = server::engine::execute_stateless(code, ExecutionConfig::new(heap_bytes));
 
     assert!(result.is_err(), "Huge allocation with small heap should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -127,7 +123,7 @@ fn test_oom_stateful_produces_descriptive_error_not_crash() {
     "#;
     let heap_bytes = 16 * 1024 * 1024; // 16MB
 
-    let (result, _oom) = server::engine::execute_stateful(code, None, heap_bytes, no_handle(), &[], heap_bytes, None, None, None);
+    let (result, _oom) = server::engine::execute_stateful(code, None, ExecutionConfig::new(heap_bytes));
 
     assert!(result.is_err(), "Huge allocation with small heap should fail, got: {:?}", result);
     let err = result.unwrap_err();
@@ -151,7 +147,7 @@ fn test_fast_computation_succeeds() {
     "#;
     let heap_bytes = 64 * 1024 * 1024;
 
-    let (result, _oom) = server::engine::execute_stateless(code, heap_bytes, no_handle(), &[], heap_bytes, None, None, None);
+    let (result, _oom) = server::engine::execute_stateless(code, ExecutionConfig::new(heap_bytes));
 
     assert!(result.is_ok(), "Fast computation should succeed, got: {:?}", result);
     assert_eq!(result.unwrap(), "499999500000");
@@ -164,7 +160,7 @@ fn test_bare_call_default_params() {
 
     let heap_bytes = 8 * 1024 * 1024;
 
-    let (result, _oom) = server::engine::execute_stateless("1 + 1", heap_bytes, no_handle(), &[], heap_bytes, None, None, None);
+    let (result, _oom) = server::engine::execute_stateless("1 + 1", ExecutionConfig::new(heap_bytes));
 
     assert!(result.is_ok(), "Simple expression should succeed, got: {:?}", result);
     assert_eq!(result.unwrap(), "2");


### PR DESCRIPTION
## Summary
- Introduces `ExecutionConfig` builder struct to replace the long parameter lists on `execute_stateless` and `execute_stateful`
- All callers (engine, fuzz targets, tests) updated to use the builder pattern
- No behavioral changes — pure refactor

## Test plan
- [ ] Existing `cargo test` passes
- [ ] Fuzz targets compile
- [ ] NixOS integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)