### PR TITLE
Add OPA/Rego-gated filesystem access

### DIFF
--- a/.github/workflows/nixos-integration-test.yml
+++ b/.github/workflows/nixos-integration-test.yml
@@ -22,6 +22,8 @@ jobs:
             check: load-balancing-test
           - name: Fetch OPA Integration Test
             check: fetch-opa-test
+          - name: Filesystem OPA Integration Test
+            check: fs-opa-test
 
     steps:
       - name: Checkout code

--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,10 @@
             inherit pkgs;
             mcp-js = self.packages.x86_64-linux.default;
           });
+          fs-opa-test = pkgs.nixosTest (import ./tests/nixos/fs-opa.nix {
+            inherit pkgs;
+            mcp-js = self.packages.x86_64-linux.default;
+          });
         };
     };
 }

--- a/server/src/engine/fs.rs
+++ b/server/src/engine/fs.rs
@@ -1,0 +1,572 @@
+//! Policy-gated filesystem operations for the JavaScript runtime.
+//!
+//! Provides a Node.js-compatible `fs` API where every operation is evaluated
+//! against a [`PolicyChain`] before execution. The chain may contain local
+//! Rego files (via regorus) and/or remote OPA servers.
+//!
+//! Binary data is transferred directly as `Uint8Array` through deno_core's
+//! native `#[buffer]` support — no base64 encoding is needed.
+//!
+//! Available operations (all return Promises):
+//! ```js
+//! const data = await fs.readFile("/tmp/data.txt");          // string (utf-8)
+//! const data = await fs.readFile("/tmp/data.bin", "buffer"); // Uint8Array
+//! await fs.writeFile("/tmp/out.txt", "hello");              // string data
+//! await fs.writeFile("/tmp/out.bin", uint8array);           // binary data
+//! await fs.appendFile("/tmp/out.txt", " world");
+//! const entries = await fs.readdir("/tmp");                  // string[]
+//! const info = await fs.stat("/tmp/data.txt");               // {size,isFile,isDirectory,...}
+//! await fs.mkdir("/tmp/newdir", { recursive: true });
+//! await fs.rm("/tmp/data.txt");
+//! await fs.rm("/tmp/newdir", { recursive: true });
+//! await fs.rename("/tmp/old.txt", "/tmp/new.txt");
+//! await fs.copyFile("/tmp/a.txt", "/tmp/b.txt");
+//! const bool = await fs.exists("/tmp/data.txt");
+//! ```
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use deno_core::{JsRuntime, OpState, op2};
+use deno_error::JsErrorBox;
+use serde::Serialize;
+
+use super::opa::PolicyChain;
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+/// Configuration for the fs module. Stored in deno_core's `OpState`.
+#[derive(Clone, Debug)]
+pub struct FsConfig {
+    pub policy_chain: Arc<PolicyChain>,
+}
+
+impl FsConfig {
+    pub fn new(chain: Arc<PolicyChain>) -> Self {
+        Self { policy_chain: chain }
+    }
+}
+
+// ── Policy input ─────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct FsPolicyInput {
+    operation: String,
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    destination: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recursive: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding: Option<String>,
+}
+
+// ── Async deno_core ops ──────────────────────────────────────────────────
+
+/// Read a file as UTF-8 text.
+#[op2(async)]
+#[string]
+async fn op_fs_read_file_text(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "readFile", &path, None, None, Some("utf8")).await?;
+
+        let content = tokio::fs::read(&path).await
+            .map_err(|e| format!("fs.readFile: {}: {}", path, e))?;
+
+        String::from_utf8(content)
+            .map_err(|e| format!("fs.readFile: invalid UTF-8 in {}: {}", path, e))
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Read a file as raw bytes, returned as a Uint8Array to JavaScript.
+#[op2(async)]
+#[buffer]
+async fn op_fs_read_file_buffer(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+) -> Result<Vec<u8>, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "readFile", &path, None, None, Some("buffer")).await?;
+
+        tokio::fs::read(&path).await
+            .map_err(|e| format!("fs.readFile: {}: {}", path, e))
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Write a file from a UTF-8 string.
+#[op2(async)]
+#[string]
+async fn op_fs_write_file_text(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+    #[string] data: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "writeFile", &path, None, None, None).await?;
+
+        tokio::fs::write(&path, data.as_bytes()).await
+            .map_err(|e| format!("fs.writeFile: {}: {}", path, e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Write a file from raw bytes (Uint8Array from JavaScript).
+#[op2(async)]
+#[string]
+async fn op_fs_write_file_buffer(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+    #[buffer(copy)] data: Vec<u8>,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "writeFile", &path, None, None, None).await?;
+
+        tokio::fs::write(&path, &data).await
+            .map_err(|e| format!("fs.writeFile: {}: {}", path, e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Append to a file.
+#[op2(async)]
+#[string]
+async fn op_fs_append_file(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+    #[string] data: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "appendFile", &path, None, None, None).await?;
+
+        use tokio::io::AsyncWriteExt;
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await
+            .map_err(|e| format!("fs.appendFile: {}: {}", path, e))?;
+
+        file.write_all(data.as_bytes()).await
+            .map_err(|e| format!("fs.appendFile: {}: {}", path, e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Read a directory. Returns JSON array of entry names.
+#[op2(async)]
+#[string]
+async fn op_fs_readdir(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "readdir", &path, None, None, None).await?;
+
+        let mut entries = Vec::new();
+        let mut dir = tokio::fs::read_dir(&path).await
+            .map_err(|e| format!("fs.readdir: {}: {}", path, e))?;
+
+        while let Some(entry) = dir.next_entry().await
+            .map_err(|e| format!("fs.readdir: {}: {}", path, e))? {
+            if let Some(name) = entry.file_name().to_str() {
+                entries.push(name.to_string());
+            }
+        }
+
+        let result = deno_core::serde_json::json!(entries);
+        Ok(result.to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Stat a path. Returns JSON with size, isFile, isDirectory, etc.
+#[op2(async)]
+#[string]
+async fn op_fs_stat(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "stat", &path, None, None, None).await?;
+
+        let metadata = tokio::fs::metadata(&path).await
+            .map_err(|e| format!("fs.stat: {}: {}", path, e))?;
+
+        let modified = metadata.modified().ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as f64);
+        let accessed = metadata.accessed().ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as f64);
+        let created = metadata.created().ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as f64);
+
+        let result = deno_core::serde_json::json!({
+            "size": metadata.len(),
+            "isFile": metadata.is_file(),
+            "isDirectory": metadata.is_dir(),
+            "isSymlink": metadata.file_type().is_symlink(),
+            "readonly": metadata.permissions().readonly(),
+            "mtimeMs": modified,
+            "atimeMs": accessed,
+            "birthtimeMs": created,
+        });
+
+        Ok(result.to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Create a directory.
+#[op2(async)]
+#[string]
+async fn op_fs_mkdir(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+    #[smi] recursive: i32,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+    let recursive = recursive != 0;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "mkdir", &path, None, Some(recursive), None).await?;
+
+        if recursive {
+            tokio::fs::create_dir_all(&path).await
+        } else {
+            tokio::fs::create_dir(&path).await
+        }.map_err(|e| format!("fs.mkdir: {}: {}", path, e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Remove a file or directory.
+#[op2(async)]
+#[string]
+async fn op_fs_rm(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+    #[smi] recursive: i32,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+    let recursive = recursive != 0;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "rm", &path, None, Some(recursive), None).await?;
+
+        let metadata = tokio::fs::metadata(&path).await
+            .map_err(|e| format!("fs.rm: {}: {}", path, e))?;
+
+        if metadata.is_dir() {
+            if recursive {
+                tokio::fs::remove_dir_all(&path).await
+            } else {
+                tokio::fs::remove_dir(&path).await
+            }
+        } else {
+            tokio::fs::remove_file(&path).await
+        }.map_err(|e| format!("fs.rm: {}: {}", path, e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Rename (move) a file or directory.
+#[op2(async)]
+#[string]
+async fn op_fs_rename(
+    state: Rc<RefCell<OpState>>,
+    #[string] from: String,
+    #[string] to: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "rename", &from, Some(&to), None, None).await?;
+
+        tokio::fs::rename(&from, &to).await
+            .map_err(|e| format!("fs.rename: {} -> {}: {}", from, to, e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Copy a file.
+#[op2(async)]
+#[string]
+async fn op_fs_copy_file(
+    state: Rc<RefCell<OpState>>,
+    #[string] from: String,
+    #[string] to: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "copyFile", &from, Some(&to), None, None).await?;
+
+        tokio::fs::copy(&from, &to).await
+            .map_err(|e| format!("fs.copyFile: {} -> {}: {}", from, to, e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Check if a path exists.
+#[op2(async)]
+#[string]
+async fn op_fs_exists(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        check_policy(&policy_chain, "exists", &path, None, None, None).await?;
+
+        let exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
+        Ok(if exists { "true" } else { "false" }.to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+// ── Extension registration ──────────────────────────────────────────────
+
+deno_core::extension!(
+    fs_ext,
+    ops = [
+        op_fs_read_file_text,
+        op_fs_read_file_buffer,
+        op_fs_write_file_text,
+        op_fs_write_file_buffer,
+        op_fs_append_file,
+        op_fs_readdir,
+        op_fs_stat,
+        op_fs_mkdir,
+        op_fs_rm,
+        op_fs_rename,
+        op_fs_copy_file,
+        op_fs_exists,
+    ],
+);
+
+pub fn create_extension() -> deno_core::Extension {
+    fs_ext::init()
+}
+
+// ── Inject fs JS wrapper into the global scope ──────────────────────────
+
+pub fn inject_fs(runtime: &mut JsRuntime) -> Result<(), String> {
+    runtime
+        .execute_script("<fs-setup>", FS_JS_WRAPPER.to_string())
+        .map_err(|e| format!("Failed to install fs wrapper: {}", e))?;
+    Ok(())
+}
+
+const FS_JS_WRAPPER: &str = r#"
+(function() {
+    globalThis.fs = {
+        readFile: async function(path, encoding) {
+            if (typeof path !== 'string') throw new TypeError('fs.readFile: path must be a string');
+            if (encoding === 'buffer') {
+                return await Deno.core.ops.op_fs_read_file_buffer(path);
+            }
+            return await Deno.core.ops.op_fs_read_file_text(path);
+        },
+
+        writeFile: async function(path, data) {
+            if (typeof path !== 'string') throw new TypeError('fs.writeFile: path must be a string');
+            if (data instanceof Uint8Array) {
+                await Deno.core.ops.op_fs_write_file_buffer(path, data);
+            } else {
+                await Deno.core.ops.op_fs_write_file_text(path, String(data));
+            }
+        },
+
+        appendFile: async function(path, data) {
+            if (typeof path !== 'string') throw new TypeError('fs.appendFile: path must be a string');
+            await Deno.core.ops.op_fs_append_file(path, String(data));
+        },
+
+        readdir: async function(path) {
+            if (typeof path !== 'string') throw new TypeError('fs.readdir: path must be a string');
+            const raw = await Deno.core.ops.op_fs_readdir(path);
+            return JSON.parse(raw);
+        },
+
+        stat: async function(path) {
+            if (typeof path !== 'string') throw new TypeError('fs.stat: path must be a string');
+            const raw = await Deno.core.ops.op_fs_stat(path);
+            return JSON.parse(raw);
+        },
+
+        mkdir: async function(path, options) {
+            if (typeof path !== 'string') throw new TypeError('fs.mkdir: path must be a string');
+            const recursive = (options && options.recursive) ? 1 : 0;
+            await Deno.core.ops.op_fs_mkdir(path, recursive);
+        },
+
+        rm: async function(path, options) {
+            if (typeof path !== 'string') throw new TypeError('fs.rm: path must be a string');
+            const recursive = (options && options.recursive) ? 1 : 0;
+            await Deno.core.ops.op_fs_rm(path, recursive);
+        },
+
+        unlink: async function(path) {
+            if (typeof path !== 'string') throw new TypeError('fs.unlink: path must be a string');
+            await Deno.core.ops.op_fs_rm(path, 0);
+        },
+
+        rename: async function(oldPath, newPath) {
+            if (typeof oldPath !== 'string') throw new TypeError('fs.rename: oldPath must be a string');
+            if (typeof newPath !== 'string') throw new TypeError('fs.rename: newPath must be a string');
+            await Deno.core.ops.op_fs_rename(oldPath, newPath);
+        },
+
+        copyFile: async function(src, dest) {
+            if (typeof src !== 'string') throw new TypeError('fs.copyFile: src must be a string');
+            if (typeof dest !== 'string') throw new TypeError('fs.copyFile: dest must be a string');
+            await Deno.core.ops.op_fs_copy_file(src, dest);
+        },
+
+        exists: async function(path) {
+            if (typeof path !== 'string') throw new TypeError('fs.exists: path must be a string');
+            const raw = await Deno.core.ops.op_fs_exists(path);
+            return raw === 'true';
+        },
+    };
+})();
+"#;
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn extract_chain(state: &Rc<RefCell<OpState>>) -> Result<Arc<PolicyChain>, JsErrorBox> {
+    let state = state.borrow();
+    let config = state.try_borrow::<FsConfig>()
+        .ok_or_else(|| JsErrorBox::generic("fs: internal error — no fs config available"))?;
+    Ok(config.policy_chain.clone())
+}
+
+async fn check_policy(
+    policy_chain: &PolicyChain,
+    operation: &str,
+    path: &str,
+    destination: Option<&str>,
+    recursive: Option<bool>,
+    encoding: Option<&str>,
+) -> Result<(), String> {
+    let input = FsPolicyInput {
+        operation: operation.to_string(),
+        path: path.to_string(),
+        destination: destination.map(|s| s.to_string()),
+        recursive,
+        encoding: encoding.map(|s| s.to_string()),
+    };
+
+    let input_value = serde_json::to_value(&input)
+        .map_err(|e| format!("fs.{}: failed to serialize policy input: {}", operation, e))?;
+
+    let allowed = policy_chain
+        .evaluate(&input_value)
+        .await
+        .map_err(|e| format!("fs.{}: policy error: {}", operation, e))?;
+
+    if !allowed {
+        return Err(format!(
+            "fs.{} denied by policy: {} is not allowed",
+            operation, path
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fs_policy_input_serialization() {
+        let input = FsPolicyInput {
+            operation: "readFile".to_string(),
+            path: "/tmp/test.txt".to_string(),
+            destination: None,
+            recursive: None,
+            encoding: Some("utf8".to_string()),
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        assert!(json.contains("\"operation\":\"readFile\""));
+        assert!(json.contains("\"path\":\"/tmp/test.txt\""));
+        assert!(json.contains("\"encoding\":\"utf8\""));
+        assert!(!json.contains("destination"));
+        assert!(!json.contains("recursive"));
+    }
+
+    #[test]
+    fn test_fs_policy_input_with_destination() {
+        let input = FsPolicyInput {
+            operation: "rename".to_string(),
+            path: "/tmp/old.txt".to_string(),
+            destination: Some("/tmp/new.txt".to_string()),
+            recursive: None,
+            encoding: None,
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        assert!(json.contains("\"destination\":\"/tmp/new.txt\""));
+    }
+}

--- a/server/src/engine/opa.rs
+++ b/server/src/engine/opa.rs
@@ -263,6 +263,8 @@ pub struct PoliciesConfig {
     pub fetch: Option<OperationPolicies>,
     /// Policy chain for module import auditing.
     pub modules: Option<OperationPolicies>,
+    /// Policy chain for filesystem operations.
+    pub filesystem: Option<OperationPolicies>,
 }
 
 /// Per-operation policy configuration.

--- a/tests/nixos/fs-opa.nix
+++ b/tests/nixos/fs-opa.nix
@@ -29,7 +29,7 @@ in
   name = "mcp-js-fs-opa";
 
   nodes = {
-    machine = { ... }: {
+    machine = { lib, ... }: {
       imports = [ ../../nix/module.nix ];
 
       # ── mcp-js server (stateless, with filesystem policy) ────────────
@@ -47,6 +47,10 @@ in
           };
         };
       };
+
+      # DynamicUser implies PrivateTmp; disable it so the service sees
+      # the /tmp/allowed directory the test script creates.
+      systemd.services.mcp-js.serviceConfig.PrivateTmp = lib.mkForce false;
 
       networking.firewall.allowedTCPPorts = [ 3000 ];
     };

--- a/tests/nixos/fs-opa.nix
+++ b/tests/nixos/fs-opa.nix
@@ -1,0 +1,257 @@
+{ pkgs, mcp-js, ... }:
+
+let
+  # ── Rego policy ──────────────────────────────────────────────────────
+  #
+  # Allow read/write/stat/exists/readdir operations only under /tmp/allowed/.
+  # mkdir is allowed under /tmp/allowed/ (recursive or not).
+  # rm, rename, copyFile, appendFile are allowed under /tmp/allowed/.
+  # Everything else is denied.
+
+  regoPolicy = pkgs.writeText "fs-policy.rego" ''
+    package mcp.filesystem
+
+    default allow = false
+
+    allow if {
+        startswith(input.path, "/tmp/allowed/")
+    }
+
+    # Also allow operations with a destination under /tmp/allowed/
+    allow if {
+        startswith(input.path, "/tmp/allowed/")
+        startswith(input.destination, "/tmp/allowed/")
+    }
+  '';
+in
+
+{
+  name = "mcp-js-fs-opa";
+
+  nodes = {
+    machine = { ... }: {
+      imports = [ ../../nix/module.nix ];
+
+      # ── mcp-js server (stateless, with filesystem policy) ────────────
+      services.mcp-js = {
+        enable = true;
+        package = mcp-js;
+        nodeId = "test";
+        stateless = true;
+        httpPort = 3000;
+        policiesJson = builtins.toJSON {
+          filesystem = {
+            policies = [{
+              url = "file://${regoPolicy}";
+            }];
+          };
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [ 3000 ];
+    };
+  };
+
+  testScript = ''
+    import json
+    import shlex
+    import time
+
+    machine.start()
+    machine.wait_for_unit("mcp-js.service")
+    machine.wait_for_open_port(3000)
+
+    # Create the allowed directory
+    machine.succeed("mkdir -p /tmp/allowed")
+
+    def exec_js(code):
+        """Execute JS code via mcp-js async /api/exec endpoint and return parsed response."""
+        body = json.dumps({"code": code})
+        raw = machine.succeed(
+            "curl -s -X POST http://localhost:3000/api/exec "
+            "-H 'Content-Type: application/json' "
+            "-d " + shlex.quote(body)
+        )
+        submit_resp = json.loads(raw)
+        exec_id = submit_resp["execution_id"]
+
+        for _ in range(60):
+            status_raw = machine.succeed(
+                "curl -s http://localhost:3000/api/executions/" + exec_id
+            )
+            status_resp = json.loads(status_raw)
+            status = status_resp.get("status", "")
+            if status in ("Completed", "completed"):
+                return {"output": status_resp.get("result", "")}
+            if status in ("Failed", "failed", "TimedOut", "Cancelled"):
+                return {"output": "Error: " + status_resp.get("error", status)}
+            time.sleep(0.5)
+
+        raise Exception("Execution " + exec_id + " did not complete within 30s")
+
+    # ── Test 1: Write and read a file in allowed directory ────────────
+
+    with subtest("should allow writeFile and readFile in /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/allowed/test.txt", "hello world");
+                const data = await fs.readFile("/tmp/allowed/test.txt");
+                return data;
+            })()
+        """)
+        print("Write+Read result: " + str(result))
+        assert result["output"] == "hello world", "Expected 'hello world', got: " + str(result)
+
+    # ── Test 2: Deny write to non-allowed directory ──────────────────
+
+    with subtest("should deny writeFile outside /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                try {
+                    await fs.writeFile("/tmp/secret.txt", "bad data");
+                    return "no error";
+                } catch(e) { return e.message; }
+            })()
+        """)
+        print("Denied write result: " + str(result))
+        assert "denied by policy" in result["output"], \
+            "Expected denied by policy error, got: " + str(result)
+
+    # ── Test 3: Deny read from non-allowed directory ─────────────────
+
+    with subtest("should deny readFile outside /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                try {
+                    const data = await fs.readFile("/etc/hostname");
+                    return "no error: " + data;
+                } catch(e) { return e.message; }
+            })()
+        """)
+        print("Denied read result: " + str(result))
+        assert "denied by policy" in result["output"], \
+            "Expected denied by policy error, got: " + str(result)
+
+    # ── Test 4: stat in allowed directory ─────────────────────────────
+
+    with subtest("should allow stat in /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                const info = await fs.stat("/tmp/allowed/test.txt");
+                return JSON.stringify({isFile: info.isFile, size: info.size});
+            })()
+        """)
+        print("Stat result: " + str(result))
+        body = json.loads(result["output"])
+        assert body["isFile"] == True, "Expected isFile=true, got: " + str(body)
+        assert body["size"] == 11, "Expected size=11, got: " + str(body)
+
+    # ── Test 5: exists in allowed directory ───────────────────────────
+
+    with subtest("should allow exists in /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                const e1 = await fs.exists("/tmp/allowed/test.txt");
+                const e2 = await fs.exists("/tmp/allowed/nonexistent.txt");
+                return JSON.stringify({exists: e1, notExists: e2});
+            })()
+        """)
+        print("Exists result: " + str(result))
+        body = json.loads(result["output"])
+        assert body["exists"] == True, "Expected exists=true, got: " + str(body)
+        assert body["notExists"] == False, "Expected notExists=false, got: " + str(body)
+
+    # ── Test 6: mkdir and readdir ─────────────────────────────────────
+
+    with subtest("should allow mkdir and readdir in /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                await fs.mkdir("/tmp/allowed/subdir", {recursive: true});
+                await fs.writeFile("/tmp/allowed/subdir/a.txt", "a");
+                await fs.writeFile("/tmp/allowed/subdir/b.txt", "b");
+                const entries = await fs.readdir("/tmp/allowed/subdir");
+                entries.sort();
+                return JSON.stringify(entries);
+            })()
+        """)
+        print("mkdir+readdir result: " + str(result))
+        entries = json.loads(result["output"])
+        assert entries == ["a.txt", "b.txt"], "Expected ['a.txt', 'b.txt'], got: " + str(entries)
+
+    # ── Test 7: appendFile ────────────────────────────────────────────
+
+    with subtest("should allow appendFile in /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/allowed/append.txt", "hello");
+                await fs.appendFile("/tmp/allowed/append.txt", " world");
+                return await fs.readFile("/tmp/allowed/append.txt");
+            })()
+        """)
+        print("appendFile result: " + str(result))
+        assert result["output"] == "hello world", "Expected 'hello world', got: " + str(result)
+
+    # ── Test 8: rename ────────────────────────────────────────────────
+
+    with subtest("should allow rename within /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/allowed/old.txt", "renamed");
+                await fs.rename("/tmp/allowed/old.txt", "/tmp/allowed/new.txt");
+                return await fs.readFile("/tmp/allowed/new.txt");
+            })()
+        """)
+        print("Rename result: " + str(result))
+        assert result["output"] == "renamed", "Expected 'renamed', got: " + str(result)
+
+    # ── Test 9: copyFile ──────────────────────────────────────────────
+
+    with subtest("should allow copyFile within /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/allowed/src.txt", "copied");
+                await fs.copyFile("/tmp/allowed/src.txt", "/tmp/allowed/dst.txt");
+                return await fs.readFile("/tmp/allowed/dst.txt");
+            })()
+        """)
+        print("CopyFile result: " + str(result))
+        assert result["output"] == "copied", "Expected 'copied', got: " + str(result)
+
+    # ── Test 10: rm ───────────────────────────────────────────────────
+
+    with subtest("should allow rm in /tmp/allowed/"):
+        result = exec_js("""
+            (async () => {
+                await fs.writeFile("/tmp/allowed/del.txt", "delete me");
+                await fs.rm("/tmp/allowed/del.txt");
+                const exists = await fs.exists("/tmp/allowed/del.txt");
+                return JSON.stringify({deleted: !exists});
+            })()
+        """)
+        print("rm result: " + str(result))
+        body = json.loads(result["output"])
+        assert body["deleted"] == True, "Expected deleted=true, got: " + str(body)
+
+    # ── Test 11: fs object is available ───────────────────────────────
+
+    with subtest("should have fs available when filesystem policy is configured"):
+        result = exec_js("typeof fs")
+        print("typeof fs: " + str(result))
+        assert result["output"] == "object", "Expected object, got: " + str(result)
+
+    # ── Test 12: binary write/read with Uint8Array ────────────────────
+
+    with subtest("should support binary write/read with Uint8Array"):
+        result = exec_js("""
+            (async () => {
+                const data = new Uint8Array([72, 101, 108, 108, 111]);
+                await fs.writeFile("/tmp/allowed/binary.bin", data);
+                const read = await fs.readFile("/tmp/allowed/binary.bin", "buffer");
+                return JSON.stringify(Array.from(read));
+            })()
+        """)
+        print("Binary write/read result: " + str(result))
+        arr = json.loads(result["output"])
+        assert arr == [72, 101, 108, 108, 111], "Expected [72,101,108,108,111], got: " + str(arr)
+  '';
+}

--- a/tests/nixos/fs-opa.nix
+++ b/tests/nixos/fs-opa.nix
@@ -29,7 +29,7 @@ in
   name = "mcp-js-fs-opa";
 
   nodes = {
-    machine = { lib, ... }: {
+    machine = { ... }: {
       imports = [ ../../nix/module.nix ];
 
       # ── mcp-js server (stateless, with filesystem policy) ────────────
@@ -48,10 +48,6 @@ in
         };
       };
 
-      # DynamicUser implies PrivateTmp; disable it so the service sees
-      # the /tmp/allowed directory the test script creates.
-      systemd.services.mcp-js.serviceConfig.PrivateTmp = lib.mkForce false;
-
       networking.firewall.allowedTCPPorts = [ 3000 ];
     };
   };
@@ -64,9 +60,6 @@ in
     machine.start()
     machine.wait_for_unit("mcp-js.service")
     machine.wait_for_open_port(3000)
-
-    # Create the allowed directory
-    machine.succeed("mkdir -p /tmp/allowed")
 
     def exec_js(code):
         """Execute JS code via mcp-js async /api/exec endpoint and return parsed response."""
@@ -92,6 +85,11 @@ in
             time.sleep(0.5)
 
         raise Exception("Execution " + exec_id + " did not complete within 30s")
+
+    # Create the allowed directory inside the service's private /tmp
+    # (DynamicUser=true implies PrivateTmp, so shell mkdir is invisible to the service)
+    setup = exec_js('(async () => { await fs.mkdir("/tmp/allowed/", {recursive: true}); return "ok"; })()')
+    assert setup["output"] == "ok", "Failed to create /tmp/allowed: " + str(setup)
 
     # ── Test 1: Write and read a file in allowed directory ────────────
 


### PR DESCRIPTION
## Summary
- Adds policy-gated `fs` API (Node.js-compatible) with 12 operations: readFile, writeFile, appendFile, readdir, stat, mkdir, rm, rename, copyFile, exists (text + binary)
- Uses `PolicyChain` architecture (local Rego via regorus + remote OPA) configured through `--policies-json` `filesystem` key
- All async ops spawn on separate tokio tasks to avoid deno_core `RefCell` re-entrancy panics
- Includes NixOS integration test (`fs-opa-test`) with 12 subtests covering all operations and policy denial

## Changes
- **`server/src/engine/fs.rs`** (new): Complete fs module with policy-gated ops, deno_core extension, JS wrapper
- **`server/src/engine/mod.rs`**: Wire `fs_config` into `ExecutionConfig`, `execute_stateless`, `execute_stateful`, and `Engine`
- **`server/src/engine/opa.rs`**: Add `filesystem` field to `PoliciesConfig`
- **`server/src/main.rs`**: Build filesystem policy chain from `--policies-json` and wire to engine
- **`tests/nixos/fs-opa.nix`** (new): NixOS integration test with local Rego policy
- **`flake.nix`**: Register `fs-opa-test` check
- **`.github/workflows/nixos-integration-test.yml`**: Add Filesystem OPA Integration Test to CI matrix

## Test plan
- [x] `cargo check` passes with no errors
- [x] Unit tests pass (fs serialization + opa policy chain tests)
- [ ] NixOS integration test (`nix build .#checks.x86_64-linux.fs-opa-test`) — runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)