### PR TITLE
Update smoke test to verify console output instead of result

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -186,7 +186,7 @@ jobs:
           echo "=== Smoke test: POST /api/exec on ${URL} ==="
           RESP=$(curl -s --max-time 10 -X POST "${URL}/api/exec" \
             -H 'Content-Type: application/json' \
-            -d '{"code":"1 + 1"}')
+            -d '{"code":"console.log(\"smoke test passed\")"}')
           echo "Response: $RESP"
 
           if [ -z "$RESP" ]; then
@@ -211,10 +211,13 @@ jobs:
             STATUS=$(echo "$STATUS_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
             if [ "$STATUS" = "Completed" ] || [ "$STATUS" = "completed" ]; then
               echo "Execution completed"
-              RESULT=$(echo "$STATUS_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))" 2>/dev/null || true)
-              echo "Result: $RESULT"
-              if [ "$RESULT" != "2" ]; then
-                echo "ERROR: Expected result '2', got '${RESULT}'"
+
+              # Check console output to verify code executed
+              OUTPUT_RESP=$(curl -s --max-time 10 "${URL}/api/executions/${EXEC_ID}/output" 2>/dev/null)
+              OUTPUT=$(echo "$OUTPUT_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('data',''))" 2>/dev/null || true)
+              echo "Console output: $OUTPUT"
+              if [[ "$OUTPUT" != *"smoke test passed"* ]]; then
+                echo "ERROR: Expected console output containing 'smoke test passed', got '${OUTPUT}'"
                 cat /tmp/loadtest/*.log || true
                 exit 1
               fi


### PR DESCRIPTION
## Summary
Modified the load test smoke test to validate code execution by checking console output instead of relying on a numeric result value. This change makes the test more robust and better aligned with how the execution API actually works.

## Key Changes
- Changed the smoke test code from `"1 + 1"` to `console.log("smoke test passed")` to produce verifiable console output
- Updated the test validation logic to:
  - Fetch console output from the `/api/executions/{id}/output` endpoint instead of checking the `result` field
  - Verify that the output contains the expected string `"smoke test passed"`
  - Provide clearer error messaging when validation fails

## Implementation Details
- The test now makes an additional API call to retrieve execution output after completion
- Uses JSON parsing to extract the `data` field from the output response
- Implements string matching with bash pattern matching (`[[ ... != *...* ]]`) for more flexible output validation
- Maintains the same timeout and error handling patterns as the original implementation

https://claude.ai/code/session_01TmtpWRE3kmD68sxkVmiYj9