### PR TITLE
Add OPA policy support for MCP tool calls

### DIFF
--- a/policies/mcp_tools.rego
+++ b/policies/mcp_tools.rego
@@ -1,0 +1,37 @@
+package mcp.tools
+
+default allow = false
+
+# Allow specific server + tool combinations.
+# Input schema:
+#   {
+#     "operation": "mcp_call_tool",
+#     "server":    "server-name",
+#     "tool":      "tool-name",
+#     "arguments": { ... } or null
+#   }
+
+# ── Allowed server/tool pairs ────────────────────────────────────────────
+# Add entries as {"server": "<name>", "tool": "<name>"} objects.
+# Use "*" as tool name to allow all tools on a server.
+
+allowed_tools := {
+    # Example: allow all tools on a server named "math"
+    # {"server": "math", "tool": "*"},
+    # Example: allow a specific tool on a specific server
+    # {"server": "db", "tool": "query"},
+}
+
+# Exact server + tool match
+allow if {
+    some entry in allowed_tools
+    entry.server == input.server
+    entry.tool == input.tool
+}
+
+# Wildcard: allow all tools on a server
+allow if {
+    some entry in allowed_tools
+    entry.server == input.server
+    entry.tool == "*"
+}

--- a/server/src/engine/mcp_client.rs
+++ b/server/src/engine/mcp_client.rs
@@ -273,9 +273,20 @@ async fn connect_one(config: &McpServerConfig) -> Result<ConnectedMcpServer, Str
 #[derive(Clone)]
 pub struct McpConfig {
     pub client_manager: McpClientManager,
+    /// Optional OPA policy chain for gating `mcp.callTool()` calls.
+    pub policy_chain: Option<std::sync::Arc<super::opa::PolicyChain>>,
 }
 
 // ── Deno ops ─────────────────────────────────────────────────────────────
+
+/// OPA policy input for MCP tool calls.
+#[derive(Serialize)]
+struct McpToolPolicyInput {
+    operation: &'static str,
+    server: String,
+    tool: String,
+    arguments: serde_json::Value,
+}
 
 /// Async op: call an MCP tool. Spawned on a separate tokio task to avoid
 /// RefCell re-entrancy issues (same pattern as op_fetch).
@@ -287,12 +298,12 @@ async fn op_mcp_call_tool(
     #[string] tool_name: String,
     #[string] arguments_json: String,
 ) -> Result<String, JsErrorBox> {
-    let manager = {
+    let (manager, policy_chain) = {
         let state = state.borrow();
         let config = state
             .try_borrow::<McpConfig>()
             .ok_or_else(|| JsErrorBox::generic("mcp: internal error — no MCP config available"))?;
-        config.client_manager.clone()
+        (config.client_manager.clone(), config.policy_chain.clone())
     };
 
     let arguments: Option<serde_json::Map<String, serde_json::Value>> =
@@ -309,6 +320,29 @@ async fn op_mcp_call_tool(
     // Spawn on separate tokio task (same pattern as fetch) to avoid
     // RefCell re-entrancy panic in deno_core's FuturesUnorderedDriver.
     tokio::spawn(async move {
+        // Evaluate OPA policy if configured.
+        if let Some(ref chain) = policy_chain {
+            let policy_input = McpToolPolicyInput {
+                operation: "mcp_call_tool",
+                server: server_name.clone(),
+                tool: tool_name.clone(),
+                arguments: arguments
+                    .as_ref()
+                    .map(|a| serde_json::Value::Object(a.clone()))
+                    .unwrap_or(serde_json::Value::Null),
+            };
+            let input_value = serde_json::to_value(&policy_input)
+                .map_err(|e| JsErrorBox::generic(format!("mcp.callTool: failed to serialize policy input: {}", e)))?;
+            let allowed = chain.evaluate(&input_value).await
+                .map_err(|e| JsErrorBox::generic(format!("mcp.callTool: policy evaluation error: {}", e)))?;
+            if !allowed {
+                return Err(JsErrorBox::generic(format!(
+                    "mcp.callTool denied by policy: {}.{} is not allowed",
+                    server_name, tool_name
+                )));
+            }
+        }
+
         let result = manager
             .call_tool(&server_name, &tool_name, arguments)
             .await

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -1077,6 +1077,8 @@ pub struct Engine {
     module_loader_config: Arc<module_loader::ModuleLoaderConfig>,
     /// MCP client manager for programmatic tool calling from JS.
     mcp_client_manager: Option<Arc<mcp_client::McpClientManager>>,
+    /// OPA policy chain for MCP tool calls (`mcp.callTool()`).
+    mcp_tools_policy_chain: Option<Arc<opa::PolicyChain>>,
 }
 
 impl Engine {
@@ -1103,6 +1105,7 @@ impl Engine {
                 policy_chain: None,
             }),
             mcp_client_manager: None,
+            mcp_tools_policy_chain: None,
         }
     }
 
@@ -1132,6 +1135,7 @@ impl Engine {
                 policy_chain: None,
             }),
             mcp_client_manager: None,
+            mcp_tools_policy_chain: None,
         }
     }
 
@@ -1174,6 +1178,12 @@ impl Engine {
     /// Enable MCP client tool calling from the JS runtime.
     pub fn with_mcp_client_manager(mut self, manager: mcp_client::McpClientManager) -> Self {
         self.mcp_client_manager = Some(Arc::new(manager));
+        self
+    }
+
+    /// Set OPA policy chain for MCP tool calls (`mcp.callTool()`).
+    pub fn with_mcp_tools_policy_chain(mut self, chain: Arc<opa::PolicyChain>) -> Self {
+        self.mcp_tools_policy_chain = Some(chain);
         self
     }
 
@@ -1270,7 +1280,7 @@ impl Engine {
                 let fsc = self.fs_config.clone();
                 let ct = console_tree;
                 let mlc = self.module_loader_config.clone();
-                let mc = self.mcp_client_manager.as_ref().map(|m| mcp_client::McpConfig { client_manager: (**m).clone() });
+                let mc = self.mcp_client_manager.as_ref().map(|m| mcp_client::McpConfig { client_manager: (**m).clone(), policy_chain: self.mcp_tools_policy_chain.clone() });
                 let mut join_handle = tokio::task::spawn_blocking(move || {
                     execute_stateless(&code, ExecutionConfig::new(max_bytes)
                         .isolate_handle(ih)
@@ -1332,7 +1342,7 @@ impl Engine {
                 let fsc = self.fs_config.clone();
                 let ct = console_tree;
                 let mlc = self.module_loader_config.clone();
-                let mc = self.mcp_client_manager.as_ref().map(|m| mcp_client::McpConfig { client_manager: (**m).clone() });
+                let mc = self.mcp_client_manager.as_ref().map(|m| mcp_client::McpConfig { client_manager: (**m).clone(), policy_chain: self.mcp_tools_policy_chain.clone() });
 
                 let snap_mutex = self.snapshot_mutex.clone();
                 let mut join_handle = tokio::task::spawn_blocking(move || {

--- a/server/src/engine/opa.rs
+++ b/server/src/engine/opa.rs
@@ -265,6 +265,8 @@ pub struct PoliciesConfig {
     pub modules: Option<OperationPolicies>,
     /// Policy chain for filesystem operations.
     pub filesystem: Option<OperationPolicies>,
+    /// Policy chain for MCP tool calls (`mcp.callTool()`).
+    pub mcp_tools: Option<OperationPolicies>,
 }
 
 /// Per-operation policy configuration.
@@ -628,6 +630,27 @@ allow if { input.admin == true }
         let fetch = config.fetch.unwrap();
         assert_eq!(fetch.mode, EvalMode::All); // default
         assert!(config.modules.is_none());
+        assert!(config.mcp_tools.is_none());
+    }
+
+    #[test]
+    fn test_policies_config_mcp_tools() {
+        let json = r#"{
+            "mcp_tools": {
+                "mode": "all",
+                "policies": [
+                    {"url": "file:///etc/policies/mcp_tools.rego", "rule": "data.mcp.tools.allow"}
+                ]
+            }
+        }"#;
+        let config: PoliciesConfig = serde_json::from_str(json).unwrap();
+        assert!(config.fetch.is_none());
+        assert!(config.modules.is_none());
+        assert!(config.filesystem.is_none());
+        let mcp_tools = config.mcp_tools.unwrap();
+        assert_eq!(mcp_tools.mode, EvalMode::All);
+        assert_eq!(mcp_tools.policies.len(), 1);
+        assert_eq!(mcp_tools.policies[0].rule.as_deref(), Some("data.mcp.tools.allow"));
     }
 
     // ── Integration: local rego through build_policy_chain + evaluate ────
@@ -652,5 +675,105 @@ allow if { input.admin == true }
 
         let post_input = serde_json::json!({"method": "POST", "url": "https://example.com"});
         assert!(!chain.evaluate(&post_input).await.unwrap());
+    }
+
+    // ── MCP tools policy tests ────────────────────────────────────────────
+
+    fn mcp_tools_rego() -> &'static str {
+        r#"
+package mcp.tools
+
+default allow = false
+
+allow if {
+    input.server == "math"
+    input.tool == "add"
+}
+
+allow if {
+    input.server == "utils"
+}
+"#
+    }
+
+    #[tokio::test]
+    async fn test_mcp_tools_policy_allow() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_rego_file(dir.path(), "mcp_tools.rego", mcp_tools_rego());
+
+        let op = OperationPolicies {
+            mode: EvalMode::All,
+            policies: vec![PolicySource {
+                url: format!("file://{}", path.display()),
+                policy_path: None,
+                rule: None,
+            }],
+        };
+        let chain = build_policy_chain(&op, "mcp/tools", "data.mcp.tools.allow").unwrap();
+
+        // Allowed: math.add
+        let input = serde_json::json!({
+            "operation": "mcp_call_tool",
+            "server": "math",
+            "tool": "add",
+            "arguments": {"a": 1, "b": 2}
+        });
+        assert!(chain.evaluate(&input).await.unwrap());
+
+        // Allowed: any tool on "utils" server
+        let input = serde_json::json!({
+            "operation": "mcp_call_tool",
+            "server": "utils",
+            "tool": "anything",
+            "arguments": null
+        });
+        assert!(chain.evaluate(&input).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_tools_policy_deny() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_rego_file(dir.path(), "mcp_tools.rego", mcp_tools_rego());
+
+        let op = OperationPolicies {
+            mode: EvalMode::All,
+            policies: vec![PolicySource {
+                url: format!("file://{}", path.display()),
+                policy_path: None,
+                rule: None,
+            }],
+        };
+        let chain = build_policy_chain(&op, "mcp/tools", "data.mcp.tools.allow").unwrap();
+
+        // Denied: math.subtract (only math.add is allowed)
+        let input = serde_json::json!({
+            "operation": "mcp_call_tool",
+            "server": "math",
+            "tool": "subtract",
+            "arguments": {"a": 5, "b": 3}
+        });
+        assert!(!chain.evaluate(&input).await.unwrap());
+
+        // Denied: unknown server
+        let input = serde_json::json!({
+            "operation": "mcp_call_tool",
+            "server": "secret",
+            "tool": "get_password",
+            "arguments": null
+        });
+        assert!(!chain.evaluate(&input).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_tools_policy_no_chain_allows_all() {
+        // Empty chain should allow all calls (permissive default).
+        let chain = PolicyChain::new(vec![], EvalMode::All);
+        let input = serde_json::json!({
+            "operation": "mcp_call_tool",
+            "server": "anything",
+            "tool": "whatever",
+            "arguments": null
+        });
+        assert!(chain.evaluate(&input).await.unwrap());
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -391,6 +391,19 @@ async fn main() -> Result<()> {
         None
     };
 
+    let mcp_tools_policy_chain = if let Some(ref config) = policies_config {
+        if let Some(ref mcp_tools_policies) = config.mcp_tools {
+            let chain = build_policy_chain(mcp_tools_policies, "mcp/tools", "data.mcp.tools.allow")
+                .map_err(|e| anyhow::anyhow!("Failed to build MCP tools policy chain: {}", e))?;
+            tracing::info!("MCP tools policy chain: {} evaluator(s), mode={:?}", mcp_tools_policies.policies.len(), mcp_tools_policies.mode);
+            Some(Arc::new(chain))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     // ── Fetch policy ───────────────────────────────────────────────────
     let header_rules = load_fetch_header_rules(&cli.fetch_headers, &cli.fetch_header_config)?;
     if !header_rules.is_empty() {
@@ -453,7 +466,13 @@ async fn main() -> Result<()> {
         let manager = engine::mcp_client::McpClientManager::connect(mcp_server_configs).await
             .map_err(|e| anyhow::anyhow!("MCP server connection failed: {}", e))?;
         tracing::info!("All MCP servers connected. JS code can use mcp.callTool(), mcp.listTools(), mcp.servers");
-        engine.with_mcp_client_manager(manager)
+        let engine = engine.with_mcp_client_manager(manager);
+        if let Some(chain) = mcp_tools_policy_chain {
+            tracing::info!("MCP tools policy: ENABLED");
+            engine.with_mcp_tools_policy_chain(chain)
+        } else {
+            engine
+        }
     } else {
         engine
     };


### PR DESCRIPTION
## Summary
This PR adds OPA (Open Policy Agent) policy evaluation support for MCP (Model Context Protocol) tool calls, allowing administrators to gate which MCP tools can be invoked through the `mcp.callTool()` JavaScript API.

## Key Changes

- **Policy Configuration**: Added `mcp_tools` field to `PoliciesConfig` struct to support optional OPA policy chains for MCP tool calls
- **Policy Evaluation**: Integrated policy evaluation into `op_mcp_call_tool()` operation, which now checks policies before executing tool calls
- **Engine Integration**: Extended `Engine` struct with `mcp_tools_policy_chain` field and added `with_mcp_tools_policy_chain()` builder method
- **MCP Config**: Updated `McpConfig` to carry the optional policy chain through to the Deno operation
- **Policy Input Schema**: Defined `McpToolPolicyInput` struct that provides server name, tool name, and arguments to the OPA policy evaluator
- **Example Policy**: Added `policies/mcp_tools.rego` template showing how to define allowed server/tool combinations with wildcard support
- **Comprehensive Tests**: Added unit tests for policy configuration parsing and integration tests for allow/deny scenarios

## Implementation Details

- Policy evaluation happens asynchronously before the actual tool call is made
- If a policy chain is configured and denies the call, a descriptive error is returned to the caller
- If no policy chain is configured, all tool calls are allowed (permissive default)
- The policy input includes the operation type ("mcp_call_tool"), server name, tool name, and arguments as JSON
- Policy chain building follows the same pattern as existing fetch and filesystem policies

https://claude.ai/code/session_015XWvwCr7gGyurAxgZSbLMJ