### PR TITLE
Add semantic versioning support to Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches:
       - main
@@ -33,6 +35,9 @@ jobs:
           tags: |
             type=sha,prefix=,format=short
             type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
Updated the Docker publish GitHub Actions workflow to support semantic versioning tags and generate corresponding Docker image tags based on git tags.

## Key Changes
- Added trigger for git tags matching the pattern `v*.*.*` to the workflow push events
- Extended Docker image tagging strategy to include semantic version patterns:
  - Full version tag (e.g., `v1.2.3`)
  - Major.minor version tag (e.g., `1.2`)
  - Major version tag (e.g., `1`)

## Implementation Details
The workflow now automatically builds and publishes Docker images when semantic version tags are pushed to the repository. The `docker/metadata-action` configuration was enhanced with three new `type=semver` patterns that extract and format version information from git tags, enabling more granular version tracking and easier version-specific image pulls.

https://claude.ai/code/session_01PoJrobhQYor1Ea7GaiVD75