### PR TITLE
Add OPA-gated subprocess execution APIs (Deno.Command and child_process.exec)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,10 @@
             inherit pkgs;
             mcp-js = self.packages.x86_64-linux.default;
           });
+          exec-opa-test = pkgs.nixosTest (import ./tests/nixos/exec-opa.nix {
+            inherit pkgs;
+            mcp-js = self.packages.x86_64-linux.default;
+          });
         };
     };
 }

--- a/policies/subprocess.rego
+++ b/policies/subprocess.rego
@@ -1,0 +1,54 @@
+package mcp.subprocess
+
+default allow = false
+
+# Subprocess policy for gating Deno.Command and child_process.exec.
+#
+# Input schema:
+#   {
+#     "operation": "command_output" | "command_spawn" | "exec",
+#     "command":   "/bin/sh" | "echo" | ...,
+#     "args":      ["-c", "ls -la"] | ["hello"] | ...,
+#     "cwd":       "/tmp" | null,
+#     "env":       {"KEY": "VALUE"} | null
+#   }
+
+# ── Allowed commands for Deno.Command (command_output) ─────────────────
+# Add command names to allow direct execution.
+
+allowed_commands := {
+    # Example: allow echo and cat
+    # "echo",
+    # "cat",
+    # "ls",
+}
+
+allow if {
+    input.operation == "command_output"
+    allowed_commands[input.command]
+}
+
+# ── Allowed shell commands for child_process.exec ──────────────────────
+# These patterns match the full command string passed to exec().
+# For exec(), input.command is the shell (/bin/sh) and
+# input.args[1] is the actual command string.
+
+allowed_exec_patterns := {
+    # Example: allow "echo" commands
+    # "echo",
+    # "ls",
+}
+
+allow if {
+    input.operation == "exec"
+    some pattern in allowed_exec_patterns
+    startswith(input.args[1], pattern)
+}
+
+# ── Blanket allow for specific working directories ─────────────────────
+# Uncomment to allow all subprocess operations within a specific directory.
+
+# allow if {
+#     input.cwd != null
+#     startswith(input.cwd, "/tmp/sandbox/")
+# }

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -8,6 +8,7 @@ pub mod mcp_client;
 pub mod module_loader;
 pub mod opa;
 pub mod session_log;
+pub mod subprocess;
 
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -666,6 +667,7 @@ pub struct ExecutionConfig<'a> {
     pub wasm_default_max_bytes: usize,
     pub fetch_config: Option<&'a fetch::FetchConfig>,
     pub fs_config: Option<&'a fs::FsConfig>,
+    pub subprocess_config: Option<&'a subprocess::SubprocessConfig>,
     pub console_tree: Option<sled::Tree>,
     pub module_loader_config: Option<&'a module_loader::ModuleLoaderConfig>,
     pub mcp_config: Option<&'a mcp_client::McpConfig>,
@@ -680,6 +682,7 @@ impl<'a> ExecutionConfig<'a> {
             wasm_default_max_bytes: heap_memory_max_bytes,
             fetch_config: None,
             fs_config: None,
+            subprocess_config: None,
             console_tree: None,
             module_loader_config: None,
             mcp_config: None,
@@ -727,6 +730,11 @@ impl<'a> ExecutionConfig<'a> {
         self
     }
 
+    pub fn maybe_subprocess_config(mut self, config: Option<&'a subprocess::SubprocessConfig>) -> Self {
+        self.subprocess_config = config;
+        self
+    }
+
     pub fn maybe_mcp_config(mut self, config: Option<&'a mcp_client::McpConfig>) -> Self {
         self.mcp_config = config;
         self
@@ -748,6 +756,7 @@ pub fn execute_stateless(
         wasm_default_max_bytes,
         fetch_config,
         fs_config,
+        subprocess_config,
         console_tree,
         module_loader_config,
         mcp_config,
@@ -765,6 +774,9 @@ pub fn execute_stateless(
         }
         if fs_config.is_some() {
             extensions.push(fs::create_extension());
+        }
+        if subprocess_config.is_some() {
+            extensions.push(subprocess::create_extension());
         }
         if mcp_config.is_some() {
             extensions.push(mcp_client::create_extension());
@@ -796,6 +808,11 @@ pub fn execute_stateless(
         // Put fs config in OpState if filesystem policies are configured.
         if let Some(fsc) = fs_config {
             runtime.op_state().borrow_mut().put(fsc.clone());
+        }
+
+        // Put subprocess config in OpState if subprocess policies are configured.
+        if let Some(sc) = subprocess_config {
+            runtime.op_state().borrow_mut().put(sc.clone());
         }
 
         // Put MCP config in OpState if MCP servers are configured.
@@ -834,6 +851,12 @@ pub fn execute_stateless(
                 // Inject fs JS wrapper if filesystem policies are configured.
                 if fs_config.is_some() {
                     if let Err(e) = fs::inject_fs(&mut runtime) {
+                        return Err(e);
+                    }
+                }
+                // Inject subprocess JS wrapper if subprocess policies are configured.
+                if subprocess_config.is_some() {
+                    if let Err(e) = subprocess::inject_subprocess(&mut runtime) {
                         return Err(e);
                     }
                 }
@@ -888,6 +911,7 @@ pub fn execute_stateful(
         wasm_default_max_bytes,
         fetch_config,
         fs_config,
+        subprocess_config,
         console_tree,
         module_loader_config,
         mcp_config,
@@ -924,6 +948,9 @@ pub fn execute_stateful(
         if fs_config.is_some() {
             extensions.push(fs::create_extension());
         }
+        if subprocess_config.is_some() {
+            extensions.push(subprocess::create_extension());
+        }
         if mcp_config.is_some() {
             extensions.push(mcp_client::create_extension());
         }
@@ -955,6 +982,11 @@ pub fn execute_stateful(
         // Put fs config in OpState if filesystem policies are configured.
         if let Some(fsc) = fs_config {
             runtime.op_state().borrow_mut().put(fsc.clone());
+        }
+
+        // Put subprocess config in OpState if subprocess policies are configured.
+        if let Some(sc) = subprocess_config {
+            runtime.op_state().borrow_mut().put(sc.clone());
         }
 
         // Put MCP config in OpState if MCP servers are configured.
@@ -1003,6 +1035,12 @@ pub fn execute_stateful(
                     // Inject fs JS wrapper if filesystem policies are configured.
                     if fs_config.is_some() {
                         if let Err(e) = fs::inject_fs(&mut runtime) {
+                            return Err(e);
+                        }
+                    }
+                    // Inject subprocess JS wrapper if subprocess policies are configured.
+                    if subprocess_config.is_some() {
+                        if let Err(e) = subprocess::inject_subprocess(&mut runtime) {
                             return Err(e);
                         }
                     }
@@ -1096,6 +1134,8 @@ pub struct Engine {
     fetch_config: Option<Arc<fetch::FetchConfig>>,
     /// Policy-gated filesystem configuration. When Some, `fs` is injected into the JS runtime.
     fs_config: Option<Arc<fs::FsConfig>>,
+    /// Policy-gated subprocess configuration. When Some, `Deno.Command` and `child_process` are injected.
+    subprocess_config: Option<Arc<subprocess::SubprocessConfig>>,
     /// Execution registry for async execution tracking and console output.
     execution_registry: Option<Arc<ExecutionRegistry>>,
     /// Module loader configuration controlling external module access and OPA auditing.
@@ -1124,6 +1164,7 @@ impl Engine {
             wasm_modules: Arc::new(Vec::new()),
             fetch_config: None,
             fs_config: None,
+            subprocess_config: None,
             execution_registry: None,
             module_loader_config: Arc::new(module_loader::ModuleLoaderConfig {
                 allow_external: false,
@@ -1154,6 +1195,7 @@ impl Engine {
             wasm_modules: Arc::new(Vec::new()),
             fetch_config: None,
             fs_config: None,
+            subprocess_config: None,
             execution_registry: None,
             module_loader_config: Arc::new(module_loader::ModuleLoaderConfig {
                 allow_external: false,
@@ -1185,6 +1227,12 @@ impl Engine {
     /// Enable policy-gated filesystem access in the JS runtime.
     pub fn with_fs_config(mut self, config: fs::FsConfig) -> Self {
         self.fs_config = Some(Arc::new(config));
+        self
+    }
+
+    /// Enable policy-gated subprocess execution in the JS runtime.
+    pub fn with_subprocess_config(mut self, config: subprocess::SubprocessConfig) -> Self {
+        self.subprocess_config = Some(Arc::new(config));
         self
     }
 
@@ -1303,6 +1351,7 @@ impl Engine {
                 let wasm_default = self.wasm_default_max_bytes;
                 let fc = self.fetch_config.clone();
                 let fsc = self.fs_config.clone();
+                let sc = self.subprocess_config.clone();
                 let ct = console_tree;
                 let mlc = self.module_loader_config.clone();
                 let mc = self.mcp_client_manager.as_ref().map(|m| mcp_client::McpConfig { client_manager: (**m).clone(), policy_chain: self.mcp_tools_policy_chain.clone() });
@@ -1313,6 +1362,7 @@ impl Engine {
                         .wasm_default_max_bytes(wasm_default)
                         .maybe_fetch_config(fc.as_deref())
                         .maybe_fs_config(fsc.as_deref())
+                        .maybe_subprocess_config(sc.as_deref())
                         .console_tree(ct)
                         .module_loader_config(&mlc)
                         .maybe_mcp_config(mc.as_ref()))
@@ -1365,6 +1415,7 @@ impl Engine {
                 let wasm_default = self.wasm_default_max_bytes;
                 let fc = self.fetch_config.clone();
                 let fsc = self.fs_config.clone();
+                let sc = self.subprocess_config.clone();
                 let ct = console_tree;
                 let mlc = self.module_loader_config.clone();
                 let mc = self.mcp_client_manager.as_ref().map(|m| mcp_client::McpConfig { client_manager: (**m).clone(), policy_chain: self.mcp_tools_policy_chain.clone() });
@@ -1378,6 +1429,7 @@ impl Engine {
                         .wasm_default_max_bytes(wasm_default)
                         .maybe_fetch_config(fc.as_deref())
                         .maybe_fs_config(fsc.as_deref())
+                        .maybe_subprocess_config(sc.as_deref())
                         .console_tree(ct)
                         .module_loader_config(&mlc)
                         .maybe_mcp_config(mc.as_ref()))

--- a/server/src/engine/opa.rs
+++ b/server/src/engine/opa.rs
@@ -267,6 +267,8 @@ pub struct PoliciesConfig {
     pub filesystem: Option<OperationPolicies>,
     /// Policy chain for MCP tool calls (`mcp.callTool()`).
     pub mcp_tools: Option<OperationPolicies>,
+    /// Policy chain for subprocess execution (`Deno.Command`, `child_process.exec`).
+    pub subprocess: Option<OperationPolicies>,
 }
 
 /// Per-operation policy configuration.
@@ -653,6 +655,27 @@ allow if { input.admin == true }
         assert_eq!(mcp_tools.policies[0].rule.as_deref(), Some("data.mcp.tools.allow"));
     }
 
+    #[test]
+    fn test_policies_config_subprocess() {
+        let json = r#"{
+            "subprocess": {
+                "mode": "all",
+                "policies": [
+                    {"url": "file:///etc/policies/subprocess.rego", "rule": "data.mcp.subprocess.allow"}
+                ]
+            }
+        }"#;
+        let config: PoliciesConfig = serde_json::from_str(json).unwrap();
+        assert!(config.fetch.is_none());
+        assert!(config.modules.is_none());
+        assert!(config.filesystem.is_none());
+        assert!(config.mcp_tools.is_none());
+        let subprocess = config.subprocess.unwrap();
+        assert_eq!(subprocess.mode, EvalMode::All);
+        assert_eq!(subprocess.policies.len(), 1);
+        assert_eq!(subprocess.policies[0].rule.as_deref(), Some("data.mcp.subprocess.allow"));
+    }
+
     // ── Integration: local rego through build_policy_chain + evaluate ────
 
     #[tokio::test]
@@ -775,5 +798,89 @@ allow if {
             "arguments": null
         });
         assert!(chain.evaluate(&input).await.unwrap());
+    }
+
+    // ── Subprocess policy tests ──────────────────────────────────────────
+
+    fn subprocess_rego() -> &'static str {
+        r#"
+package mcp.subprocess
+
+default allow = false
+
+allow if {
+    input.operation == "command_output"
+    input.command == "echo"
+}
+
+allow if {
+    input.operation == "exec"
+    startswith(input.args[1], "echo")
+}
+"#
+    }
+
+    #[tokio::test]
+    async fn test_subprocess_policy_allow() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_rego_file(dir.path(), "subprocess.rego", subprocess_rego());
+
+        let op = OperationPolicies {
+            mode: EvalMode::All,
+            policies: vec![PolicySource {
+                url: format!("file://{}", path.display()),
+                policy_path: None,
+                rule: None,
+            }],
+        };
+        let chain = build_policy_chain(&op, "mcp/subprocess", "data.mcp.subprocess.allow").unwrap();
+
+        // Allowed: command_output for "echo"
+        let input = serde_json::json!({
+            "operation": "command_output",
+            "command": "echo",
+            "args": ["hello"]
+        });
+        assert!(chain.evaluate(&input).await.unwrap());
+
+        // Allowed: exec with "echo hello"
+        let input = serde_json::json!({
+            "operation": "exec",
+            "command": "/bin/sh",
+            "args": ["-c", "echo hello"]
+        });
+        assert!(chain.evaluate(&input).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_subprocess_policy_deny() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_rego_file(dir.path(), "subprocess.rego", subprocess_rego());
+
+        let op = OperationPolicies {
+            mode: EvalMode::All,
+            policies: vec![PolicySource {
+                url: format!("file://{}", path.display()),
+                policy_path: None,
+                rule: None,
+            }],
+        };
+        let chain = build_policy_chain(&op, "mcp/subprocess", "data.mcp.subprocess.allow").unwrap();
+
+        // Denied: command_output for "rm"
+        let input = serde_json::json!({
+            "operation": "command_output",
+            "command": "rm",
+            "args": ["-rf", "/"]
+        });
+        assert!(!chain.evaluate(&input).await.unwrap());
+
+        // Denied: exec with "rm -rf /"
+        let input = serde_json::json!({
+            "operation": "exec",
+            "command": "/bin/sh",
+            "args": ["-c", "rm -rf /"]
+        });
+        assert!(!chain.evaluate(&input).await.unwrap());
     }
 }

--- a/server/src/engine/subprocess.rs
+++ b/server/src/engine/subprocess.rs
@@ -1,0 +1,477 @@
+//! OPA-gated subprocess execution for the JavaScript runtime.
+//!
+//! Provides two subprocess APIs, both policy-gated via OPA:
+//!
+//! **Deno.Command** (Deno subprocess API):
+//! ```js
+//! const cmd = new Deno.Command("echo", { args: ["hello"] });
+//! const { code, stdout, stderr } = await cmd.output();
+//! console.log(new TextDecoder().decode(stdout));
+//! ```
+//!
+//! **child_process.exec** (Node.js-compatible):
+//! ```js
+//! const { stdout, stderr } = await child_process.exec("echo hello");
+//! const result = await child_process.exec("ls -la", { cwd: "/tmp" });
+//! ```
+//!
+//! Every subprocess invocation is evaluated against an OPA policy chain
+//! before execution. The policy input includes the command, arguments,
+//! working directory, and environment variables.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use deno_core::{JsRuntime, OpState, op2};
+use deno_error::JsErrorBox;
+use serde::Serialize;
+
+use super::opa::PolicyChain;
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+/// Configuration for subprocess execution. Stored in deno_core's `OpState`.
+#[derive(Clone, Debug)]
+pub struct SubprocessConfig {
+    pub policy_chain: Arc<PolicyChain>,
+}
+
+impl SubprocessConfig {
+    pub fn new(chain: Arc<PolicyChain>) -> Self {
+        Self { policy_chain: chain }
+    }
+}
+
+// ── Policy input ─────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct SubprocessPolicyInput {
+    /// The type of operation: "command_output", "command_spawn", or "exec".
+    operation: String,
+    /// The command to execute.
+    command: String,
+    /// Arguments to the command.
+    args: Vec<String>,
+    /// Working directory (if specified).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<String>,
+    /// Environment variables (if specified).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    env: Option<HashMap<String, String>>,
+}
+
+// ── Async deno_core ops ──────────────────────────────────────────────────
+
+/// Async op: Run a command to completion (Deno.Command.output() equivalent).
+/// Called from JS via `Deno.core.ops.op_subprocess_output(command, args_json, options_json)`.
+/// Returns a JSON string with {code, stdout, stderr}.
+#[op2(async)]
+#[string]
+async fn op_subprocess_output(
+    state: Rc<RefCell<OpState>>,
+    #[string] command: String,
+    #[string] args_json: String,
+    #[string] options_json: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        let args: Vec<String> = serde_json::from_str(&args_json)
+            .map_err(|e| format!("subprocess: invalid args JSON: {}", e))?;
+        let options: SubprocessOptions = serde_json::from_str(&options_json)
+            .map_err(|e| format!("subprocess: invalid options JSON: {}", e))?;
+
+        check_policy(&policy_chain, "command_output", &command, &args, &options).await?;
+
+        let mut cmd = tokio::process::Command::new(&command);
+        cmd.args(&args);
+
+        if let Some(ref cwd) = options.cwd {
+            cmd.current_dir(cwd);
+        }
+        if let Some(ref env) = options.env {
+            cmd.envs(env);
+        }
+
+        let output = cmd.output().await
+            .map_err(|e| format!("subprocess: failed to execute '{}': {}", command, e))?;
+
+        let stdout = base64_encode(&output.stdout);
+        let stderr = base64_encode(&output.stderr);
+
+        let result = serde_json::json!({
+            "code": output.status.code().unwrap_or(-1),
+            "stdout": stdout,
+            "stderr": stderr,
+            "success": output.status.success(),
+        });
+
+        Ok(result.to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("subprocess task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Async op: Execute a shell command (Node.js child_process.exec equivalent).
+/// Called from JS via `Deno.core.ops.op_subprocess_exec(command, options_json)`.
+/// Returns a JSON string with {code, stdout, stderr}.
+#[op2(async)]
+#[string]
+async fn op_subprocess_exec(
+    state: Rc<RefCell<OpState>>,
+    #[string] command: String,
+    #[string] options_json: String,
+) -> Result<String, JsErrorBox> {
+    let policy_chain = extract_chain(&state)?;
+
+    tokio::spawn(async move {
+        let options: SubprocessOptions = serde_json::from_str(&options_json)
+            .map_err(|e| format!("subprocess.exec: invalid options JSON: {}", e))?;
+
+        // For exec(), the command is run via shell. We pass it as a single
+        // string to the shell, so args in the policy input is the full command.
+        let shell = if cfg!(target_os = "windows") { "cmd" } else { "/bin/sh" };
+        let shell_arg = if cfg!(target_os = "windows") { "/C" } else { "-c" };
+
+        check_policy(
+            &policy_chain,
+            "exec",
+            shell,
+            &[shell_arg.to_string(), command.clone()],
+            &options,
+        ).await?;
+
+        let mut cmd = tokio::process::Command::new(shell);
+        cmd.arg(shell_arg).arg(&command);
+
+        if let Some(ref cwd) = options.cwd {
+            cmd.current_dir(cwd);
+        }
+        if let Some(ref env) = options.env {
+            cmd.envs(env);
+        }
+
+        let output = cmd.output().await
+            .map_err(|e| format!("subprocess.exec: failed to execute '{}': {}", command, e))?;
+
+        let encoding = options.encoding.as_deref().unwrap_or("utf8");
+        let (stdout, stderr) = if encoding == "buffer" {
+            (base64_encode(&output.stdout), base64_encode(&output.stderr))
+        } else {
+            (
+                String::from_utf8_lossy(&output.stdout).to_string(),
+                String::from_utf8_lossy(&output.stderr).to_string(),
+            )
+        };
+
+        let result = serde_json::json!({
+            "code": output.status.code().unwrap_or(-1),
+            "stdout": stdout,
+            "stderr": stderr,
+            "success": output.status.success(),
+            "encoding": encoding,
+        });
+
+        Ok(result.to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("subprocess task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+// ── Extension registration ──────────────────────────────────────────────
+
+deno_core::extension!(
+    subprocess_ext,
+    ops = [op_subprocess_output, op_subprocess_exec],
+);
+
+pub fn create_extension() -> deno_core::Extension {
+    subprocess_ext::init()
+}
+
+// ── Inject subprocess JS wrappers into the global scope ─────────────────
+
+pub fn inject_subprocess(runtime: &mut JsRuntime) -> Result<(), String> {
+    runtime
+        .execute_script("<subprocess-setup>", SUBPROCESS_JS_WRAPPER.to_string())
+        .map_err(|e| format!("Failed to install subprocess wrapper: {}", e))?;
+    Ok(())
+}
+
+/// JavaScript wrapper providing both Deno.Command and child_process.exec APIs.
+const SUBPROCESS_JS_WRAPPER: &str = r#"
+(function() {
+    // ── Base64 decode helper (for binary output from Deno.Command) ──────
+    function base64ToUint8Array(base64) {
+        var raw = '';
+        var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+        // Remove padding
+        var stripped = base64.replace(/=+$/, '');
+        for (var i = 0; i < stripped.length; i += 4) {
+            var a = chars.indexOf(stripped[i]);
+            var b = chars.indexOf(stripped[i + 1]);
+            var c = chars.indexOf(stripped[i + 2]);
+            var d = chars.indexOf(stripped[i + 3]);
+            var n = (a << 18) | (b << 12) | ((c >= 0 ? c : 0) << 6) | (d >= 0 ? d : 0);
+            raw += String.fromCharCode((n >> 16) & 0xFF);
+            if (c >= 0) raw += String.fromCharCode((n >> 8) & 0xFF);
+            if (d >= 0) raw += String.fromCharCode(n & 0xFF);
+        }
+        var bytes = new Uint8Array(raw.length);
+        for (var j = 0; j < raw.length; j++) {
+            bytes[j] = raw.charCodeAt(j);
+        }
+        return bytes;
+    }
+
+    // ── Deno.Command API ────────────────────────────────────────────────
+    // https://docs.deno.com/api/deno/subprocess
+    //
+    // Usage:
+    //   const cmd = new Deno.Command("echo", { args: ["hello"] });
+    //   const { code, stdout, stderr, success } = await cmd.output();
+    //
+    //   // stdout/stderr are Uint8Array by default
+    //   console.log(new TextDecoder().decode(stdout));
+
+    function DenoCommand(command, options) {
+        if (typeof command !== 'string') {
+            throw new TypeError('Deno.Command: command must be a string');
+        }
+        this._command = command;
+        this._options = options || {};
+    }
+
+    DenoCommand.prototype.output = async function() {
+        var args = this._options.args || [];
+        if (!Array.isArray(args)) {
+            throw new TypeError('Deno.Command: args must be an array');
+        }
+        var argsJson = JSON.stringify(args.map(String));
+        var optionsJson = JSON.stringify({
+            cwd: this._options.cwd || null,
+            env: this._options.env || null,
+        });
+
+        var rawResult = await Deno.core.ops.op_subprocess_output(
+            this._command, argsJson, optionsJson
+        );
+        var result = JSON.parse(rawResult);
+
+        return {
+            code: result.code,
+            success: result.success,
+            stdout: base64ToUint8Array(result.stdout),
+            stderr: base64ToUint8Array(result.stderr),
+            signal: null,
+        };
+    };
+
+    DenoCommand.prototype.outputSync = function() {
+        throw new Error('Deno.Command.outputSync() is not supported; use output() instead');
+    };
+
+    DenoCommand.prototype.spawn = function() {
+        throw new Error('Deno.Command.spawn() is not yet supported; use output() instead');
+    };
+
+    // Attach to Deno namespace (create if needed)
+    if (typeof globalThis.Deno === 'undefined') {
+        globalThis.Deno = {};
+    }
+    globalThis.Deno.Command = DenoCommand;
+
+    // ── child_process.exec API ──────────────────────────────────────────
+    // https://docs.deno.com/api/node/child_process/~/exec
+    //
+    // Usage:
+    //   const { stdout, stderr } = await child_process.exec("echo hello");
+    //   const result = await child_process.exec("ls -la", { cwd: "/tmp" });
+    //
+    // Returns a Promise that resolves to { code, stdout, stderr, success }.
+    // Encoding defaults to "utf8" (returns strings).
+    // Set encoding to "buffer" to get base64-encoded binary output.
+
+    globalThis.child_process = {
+        exec: async function(command, options) {
+            if (typeof command !== 'string') {
+                throw new TypeError('child_process.exec: command must be a string');
+            }
+            var opts = options || {};
+            var optionsJson = JSON.stringify({
+                cwd: opts.cwd || null,
+                env: opts.env || null,
+                encoding: opts.encoding || 'utf8',
+                timeout: opts.timeout || null,
+            });
+
+            var rawResult = await Deno.core.ops.op_subprocess_exec(
+                command, optionsJson
+            );
+            var result = JSON.parse(rawResult);
+
+            if (result.encoding === 'buffer') {
+                result.stdout = base64ToUint8Array(result.stdout);
+                result.stderr = base64ToUint8Array(result.stderr);
+            }
+
+            return {
+                code: result.code,
+                stdout: result.stdout,
+                stderr: result.stderr,
+                success: result.success,
+            };
+        },
+    };
+})();
+"#;
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct SubprocessOptions {
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    encoding: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    timeout: Option<u64>,
+}
+
+fn extract_chain(state: &Rc<RefCell<OpState>>) -> Result<Arc<PolicyChain>, JsErrorBox> {
+    let state = state.borrow();
+    let config = state.try_borrow::<SubprocessConfig>()
+        .ok_or_else(|| JsErrorBox::generic("subprocess: internal error — no subprocess config available"))?;
+    Ok(config.policy_chain.clone())
+}
+
+async fn check_policy(
+    policy_chain: &PolicyChain,
+    operation: &str,
+    command: &str,
+    args: &[String],
+    options: &SubprocessOptions,
+) -> Result<(), String> {
+    let input = SubprocessPolicyInput {
+        operation: operation.to_string(),
+        command: command.to_string(),
+        args: args.to_vec(),
+        cwd: options.cwd.clone(),
+        env: options.env.clone(),
+    };
+
+    let input_value = serde_json::to_value(&input)
+        .map_err(|e| format!("subprocess.{}: failed to serialize policy input: {}", operation, e))?;
+
+    let allowed = policy_chain
+        .evaluate(&input_value)
+        .await
+        .map_err(|e| format!("subprocess.{}: policy error: {}", operation, e))?;
+
+    if !allowed {
+        return Err(format!(
+            "subprocess.{} denied by policy: '{}' is not allowed",
+            operation, command
+        ));
+    }
+
+    Ok(())
+}
+
+fn base64_encode(data: &[u8]) -> String {
+    use std::fmt::Write;
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut result = String::with_capacity((data.len() + 2) / 3 * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        let _ = write!(result, "{}", CHARS[((n >> 18) & 0x3F) as usize] as char);
+        let _ = write!(result, "{}", CHARS[((n >> 12) & 0x3F) as usize] as char);
+        if chunk.len() > 1 {
+            let _ = write!(result, "{}", CHARS[((n >> 6) & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+        if chunk.len() > 2 {
+            let _ = write!(result, "{}", CHARS[(n & 0x3F) as usize] as char);
+        } else {
+            result.push('=');
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subprocess_policy_input_serialization() {
+        let input = SubprocessPolicyInput {
+            operation: "command_output".to_string(),
+            command: "echo".to_string(),
+            args: vec!["hello".to_string(), "world".to_string()],
+            cwd: Some("/tmp".to_string()),
+            env: None,
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        assert!(json.contains("\"operation\":\"command_output\""));
+        assert!(json.contains("\"command\":\"echo\""));
+        assert!(json.contains("\"args\":[\"hello\",\"world\"]"));
+        assert!(json.contains("\"cwd\":\"/tmp\""));
+        assert!(!json.contains("\"env\""));
+    }
+
+    #[test]
+    fn test_subprocess_policy_input_with_env() {
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), "/usr/bin".to_string());
+        let input = SubprocessPolicyInput {
+            operation: "exec".to_string(),
+            command: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "ls".to_string()],
+            cwd: None,
+            env: Some(env),
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        assert!(json.contains("\"env\":{\"PATH\":\"/usr/bin\"}"));
+        assert!(!json.contains("\"cwd\""));
+    }
+
+    #[test]
+    fn test_base64_encode() {
+        assert_eq!(base64_encode(b"hello"), "aGVsbG8=");
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"a"), "YQ==");
+        assert_eq!(base64_encode(b"ab"), "YWI=");
+        assert_eq!(base64_encode(b"abc"), "YWJj");
+        assert_eq!(base64_encode(b"Hello, World!"), "SGVsbG8sIFdvcmxkIQ==");
+    }
+
+    #[test]
+    fn test_subprocess_options_deserialize() {
+        let json = r#"{"cwd": "/tmp", "env": {"KEY": "val"}, "encoding": "utf8"}"#;
+        let opts: SubprocessOptions = serde_json::from_str(json).unwrap();
+        assert_eq!(opts.cwd.as_deref(), Some("/tmp"));
+        assert_eq!(opts.env.as_ref().unwrap()["KEY"], "val");
+        assert_eq!(opts.encoding.as_deref(), Some("utf8"));
+    }
+
+    #[test]
+    fn test_subprocess_options_defaults() {
+        let json = r#"{}"#;
+        let opts: SubprocessOptions = serde_json::from_str(json).unwrap();
+        assert!(opts.cwd.is_none());
+        assert!(opts.env.is_none());
+        assert!(opts.encoding.is_none());
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -14,6 +14,7 @@ mod cluster;
 use engine::{initialize_v8, Engine, WasmModule, DEFAULT_EXECUTION_TIMEOUT_SECS};
 use engine::fetch::FetchConfig;
 use engine::fs::FsConfig;
+use engine::subprocess::SubprocessConfig;
 use engine::execution::ExecutionRegistry;
 use engine::module_loader::ModuleLoaderConfig;
 use engine::opa::{PoliciesConfig, build_policy_chain};
@@ -404,6 +405,19 @@ async fn main() -> Result<()> {
         None
     };
 
+    let subprocess_policy_chain = if let Some(ref config) = policies_config {
+        if let Some(ref subprocess_policies) = config.subprocess {
+            let chain = build_policy_chain(subprocess_policies, "mcp/subprocess", "data.mcp.subprocess.allow")
+                .map_err(|e| anyhow::anyhow!("Failed to build subprocess policy chain: {}", e))?;
+            tracing::info!("Subprocess policy chain: {} evaluator(s), mode={:?}", subprocess_policies.policies.len(), subprocess_policies.mode);
+            Some(Arc::new(chain))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     // ── Fetch policy ───────────────────────────────────────────────────
     let header_rules = load_fetch_header_rules(&cli.fetch_headers, &cli.fetch_header_config)?;
     if !header_rules.is_empty() {
@@ -421,6 +435,13 @@ async fn main() -> Result<()> {
     // ── Filesystem policy ────────────────────────────────────────────────
     let engine = if let Some(chain) = fs_policy_chain {
         engine.with_fs_config(FsConfig::new(chain))
+    } else {
+        engine
+    };
+
+    // ── Subprocess policy ──────────────────────────────────────────────
+    let engine = if let Some(chain) = subprocess_policy_chain {
+        engine.with_subprocess_config(SubprocessConfig::new(chain))
     } else {
         engine
     };

--- a/tests/nixos/exec-opa.nix
+++ b/tests/nixos/exec-opa.nix
@@ -1,0 +1,260 @@
+{ pkgs, mcp-js, ... }:
+
+let
+  # ── Rego policy ──────────────────────────────────────────────────────
+  #
+  # Deno.Command (command_output): allow "echo" and "cat".
+  # child_process.exec (exec):    allow commands starting with "echo" or "cat".
+  # Everything else is denied.
+
+  regoPolicy = pkgs.writeText "subprocess-policy.rego" ''
+    package mcp.subprocess
+
+    default allow = false
+
+    # ── Deno.Command (command_output) ─────────────────────────────────
+    allowed_commands := {"echo", "cat"}
+
+    allow if {
+        input.operation == "command_output"
+        allowed_commands[input.command]
+    }
+
+    # ── child_process.exec ────────────────────────────────────────────
+    allowed_exec_patterns := {"echo", "cat"}
+
+    allow if {
+        input.operation == "exec"
+        some pattern in allowed_exec_patterns
+        startswith(input.args[1], pattern)
+    }
+  '';
+in
+
+{
+  name = "mcp-js-exec-opa";
+
+  nodes = {
+    machine = { ... }: {
+      imports = [ ../../nix/module.nix ];
+
+      # ── mcp-js server (stateless, with subprocess policy) ───────────
+      services.mcp-js = {
+        enable = true;
+        package = mcp-js;
+        nodeId = "test";
+        stateless = true;
+        httpPort = 3000;
+        policiesJson = builtins.toJSON {
+          subprocess = {
+            policies = [{
+              url = "file://${regoPolicy}";
+            }];
+          };
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [ 3000 ];
+    };
+  };
+
+  testScript = ''
+    import json
+    import shlex
+    import time
+
+    machine.start()
+    machine.wait_for_unit("mcp-js.service")
+    machine.wait_for_open_port(3000)
+
+    def exec_js(code):
+        """Execute JS code via mcp-js async /api/exec endpoint and return parsed response.
+
+        All code runs as ES modules, so results must be captured via console.log().
+        Returns a dict with 'output' key containing console output.
+        """
+        body = json.dumps({"code": code})
+        raw = machine.succeed(
+            "curl -s -X POST http://localhost:3000/api/exec "
+            "-H 'Content-Type: application/json' "
+            "-d " + shlex.quote(body)
+        )
+        submit_resp = json.loads(raw)
+        exec_id = submit_resp["execution_id"]
+
+        for _ in range(60):
+            status_raw = machine.succeed(
+                "curl -s http://localhost:3000/api/executions/" + exec_id
+            )
+            status_resp = json.loads(status_raw)
+            status = status_resp.get("status", "")
+            if status in ("Completed", "completed"):
+                output_raw = machine.succeed(
+                    "curl -s http://localhost:3000/api/executions/" + exec_id + "/output"
+                )
+                output_resp = json.loads(output_raw)
+                console_data = output_resp.get("data", "").strip()
+                return {"output": console_data}
+            if status in ("Failed", "failed", "TimedOut", "Cancelled"):
+                return {"output": "Error: " + status_resp.get("error", status)}
+            time.sleep(0.5)
+
+        raise Exception("Execution " + exec_id + " did not complete within 30s")
+
+    # ── Test 1: Deno.Command – allowed command (echo) ──────────────────
+
+    with subtest("Deno.Command should allow echo"):
+        result = exec_js("""
+            const cmd = new Deno.Command("echo", { args: ["hello", "world"] });
+            const { code, stdout } = await cmd.output();
+            console.log(new TextDecoder().decode(stdout).trim());
+        """)
+        print("Deno.Command echo result: " + str(result))
+        assert result["output"] == "hello world", \
+            "Expected 'hello world', got: " + str(result)
+
+    # ── Test 2: Deno.Command – allowed command (cat) ───────────────────
+
+    with subtest("Deno.Command should allow cat"):
+        result = exec_js("""
+            const cmd = new Deno.Command("cat", { args: ["/etc/hostname"] });
+            const { code, stdout } = await cmd.output();
+            const output = new TextDecoder().decode(stdout).trim();
+            console.log(output.length > 0 ? "ok" : "empty");
+        """)
+        print("Deno.Command cat result: " + str(result))
+        assert result["output"] == "ok", \
+            "Expected 'ok', got: " + str(result)
+
+    # ── Test 3: Deno.Command – denied command (ls) ─────────────────────
+
+    with subtest("Deno.Command should deny ls"):
+        result = exec_js("""
+            try {
+                const cmd = new Deno.Command("ls", { args: ["/tmp"] });
+                await cmd.output();
+                console.log("no error");
+            } catch(e) { console.log(e.message); }
+        """)
+        print("Deno.Command deny result: " + str(result))
+        assert "denied by policy" in result["output"], \
+            "Expected denied by policy error, got: " + str(result)
+
+    # ── Test 4: Deno.Command – denied command (rm) ─────────────────────
+
+    with subtest("Deno.Command should deny rm"):
+        result = exec_js("""
+            try {
+                const cmd = new Deno.Command("rm", { args: ["-rf", "/tmp/foo"] });
+                await cmd.output();
+                console.log("no error");
+            } catch(e) { console.log(e.message); }
+        """)
+        print("Deno.Command deny rm result: " + str(result))
+        assert "denied by policy" in result["output"], \
+            "Expected denied by policy error, got: " + str(result)
+
+    # ── Test 5: child_process.exec – allowed command ───────────────────
+
+    with subtest("child_process.exec should allow echo"):
+        result = exec_js("""
+            const { stdout } = await child_process.exec("echo hello from exec");
+            console.log(stdout.trim());
+        """)
+        print("child_process.exec echo result: " + str(result))
+        assert result["output"] == "hello from exec", \
+            "Expected 'hello from exec', got: " + str(result)
+
+    # ── Test 6: child_process.exec – allowed cat command ───────────────
+
+    with subtest("child_process.exec should allow cat"):
+        result = exec_js("""
+            const { stdout } = await child_process.exec("cat /etc/hostname");
+            console.log(stdout.trim().length > 0 ? "ok" : "empty");
+        """)
+        print("child_process.exec cat result: " + str(result))
+        assert result["output"] == "ok", \
+            "Expected 'ok', got: " + str(result)
+
+    # ── Test 7: child_process.exec – denied command ────────────────────
+
+    with subtest("child_process.exec should deny ls"):
+        result = exec_js("""
+            try {
+                await child_process.exec("ls -la /tmp");
+                console.log("no error");
+            } catch(e) { console.log(e.message); }
+        """)
+        print("child_process.exec deny result: " + str(result))
+        assert "denied by policy" in result["output"], \
+            "Expected denied by policy error, got: " + str(result)
+
+    # ── Test 8: child_process.exec – denied dangerous command ──────────
+
+    with subtest("child_process.exec should deny rm -rf"):
+        result = exec_js("""
+            try {
+                await child_process.exec("rm -rf /tmp");
+                console.log("no error");
+            } catch(e) { console.log(e.message); }
+        """)
+        print("child_process.exec deny rm result: " + str(result))
+        assert "denied by policy" in result["output"], \
+            "Expected denied by policy error, got: " + str(result)
+
+    # ── Test 9: Deno.Command – verify exit code ────────────────────────
+
+    with subtest("Deno.Command should return correct exit code"):
+        result = exec_js("""
+            const cmd = new Deno.Command("echo", { args: [] });
+            const { code, success } = await cmd.output();
+            console.log(JSON.stringify({ code, success }));
+        """)
+        print("Deno.Command exit code result: " + str(result))
+        body = json.loads(result["output"])
+        assert body["code"] == 0, "Expected exit code 0, got: " + str(body)
+        assert body["success"] == True, "Expected success=true, got: " + str(body)
+
+    # ── Test 10: child_process.exec – with cwd option ──────────────────
+
+    with subtest("child_process.exec should respect cwd option"):
+        result = exec_js("""
+            const { stdout } = await child_process.exec("echo from-cwd", { cwd: "/tmp" });
+            console.log(stdout.trim());
+        """)
+        print("child_process.exec cwd result: " + str(result))
+        assert result["output"] == "from-cwd", \
+            "Expected 'from-cwd', got: " + str(result)
+
+    # ── Test 11: Deno.Command and child_process are available ──────────
+
+    with subtest("subprocess APIs should be available when policy is configured"):
+        result = exec_js("""
+            console.log(JSON.stringify({
+                denoCommand: typeof Deno.Command,
+                childProcess: typeof child_process.exec,
+            }));
+        """)
+        print("API availability: " + str(result))
+        body = json.loads(result["output"])
+        assert body["denoCommand"] == "function", \
+            "Expected Deno.Command to be function, got: " + str(body)
+        assert body["childProcess"] == "function", \
+            "Expected child_process.exec to be function, got: " + str(body)
+
+    # ── Test 12: Deno.Command with stdout and stderr ───────────────────
+
+    with subtest("Deno.Command should capture stdout correctly"):
+        result = exec_js("""
+            const cmd = new Deno.Command("echo", { args: ["line1"] });
+            const { stdout, stderr } = await cmd.output();
+            const out = new TextDecoder().decode(stdout).trim();
+            const err = new TextDecoder().decode(stderr);
+            console.log(JSON.stringify({ out, err }));
+        """)
+        print("Deno.Command stdout/stderr result: " + str(result))
+        body = json.loads(result["output"])
+        assert body["out"] == "line1", "Expected 'line1', got: " + str(body)
+        assert body["err"] == "", "Expected empty stderr, got: " + str(body)
+  '';
+}


### PR DESCRIPTION
## Summary

This PR adds policy-gated subprocess execution capabilities to the JavaScript runtime, supporting both Deno's `Command` API and Node.js-compatible `child_process.exec()`. All subprocess invocations are evaluated against an OPA policy chain before execution.

## Key Changes

- **New subprocess module** (`server/src/engine/subprocess.rs`):
  - Implements two async ops: `op_subprocess_output` (for `Deno.Command.output()`) and `op_subprocess_exec` (for `child_process.exec()`)
  - Provides JavaScript wrappers that expose both APIs to user code
  - Supports command execution with arguments, working directory, and environment variable configuration
  - Returns structured output with exit code, stdout, stderr, and success status
  - Encodes binary output as base64 for safe transmission across the JS/Rust boundary

- **OPA policy integration**:
  - Subprocess operations are gated by OPA policies before execution
  - Policy input includes operation type, command, arguments, working directory, and environment variables
  - Supports three operation types: `command_output`, `command_spawn`, and `exec`
  - Added `subprocess` field to `PoliciesConfig` to configure subprocess policy chains

- **Runtime integration**:
  - Added `SubprocessConfig` to `ExecutionConfig` for passing policy chains to the runtime
  - Conditionally registers subprocess extension and injects JavaScript wrappers when subprocess policies are configured
  - Integrated subprocess policy chain initialization in `main.rs`

- **Example policy** (`policies/subprocess.rego`):
  - Provides template for defining allowed commands and shell command patterns
  - Demonstrates filtering by operation type, command name, and working directory

- **Comprehensive testing**:
  - Unit tests for policy input serialization, base64 encoding, and options deserialization
  - Integration tests verifying policy allow/deny behavior for subprocess operations

## Implementation Details

- Binary output from subprocess calls is base64-encoded in Rust and decoded back to `Uint8Array` in JavaScript for the Deno API
- The `child_process.exec()` implementation supports configurable encoding (defaults to UTF-8 strings, can be set to "buffer" for binary)
- Shell execution for `exec()` is platform-aware (uses `/bin/sh -c` on Unix, `cmd /C` on Windows)
- Policy evaluation is async and occurs before any subprocess is spawned

https://claude.ai/code/session_011eLgvj7BYjWQzr42j3WHK5