### PR TITLE
feat(ci): add aarch64-linux binary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
             bin_name: mcp-v8-linux
             build_cmd: cargo build --release --target x86_64-unknown-linux-gnu
             out_path: server/target/x86_64-unknown-linux-gnu/release/server
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            bin_name: mcp-v8-linux-arm64
+            build_cmd: cargo build --release --target aarch64-unknown-linux-gnu
+            out_path: server/target/aarch64-unknown-linux-gnu/release/server
           - name: macOS ARM64
             os: macos-14
             target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary
- Adds aarch64-linux (ARM64) binary builds to the release workflow
- Publishes `server-mcp-v8-linux-arm64` and `server-mcp-v8-linux-arm64.gz` release assets
- Uses GitHub's `ubuntu-24.04-arm` runner for native ARM64 builds

## Motivation
NixOS deployments on aarch64-linux instances need a prebuilt binary to avoid compiling V8 from source, which takes 15-20 minutes on ARM.

## Implementation
Added a new matrix entry in the existing build strategy:
- **Runner:** `ubuntu-24.04-arm` (GitHub-hosted ARM64 runner)
- **Target:** `aarch64-unknown-linux-gnu`
- **V8 library:** The flake's `nix develop` shell automatically resolves `RUSTY_V8_ARCHIVE` to the correct `librusty_v8_release_aarch64-unknown-linux-gnu.a` on ARM runners

## Test plan
- [ ] Verify the release workflow builds successfully on ARM runner
- [ ] Verify the produced binary runs on aarch64-linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)