### PR TITLE
Make mcp.callTool throw McpToolError on tool errors

### DIFF
--- a/server/src/engine/mcp_client.rs
+++ b/server/src/engine/mcp_client.rs
@@ -9,7 +9,7 @@
 //! mcp.servers                              // string[] — connected server names
 //! mcp.listTools("server")                  // [{server, name, description, inputSchema}, ...]
 //! mcp.listTools()                          // all tools from all servers
-//! await mcp.callTool("server", "tool", {}) // {content: [...], isError: bool}
+//! await mcp.callTool("server", "tool", {}) // {content: [...], isError: false} — throws McpToolError on error
 //! ```
 
 use std::cell::RefCell;
@@ -418,20 +418,44 @@ pub fn inject_mcp(runtime: &mut JsRuntime) -> Result<(), String> {
 /// JavaScript wrapper that provides the `globalThis.mcp` API.
 const MCP_JS_WRAPPER: &str = r#"
 (function() {
+    /**
+     * Error thrown when an MCP tool returns an error result.
+     * The original result (with content and isError) is available on the `result` property.
+     */
+    class McpToolError extends Error {
+        constructor(serverName, toolName, result) {
+            var text = (result.content && result.content.length > 0 && result.content[0].text)
+                ? result.content[0].text
+                : 'Tool returned an error';
+            super('mcp.callTool ' + serverName + '.' + toolName + ' failed: ' + text);
+            this.name = 'McpToolError';
+            this.result = result;
+            this.serverName = serverName;
+            this.toolName = toolName;
+        }
+    }
+    globalThis.McpToolError = McpToolError;
+
     globalThis.mcp = {
         /**
          * Call a tool on a connected MCP server.
+         * Throws McpToolError if the tool returns an error result (isError: true).
          * @param {string} serverName - Name of the MCP server
          * @param {string} toolName - Name of the tool to call
          * @param {object} [args] - Arguments to pass to the tool
          * @returns {Promise<{content: Array, isError: boolean}>}
+         * @throws {McpToolError} When the tool returns isError: true
          */
         callTool: async function(serverName, toolName, args) {
             if (typeof serverName !== 'string') throw new TypeError('mcp.callTool: serverName must be a string');
             if (typeof toolName !== 'string') throw new TypeError('mcp.callTool: toolName must be a string');
             var argsJson = args ? JSON.stringify(args) : '';
             var raw = await Deno.core.ops.op_mcp_call_tool(serverName, toolName, argsJson);
-            return JSON.parse(raw);
+            var result = JSON.parse(raw);
+            if (result.isError) {
+                throw new McpToolError(serverName, toolName, result);
+            }
+            return result;
         },
 
         /**


### PR DESCRIPTION
## Summary
Updated the MCP client JavaScript wrapper to throw a `McpToolError` exception when a tool returns an error result, rather than returning the error result to the caller. This provides better error handling semantics and makes error cases explicit.

## Key Changes
- Added `McpToolError` class that extends `Error` and captures the original result, server name, and tool name
- Modified `mcp.callTool()` to check the `isError` flag on the result and throw `McpToolError` if true
- Updated JSDoc comments to document the new error-throwing behavior
- Updated the API documentation comment to reflect that `callTool` throws on errors instead of returning `{isError: true}`

## Implementation Details
- The `McpToolError` message is constructed from the tool's error content (if available) or a generic fallback message
- The original result object is preserved on the `result` property of the error for inspection if needed
- The error class is exposed as `globalThis.McpToolError` for use in catch blocks
- This is a breaking change for callers that were previously checking the `isError` flag on the returned result

https://claude.ai/code/session_01DBkCTckBQYsyQ97a7tDkuL