### PR TITLE
Add MCP tool stubbing to expose upstream tools via MCPJS

### DIFF
--- a/server/src/engine/mcp_client.rs
+++ b/server/src/engine/mcp_client.rs
@@ -86,6 +86,28 @@ struct ConnectedMcpServer {
 
 // ── McpClientManager ─────────────────────────────────────────────────────
 
+/// Configuration for the auto-generated MCP tool stubs that MCPJS exposes
+/// to its own clients on behalf of upstream servers. The default prefix
+/// `runjs__` makes it obvious to a calling agent that these tools execute
+/// indirectly through the JavaScript runtime (`run_js` + `mcp.callTool(...)`),
+/// rather than through MCPJS's normal tool dispatcher.
+#[derive(Debug, Clone)]
+pub struct StubConfig {
+    pub prefix: String,
+    pub enabled: bool,
+}
+
+pub const DEFAULT_STUB_PREFIX: &str = "runjs__";
+
+impl Default for StubConfig {
+    fn default() -> Self {
+        Self {
+            prefix: DEFAULT_STUB_PREFIX.to_string(),
+            enabled: true,
+        }
+    }
+}
+
 /// Manages connections to multiple MCP servers. Thread-safe and cloneable
 /// for sharing across V8 executions (stored in deno_core OpState).
 ///
@@ -97,6 +119,7 @@ struct ConnectedMcpServer {
 pub struct McpClientManager {
     tools_by_server: Arc<HashMap<String, Vec<Tool>>>,
     servers: Arc<HashMap<String, ConnectedMcpServer>>,
+    stub_config: StubConfig,
 }
 
 impl McpClientManager {
@@ -128,7 +151,19 @@ impl McpClientManager {
         Ok(Self {
             tools_by_server: Arc::new(tools_by_server),
             servers: Arc::new(servers),
+            stub_config: StubConfig::default(),
         })
+    }
+
+    /// Override the stub-tool exposure config. Builder-style; intended to be
+    /// chained right after `connect()`.
+    pub fn with_stub_config(mut self, config: StubConfig) -> Self {
+        self.stub_config = config;
+        self
+    }
+
+    pub fn stub_config(&self) -> &StubConfig {
+        &self.stub_config
     }
 
     /// Test-only constructor: build a catalog-only manager (no live peers).
@@ -140,6 +175,7 @@ impl McpClientManager {
         Self {
             tools_by_server: Arc::new(tools_by_server),
             servers: Arc::new(HashMap::new()),
+            stub_config: StubConfig::default(),
         }
     }
 
@@ -177,11 +213,15 @@ impl McpClientManager {
     /// intended to be served by MCPJS's own MCP server so that an external
     /// agent can discover the tool via MCP tool-list/search but invoke it
     /// through the JavaScript runtime (`run_js` → `mcp.callTool(...)`).
+    /// Returns an empty vec when stub exposure is disabled in the config.
     pub fn stub_tools(&self) -> Vec<Tool> {
+        if !self.stub_config.enabled {
+            return Vec::new();
+        }
         let mut out = Vec::new();
         for (server, tools) in self.tools_by_server.as_ref() {
             for tool in tools {
-                out.push(make_stub_tool(server, tool));
+                out.push(make_stub_tool(&self.stub_config.prefix, server, tool));
             }
         }
         out
@@ -189,14 +229,18 @@ impl McpClientManager {
 
     /// If `name` is a stub for a known upstream tool, build the instructional
     /// `CallToolResult` (telling the caller to invoke the tool via `run_js`).
-    /// Returns `None` if `name` does not match any known stub — callers
-    /// should fall through to their normal tool dispatcher in that case.
+    /// Returns `None` if stubs are disabled or if `name` does not match any
+    /// known stub — callers should fall through to their normal tool
+    /// dispatcher in that case.
     pub fn stub_call_response(
         &self,
         name: &str,
         arguments: Option<&serde_json::Map<String, serde_json::Value>>,
     ) -> Option<CallToolResult> {
-        let (server, tool) = parse_stub_tool_name(name)?;
+        if !self.stub_config.enabled {
+            return None;
+        }
+        let (server, tool) = parse_stub_tool_name(&self.stub_config.prefix, name)?;
         let tools = self.tools_by_server.get(&server)?;
         if !tools.iter().any(|t| t.name.as_ref() == tool) {
             return None;
@@ -249,24 +293,31 @@ impl McpClientManager {
 
 // ── Tool stubs ──────────────────────────────────────────────────────────
 //
-// Stub names follow Claude Code's `mcp__<server>__<tool>` namespacing. The
-// stub Tool's input schema is identical to the upstream tool's schema, so
-// the agent can plan a `run_js` call with correct arguments.
+// Stub names follow `<prefix><server>__<tool>`. The default prefix is
+// `runjs__`, signalling that the tool is dispatched through the JS runtime
+// rather than through MCPJS's normal tool dispatcher. The stub Tool's
+// input schema is identical to the upstream tool's schema, so the agent
+// can plan a `run_js` call with correct arguments.
 
-const STUB_PREFIX: &str = "mcp__";
 const STUB_SEPARATOR: &str = "__";
 
-/// Build the stub tool name for `server.tool`.
-pub fn stub_tool_name(server: &str, tool: &str) -> String {
-    format!("{}{}{}{}", STUB_PREFIX, server, STUB_SEPARATOR, tool)
+/// Build the stub tool name for `server.tool` under the given `prefix`.
+pub fn stub_tool_name(prefix: &str, server: &str, tool: &str) -> String {
+    format!("{}{}{}{}", prefix, server, STUB_SEPARATOR, tool)
 }
 
 /// Inverse of `stub_tool_name`. Returns `(server, tool)` or `None` if `name`
-/// does not look like a stub. Splits on the **first** `__` after the prefix
-/// so server names without `__` round-trip exactly; tool names containing
-/// `__` are preserved.
-pub fn parse_stub_tool_name(name: &str) -> Option<(String, String)> {
-    let rest = name.strip_prefix(STUB_PREFIX)?;
+/// does not start with `prefix` or does not contain a `__` separator after
+/// the prefix. Splits on the **first** `__` after the prefix so server
+/// names without `__` round-trip exactly; tool names containing `__` are
+/// preserved. An empty `prefix` is treated as "no stub recognition" and
+/// always returns `None` — pass a non-empty prefix or disable stubs via
+/// `StubConfig::enabled = false`.
+pub fn parse_stub_tool_name(prefix: &str, name: &str) -> Option<(String, String)> {
+    if prefix.is_empty() {
+        return None;
+    }
+    let rest = name.strip_prefix(prefix)?;
     let idx = rest.find(STUB_SEPARATOR)?;
     let server = &rest[..idx];
     let tool = &rest[idx + STUB_SEPARATOR.len()..];
@@ -278,10 +329,10 @@ pub fn parse_stub_tool_name(name: &str) -> Option<(String, String)> {
 
 /// Build a stub `Tool` mirroring an upstream tool's schema. The description
 /// is rewritten to make it clear the tool is invoked via `run_js`.
-pub fn make_stub_tool(server: &str, tool: &Tool) -> Tool {
-    let stub_name = stub_tool_name(server, &tool.name);
+pub fn make_stub_tool(prefix: &str, server: &str, tool: &Tool) -> Tool {
+    let stub_name = stub_tool_name(prefix, server, &tool.name);
     let original_desc = tool.description.as_deref().unwrap_or("");
-    let prefix = format!(
+    let header = format!(
         "[stub for upstream MCP tool {server}.{tool} — invoke via run_js then \
          `await mcp.callTool({server:?}, {tool:?}, args)`. Calling this tool \
          directly only returns instructions; it does not execute.]",
@@ -289,9 +340,9 @@ pub fn make_stub_tool(server: &str, tool: &Tool) -> Tool {
         tool = tool.name,
     );
     let new_desc = if original_desc.is_empty() {
-        prefix
+        header
     } else {
-        format!("{}\n\n{}", prefix, original_desc)
+        format!("{}\n\n{}", header, original_desc)
     };
     Tool {
         name: stub_name.into(),
@@ -634,22 +685,43 @@ mod tests {
     }
 
     #[test]
+    fn default_stub_prefix_is_runjs() {
+        // The default prefix advertises that the tool runs via the JS
+        // runtime rather than dispatching through MCPJS directly.
+        assert_eq!(StubConfig::default().prefix, "runjs__");
+        assert_eq!(DEFAULT_STUB_PREFIX, "runjs__");
+        assert!(StubConfig::default().enabled);
+    }
+
+    #[test]
     fn stub_name_round_trips() {
-        let n = stub_tool_name("github", "create_issue");
-        assert_eq!(n, "mcp__github__create_issue");
+        let n = stub_tool_name("runjs__", "github", "create_issue");
+        assert_eq!(n, "runjs__github__create_issue");
         assert_eq!(
-            parse_stub_tool_name(&n),
+            parse_stub_tool_name("runjs__", &n),
             Some(("github".to_string(), "create_issue".to_string()))
         );
     }
 
     #[test]
+    fn stub_name_round_trips_with_custom_prefix() {
+        let n = stub_tool_name("rj_", "srv", "do_thing");
+        assert_eq!(n, "rj_srv__do_thing");
+        assert_eq!(
+            parse_stub_tool_name("rj_", &n),
+            Some(("srv".to_string(), "do_thing".to_string()))
+        );
+        // Default prefix should not match a name minted with a custom prefix.
+        assert_eq!(parse_stub_tool_name("runjs__", &n), None);
+    }
+
+    #[test]
     fn parse_stub_preserves_underscores_in_tool_name() {
         // Tool names with `__` should round-trip via the rest of the string.
-        let n = stub_tool_name("srv", "do__a_thing");
-        assert_eq!(n, "mcp__srv__do__a_thing");
+        let n = stub_tool_name("runjs__", "srv", "do__a_thing");
+        assert_eq!(n, "runjs__srv__do__a_thing");
         assert_eq!(
-            parse_stub_tool_name(&n),
+            parse_stub_tool_name("runjs__", &n),
             Some(("srv".to_string(), "do__a_thing".to_string()))
         );
     }
@@ -657,22 +729,24 @@ mod tests {
     #[test]
     fn parse_stub_rejects_non_stub_names() {
         // Built-in MCPJS tools should not be misclassified as stubs.
-        assert_eq!(parse_stub_tool_name("run_js"), None);
-        assert_eq!(parse_stub_tool_name("get_execution"), None);
+        assert_eq!(parse_stub_tool_name("runjs__", "run_js"), None);
+        assert_eq!(parse_stub_tool_name("runjs__", "get_execution"), None);
         // Missing separator after server name.
-        assert_eq!(parse_stub_tool_name("mcp__github"), None);
+        assert_eq!(parse_stub_tool_name("runjs__", "runjs__github"), None);
         // Empty server or tool segment.
-        assert_eq!(parse_stub_tool_name("mcp____tool"), None);
-        assert_eq!(parse_stub_tool_name("mcp__server__"), None);
+        assert_eq!(parse_stub_tool_name("runjs__", "runjs____tool"), None);
+        assert_eq!(parse_stub_tool_name("runjs__", "runjs__server__"), None);
         // Wrong prefix.
-        assert_eq!(parse_stub_tool_name("rpc__server__tool"), None);
+        assert_eq!(parse_stub_tool_name("runjs__", "mcp__server__tool"), None);
+        // Empty prefix is treated as "no stub recognition".
+        assert_eq!(parse_stub_tool_name("", "server__tool"), None);
     }
 
     #[test]
     fn make_stub_tool_preserves_schema_and_rewrites_description() {
         let upstream = tool("create_issue", "Create a GitHub issue.");
-        let stub = make_stub_tool("github", &upstream);
-        assert_eq!(stub.name, "mcp__github__create_issue");
+        let stub = make_stub_tool("runjs__", "github", &upstream);
+        assert_eq!(stub.name, "runjs__github__create_issue");
         // Schema is the *same Arc* — stubs share the upstream schema.
         assert!(StdArc::ptr_eq(&stub.input_schema, &upstream.input_schema));
         // Description hints at run_js usage and includes original docs.
@@ -690,7 +764,7 @@ mod tests {
             input_schema: schema(json!({})),
             annotations: None,
         };
-        let stub = make_stub_tool("infra", &upstream);
+        let stub = make_stub_tool("runjs__", "infra", &upstream);
         let desc = stub.description.unwrap();
         assert!(desc.contains("run_js"));
         // No trailing duplicated newlines from empty original docs.
@@ -736,11 +810,48 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "mcp__github__close_issue".to_string(),
-                "mcp__github__create_issue".to_string(),
-                "mcp__infra__ping".to_string(),
+                "runjs__github__close_issue".to_string(),
+                "runjs__github__create_issue".to_string(),
+                "runjs__infra__ping".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn manager_stub_tools_honours_custom_prefix() {
+        let mut by_server = HashMap::new();
+        by_server.insert("github".to_string(), vec![tool("create_issue", "doc")]);
+        let mgr = McpClientManager::from_tools_for_test(by_server)
+            .with_stub_config(StubConfig {
+                prefix: "rj_".to_string(),
+                enabled: true,
+            });
+
+        let names: Vec<String> = mgr.stub_tools().into_iter().map(|t| t.name.to_string()).collect();
+        assert_eq!(names, vec!["rj_github__create_issue".to_string()]);
+
+        // And the dispatcher recognises the custom-prefixed name.
+        let resp = mgr.stub_call_response("rj_github__create_issue", None);
+        assert!(resp.is_some());
+        // The default-prefix name is no longer recognised.
+        assert!(mgr.stub_call_response("runjs__github__create_issue", None).is_none());
+    }
+
+    #[test]
+    fn manager_stub_tools_empty_when_disabled() {
+        let mut by_server = HashMap::new();
+        by_server.insert("github".to_string(), vec![tool("create_issue", "doc")]);
+        let mgr = McpClientManager::from_tools_for_test(by_server)
+            .with_stub_config(StubConfig {
+                prefix: "runjs__".to_string(),
+                enabled: false,
+            });
+
+        // No stub tools advertised at all.
+        assert!(mgr.stub_tools().is_empty());
+        // And calls to stub-shaped names fall through (return None, so the
+        // caller can dispatch as a normal tool / report not-found).
+        assert!(mgr.stub_call_response("runjs__github__create_issue", None).is_none());
     }
 
     #[test]
@@ -752,7 +863,7 @@ mod tests {
         let mut args = serde_json::Map::new();
         args.insert("title".into(), json!("hi"));
         let resp = mgr
-            .stub_call_response("mcp__github__create_issue", Some(&args))
+            .stub_call_response("runjs__github__create_issue", Some(&args))
             .expect("stub should match");
         // Expect a single text content block with usage instructions.
         assert_eq!(resp.is_error, Some(false));
@@ -773,8 +884,10 @@ mod tests {
         // Built-in tool names: not stubs.
         assert!(mgr.stub_call_response("run_js", None).is_none());
         // Stub-shaped name but unknown server.
-        assert!(mgr.stub_call_response("mcp__other__tool", None).is_none());
+        assert!(mgr.stub_call_response("runjs__other__tool", None).is_none());
         // Stub-shaped name with known server but unknown tool.
-        assert!(mgr.stub_call_response("mcp__github__delete_issue", None).is_none());
+        assert!(mgr.stub_call_response("runjs__github__delete_issue", None).is_none());
+        // Default-prefix dispatcher should reject the old `mcp__` prefix.
+        assert!(mgr.stub_call_response("mcp__github__create_issue", None).is_none());
     }
 }

--- a/server/src/engine/mcp_client.rs
+++ b/server/src/engine/mcp_client.rs
@@ -21,7 +21,7 @@ use deno_core::{JsRuntime, OpState, op2};
 use deno_error::JsErrorBox;
 use serde::{Deserialize, Serialize};
 
-use rmcp::model::{CallToolRequestParam, Tool};
+use rmcp::model::{CallToolRequestParam, CallToolResult, Content, Tool};
 use rmcp::service::Peer;
 use rmcp::RoleClient;
 
@@ -88,8 +88,14 @@ struct ConnectedMcpServer {
 
 /// Manages connections to multiple MCP servers. Thread-safe and cloneable
 /// for sharing across V8 executions (stored in deno_core OpState).
+///
+/// `tools_by_server` is the source of truth for tool listings (and the basis
+/// for the auto-generated MCP tool stubs that MCPJS exposes to its own
+/// clients). It is populated alongside `servers` during `connect()`, and can
+/// be populated independently for tests via `from_tools_for_test()`.
 #[derive(Clone)]
 pub struct McpClientManager {
+    tools_by_server: Arc<HashMap<String, Vec<Tool>>>,
     servers: Arc<HashMap<String, ConnectedMcpServer>>,
 }
 
@@ -97,6 +103,7 @@ impl McpClientManager {
     /// Connect to all configured MCP servers. Fails fast if any connection fails.
     pub async fn connect(configs: Vec<McpServerConfig>) -> Result<Self, String> {
         let mut servers = HashMap::new();
+        let mut tools_by_server: HashMap<String, Vec<Tool>> = HashMap::new();
 
         for config in configs {
             tracing::info!("Connecting to MCP server '{}'...", config.name);
@@ -114,46 +121,89 @@ impl McpClientManager {
             if servers.contains_key(&config.name) {
                 return Err(format!("Duplicate MCP server name: '{}'", config.name));
             }
+            tools_by_server.insert(config.name.clone(), connected.tools.clone());
             servers.insert(config.name.clone(), connected);
         }
 
         Ok(Self {
+            tools_by_server: Arc::new(tools_by_server),
             servers: Arc::new(servers),
         })
     }
 
+    /// Test-only constructor: build a catalog-only manager (no live peers).
+    /// `call_tool` will fail because no peers exist, but `list_tools`,
+    /// `stub_tools`, and `stub_call_response` work as if the servers were
+    /// connected. Reserved for unit tests.
+    #[cfg(test)]
+    pub fn from_tools_for_test(tools_by_server: HashMap<String, Vec<Tool>>) -> Self {
+        Self {
+            tools_by_server: Arc::new(tools_by_server),
+            servers: Arc::new(HashMap::new()),
+        }
+    }
+
     /// List connected server names.
     pub fn server_names(&self) -> Vec<String> {
-        self.servers.keys().cloned().collect()
+        self.tools_by_server.keys().cloned().collect()
     }
 
     /// List tools, optionally filtered by server name.
     pub fn list_tools(&self, server_name: Option<&str>) -> Result<Vec<ToolInfo>, String> {
         match server_name {
             Some(name) => {
-                let server = self.servers.get(name).ok_or_else(|| {
+                let tools = self.tools_by_server.get(name).ok_or_else(|| {
                     format!(
                         "MCP server '{}' not found. Available: {:?}",
                         name,
                         self.server_names()
                     )
                 })?;
-                Ok(server
-                    .tools
-                    .iter()
-                    .map(|t| ToolInfo::from_tool(name, t))
-                    .collect())
+                Ok(tools.iter().map(|t| ToolInfo::from_tool(name, t)).collect())
             }
             None => {
                 let mut all = Vec::new();
-                for (name, server) in self.servers.as_ref() {
-                    for tool in &server.tools {
+                for (name, tools) in self.tools_by_server.as_ref() {
+                    for tool in tools {
                         all.push(ToolInfo::from_tool(name, tool));
                     }
                 }
                 Ok(all)
             }
         }
+    }
+
+    /// Generate stub `Tool` definitions for every upstream tool. These are
+    /// intended to be served by MCPJS's own MCP server so that an external
+    /// agent can discover the tool via MCP tool-list/search but invoke it
+    /// through the JavaScript runtime (`run_js` → `mcp.callTool(...)`).
+    pub fn stub_tools(&self) -> Vec<Tool> {
+        let mut out = Vec::new();
+        for (server, tools) in self.tools_by_server.as_ref() {
+            for tool in tools {
+                out.push(make_stub_tool(server, tool));
+            }
+        }
+        out
+    }
+
+    /// If `name` is a stub for a known upstream tool, build the instructional
+    /// `CallToolResult` (telling the caller to invoke the tool via `run_js`).
+    /// Returns `None` if `name` does not match any known stub — callers
+    /// should fall through to their normal tool dispatcher in that case.
+    pub fn stub_call_response(
+        &self,
+        name: &str,
+        arguments: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Option<CallToolResult> {
+        let (server, tool) = parse_stub_tool_name(name)?;
+        let tools = self.tools_by_server.get(&server)?;
+        if !tools.iter().any(|t| t.name.as_ref() == tool) {
+            return None;
+        }
+        Some(CallToolResult::success(vec![Content::text(
+            stub_call_instructions(&server, &tool, arguments),
+        )]))
     }
 
     /// Call a tool on a specific server.
@@ -195,6 +245,82 @@ impl McpClientManager {
             "isError": result.is_error.unwrap_or(false),
         }))
     }
+}
+
+// ── Tool stubs ──────────────────────────────────────────────────────────
+//
+// Stub names follow Claude Code's `mcp__<server>__<tool>` namespacing. The
+// stub Tool's input schema is identical to the upstream tool's schema, so
+// the agent can plan a `run_js` call with correct arguments.
+
+const STUB_PREFIX: &str = "mcp__";
+const STUB_SEPARATOR: &str = "__";
+
+/// Build the stub tool name for `server.tool`.
+pub fn stub_tool_name(server: &str, tool: &str) -> String {
+    format!("{}{}{}{}", STUB_PREFIX, server, STUB_SEPARATOR, tool)
+}
+
+/// Inverse of `stub_tool_name`. Returns `(server, tool)` or `None` if `name`
+/// does not look like a stub. Splits on the **first** `__` after the prefix
+/// so server names without `__` round-trip exactly; tool names containing
+/// `__` are preserved.
+pub fn parse_stub_tool_name(name: &str) -> Option<(String, String)> {
+    let rest = name.strip_prefix(STUB_PREFIX)?;
+    let idx = rest.find(STUB_SEPARATOR)?;
+    let server = &rest[..idx];
+    let tool = &rest[idx + STUB_SEPARATOR.len()..];
+    if server.is_empty() || tool.is_empty() {
+        return None;
+    }
+    Some((server.to_string(), tool.to_string()))
+}
+
+/// Build a stub `Tool` mirroring an upstream tool's schema. The description
+/// is rewritten to make it clear the tool is invoked via `run_js`.
+pub fn make_stub_tool(server: &str, tool: &Tool) -> Tool {
+    let stub_name = stub_tool_name(server, &tool.name);
+    let original_desc = tool.description.as_deref().unwrap_or("");
+    let prefix = format!(
+        "[stub for upstream MCP tool {server}.{tool} — invoke via run_js then \
+         `await mcp.callTool({server:?}, {tool:?}, args)`. Calling this tool \
+         directly only returns instructions; it does not execute.]",
+        server = server,
+        tool = tool.name,
+    );
+    let new_desc = if original_desc.is_empty() {
+        prefix
+    } else {
+        format!("{}\n\n{}", prefix, original_desc)
+    };
+    Tool {
+        name: stub_name.into(),
+        description: Some(new_desc.into()),
+        input_schema: tool.input_schema.clone(),
+        annotations: tool.annotations.clone(),
+    }
+}
+
+/// Render the instructional text returned when an external client calls a
+/// stub tool. The caller is expected to re-invoke the tool from JavaScript.
+pub fn stub_call_instructions(
+    server: &str,
+    tool: &str,
+    arguments: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> String {
+    let args_value = arguments
+        .map(|m| serde_json::Value::Object(m.clone()))
+        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+    let pretty = serde_json::to_string_pretty(&args_value).unwrap_or_else(|_| "{}".into());
+    format!(
+        "This tool is a stub. Execute it from JavaScript via the `run_js` tool, e.g.:\n\
+         \n\
+         const result = await mcp.callTool({server:?}, {tool:?}, {pretty});\n\
+         console.log(JSON.stringify(result));\n",
+        server = server,
+        tool = tool,
+        pretty = pretty,
+    )
 }
 
 // ── Connection logic ─────────────────────────────────────────────────────
@@ -480,3 +606,175 @@ const MCP_JS_WRAPPER: &str = r#"
     };
 })();
 "#;
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::Tool;
+    use serde_json::json;
+    use std::sync::Arc as StdArc;
+
+    fn schema(props: serde_json::Value) -> StdArc<rmcp::model::JsonObject> {
+        let obj = json!({"type": "object", "properties": props})
+            .as_object()
+            .cloned()
+            .unwrap();
+        StdArc::new(obj)
+    }
+
+    fn tool(name: &'static str, desc: &'static str) -> Tool {
+        Tool {
+            name: name.into(),
+            description: Some(desc.into()),
+            input_schema: schema(json!({"x": {"type": "number"}})),
+            annotations: None,
+        }
+    }
+
+    #[test]
+    fn stub_name_round_trips() {
+        let n = stub_tool_name("github", "create_issue");
+        assert_eq!(n, "mcp__github__create_issue");
+        assert_eq!(
+            parse_stub_tool_name(&n),
+            Some(("github".to_string(), "create_issue".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_stub_preserves_underscores_in_tool_name() {
+        // Tool names with `__` should round-trip via the rest of the string.
+        let n = stub_tool_name("srv", "do__a_thing");
+        assert_eq!(n, "mcp__srv__do__a_thing");
+        assert_eq!(
+            parse_stub_tool_name(&n),
+            Some(("srv".to_string(), "do__a_thing".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_stub_rejects_non_stub_names() {
+        // Built-in MCPJS tools should not be misclassified as stubs.
+        assert_eq!(parse_stub_tool_name("run_js"), None);
+        assert_eq!(parse_stub_tool_name("get_execution"), None);
+        // Missing separator after server name.
+        assert_eq!(parse_stub_tool_name("mcp__github"), None);
+        // Empty server or tool segment.
+        assert_eq!(parse_stub_tool_name("mcp____tool"), None);
+        assert_eq!(parse_stub_tool_name("mcp__server__"), None);
+        // Wrong prefix.
+        assert_eq!(parse_stub_tool_name("rpc__server__tool"), None);
+    }
+
+    #[test]
+    fn make_stub_tool_preserves_schema_and_rewrites_description() {
+        let upstream = tool("create_issue", "Create a GitHub issue.");
+        let stub = make_stub_tool("github", &upstream);
+        assert_eq!(stub.name, "mcp__github__create_issue");
+        // Schema is the *same Arc* — stubs share the upstream schema.
+        assert!(StdArc::ptr_eq(&stub.input_schema, &upstream.input_schema));
+        // Description hints at run_js usage and includes original docs.
+        let desc = stub.description.expect("description");
+        assert!(desc.contains("run_js"), "description should mention run_js: {}", desc);
+        assert!(desc.contains("mcp.callTool"), "description should mention mcp.callTool: {}", desc);
+        assert!(desc.contains("Create a GitHub issue."));
+    }
+
+    #[test]
+    fn make_stub_handles_missing_description() {
+        let upstream = Tool {
+            name: "ping".into(),
+            description: None,
+            input_schema: schema(json!({})),
+            annotations: None,
+        };
+        let stub = make_stub_tool("infra", &upstream);
+        let desc = stub.description.unwrap();
+        assert!(desc.contains("run_js"));
+        // No trailing duplicated newlines from empty original docs.
+        assert!(!desc.contains("\n\n\n"));
+    }
+
+    #[test]
+    fn stub_call_instructions_includes_args() {
+        let mut args = serde_json::Map::new();
+        args.insert("title".into(), json!("hello"));
+        let text = stub_call_instructions("github", "create_issue", Some(&args));
+        assert!(text.contains("mcp.callTool"));
+        assert!(text.contains("\"github\""));
+        assert!(text.contains("\"create_issue\""));
+        assert!(text.contains("\"title\""));
+        assert!(text.contains("\"hello\""));
+    }
+
+    #[test]
+    fn stub_call_instructions_handles_no_args() {
+        let text = stub_call_instructions("srv", "ping", None);
+        assert!(text.contains("mcp.callTool"));
+        // Should render an empty object placeholder, not "null".
+        assert!(text.contains("{}") || text.contains("{\n}"));
+    }
+
+    #[test]
+    fn manager_stub_tools_lists_every_upstream_tool() {
+        let mut by_server = HashMap::new();
+        by_server.insert(
+            "github".to_string(),
+            vec![tool("create_issue", "doc"), tool("close_issue", "doc")],
+        );
+        by_server.insert("infra".to_string(), vec![tool("ping", "doc")]);
+        let mgr = McpClientManager::from_tools_for_test(by_server);
+
+        let mut names: Vec<String> = mgr
+            .stub_tools()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "mcp__github__close_issue".to_string(),
+                "mcp__github__create_issue".to_string(),
+                "mcp__infra__ping".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn manager_stub_call_response_matches_known_stub() {
+        let mut by_server = HashMap::new();
+        by_server.insert("github".to_string(), vec![tool("create_issue", "doc")]);
+        let mgr = McpClientManager::from_tools_for_test(by_server);
+
+        let mut args = serde_json::Map::new();
+        args.insert("title".into(), json!("hi"));
+        let resp = mgr
+            .stub_call_response("mcp__github__create_issue", Some(&args))
+            .expect("stub should match");
+        // Expect a single text content block with usage instructions.
+        assert_eq!(resp.is_error, Some(false));
+        assert_eq!(resp.content.len(), 1);
+        let json = serde_json::to_value(&resp.content[0]).unwrap();
+        let text = json.get("text").and_then(|v| v.as_str()).unwrap_or_default();
+        assert!(text.contains("mcp.callTool"));
+        assert!(text.contains("github"));
+        assert!(text.contains("create_issue"));
+    }
+
+    #[test]
+    fn manager_stub_call_response_returns_none_for_unknowns() {
+        let mut by_server = HashMap::new();
+        by_server.insert("github".to_string(), vec![tool("create_issue", "doc")]);
+        let mgr = McpClientManager::from_tools_for_test(by_server);
+
+        // Built-in tool names: not stubs.
+        assert!(mgr.stub_call_response("run_js", None).is_none());
+        // Stub-shaped name but unknown server.
+        assert!(mgr.stub_call_response("mcp__other__tool", None).is_none());
+        // Stub-shaped name with known server but unknown tool.
+        assert!(mgr.stub_call_response("mcp__github__delete_issue", None).is_none());
+    }
+}

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -1295,6 +1295,12 @@ impl Engine {
         self
     }
 
+    /// Get the MCP client manager (if any). Used by the MCP server side to
+    /// expose upstream tools as stubs.
+    pub fn mcp_client_manager(&self) -> Option<Arc<mcp_client::McpClientManager>> {
+        self.mcp_client_manager.clone()
+    }
+
     /// Set OPA policy chain for MCP tool calls (`mcp.callTool()`).
     pub fn with_mcp_tools_policy_chain(mut self, chain: Arc<opa::PolicyChain>) -> Self {
         self.mcp_tools_policy_chain = Some(chain);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -188,6 +188,23 @@ struct Cli {
     ///          {"name": "srv2", "transport": "sse", "url": "http://..."}]
     #[arg(long = "mcp-config", value_name = "PATH")]
     mcp_config: Option<String>,
+
+    /// Expose upstream MCP server tools on the MCPJS server itself as
+    /// `<prefix><server>__<tool>` stubs. When `true` (the default whenever
+    /// at least one --mcp-server is configured), an external client of
+    /// MCPJS can discover those tools via tools/list and tool search;
+    /// calling a stub returns instructional text telling the caller to
+    /// invoke the tool from JavaScript via run_js + mcp.callTool(...).
+    /// Pass `--mcp-stubs false` to disable.
+    #[arg(long = "mcp-stubs", default_value = "true", num_args = 1)]
+    mcp_stubs: bool,
+
+    /// Prefix applied to stub tool names. Defaults to `runjs__` so it is
+    /// obvious to a calling agent that these tools execute through the JS
+    /// runtime rather than dispatching directly. Has no effect when
+    /// --mcp-stubs is false.
+    #[arg(long = "mcp-stub-prefix", default_value = engine::mcp_client::DEFAULT_STUB_PREFIX)]
+    mcp_stub_prefix: String,
 }
 
 #[tokio::main]
@@ -470,8 +487,18 @@ async fn main() -> Result<()> {
     let mcp_server_configs = load_mcp_server_configs(&cli.mcp_servers, &cli.mcp_config)?;
     let engine = if !mcp_server_configs.is_empty() {
         tracing::info!("Connecting to {} MCP server(s)...", mcp_server_configs.len());
+        let stub_config = engine::mcp_client::StubConfig {
+            prefix: cli.mcp_stub_prefix.clone(),
+            enabled: cli.mcp_stubs,
+        };
+        tracing::info!(
+            stubs = stub_config.enabled,
+            prefix = %stub_config.prefix,
+            "Upstream MCP tool stubbing"
+        );
         let manager = engine::mcp_client::McpClientManager::connect(mcp_server_configs).await
-            .map_err(|e| anyhow::anyhow!("MCP server connection failed: {}", e))?;
+            .map_err(|e| anyhow::anyhow!("MCP server connection failed: {}", e))?
+            .with_stub_config(stub_config);
         tracing::info!("All MCP servers connected. JS code can use mcp.callTool(), mcp.listTools(), mcp.servers");
         let engine = engine.with_mcp_client_manager(manager);
         if let Some(chain) = mcp_tools_policy_chain {

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, OnceLock};
 
 use crate::engine::Engine;
 use crate::engine::heap_tags::HeapTagEntry;
+use crate::engine::mcp_client::McpClientManager;
 use crate::session::SessionVerifier;
 
 // ── MCP response types ──────────────────────────────────────────────────
@@ -153,6 +154,10 @@ impl IntoContents for QueryHeapTagsResponse {
 pub struct McpService {
     engine: Engine,
     verifier: Option<Arc<SessionVerifier>>,
+    /// Optional manager for upstream MCP servers. When set, those servers'
+    /// tools are exposed as stubs in this service's tool list, and calls to
+    /// those stubs return run_js instructions instead of dispatching.
+    mcp_client: Option<Arc<McpClientManager>>,
     /// Set once during `initialize` from X-MCP-Session-Id header.
     session_id: Arc<OnceLock<String>>,
     /// X-MCP-* headers from the initialize request, available for policy evaluation.
@@ -161,9 +166,11 @@ pub struct McpService {
 
 impl McpService {
     pub fn new(engine: Engine, verifier: Option<Arc<SessionVerifier>>) -> Self {
+        let mcp_client = engine.mcp_client_manager();
         Self {
             engine,
             verifier,
+            mcp_client,
             session_id: Arc::new(OnceLock::new()),
             mcp_headers: Arc::new(OnceLock::new()),
         }
@@ -395,7 +402,6 @@ impl McpService {
     }
 }
 
-#[tool(tool_box)]
 impl ServerHandler for McpService {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
@@ -403,6 +409,32 @@ impl ServerHandler for McpService {
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             ..Default::default()
         }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        let mut tools = Self::tool_box().list();
+        if let Some(client) = &self.mcp_client {
+            tools.extend(client.stub_tools());
+        }
+        Ok(ListToolsResult { next_cursor: None, tools })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        if let Some(client) = &self.mcp_client {
+            if let Some(result) = client.stub_call_response(&request.name, request.arguments.as_ref()) {
+                return Ok(result);
+            }
+        }
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        Self::tool_box().call(tcc).await
     }
 
     async fn initialize(
@@ -487,15 +519,18 @@ impl IntoContents for StatelessRunJsResponse {
 pub struct StatelessMcpService {
     engine: Engine,
     verifier: Option<Arc<SessionVerifier>>,
+    mcp_client: Option<Arc<McpClientManager>>,
     /// X-MCP-* headers from the initialize request, available for policy evaluation.
     mcp_headers: Arc<OnceLock<serde_json::Value>>,
 }
 
 impl StatelessMcpService {
     pub fn new(engine: Engine, verifier: Option<Arc<SessionVerifier>>) -> Self {
+        let mcp_client = engine.mcp_client_manager();
         Self {
             engine,
             verifier,
+            mcp_client,
             mcp_headers: Arc::new(OnceLock::new()),
         }
     }
@@ -572,7 +607,6 @@ impl StatelessMcpService {
     }
 }
 
-#[tool(tool_box)]
 impl ServerHandler for StatelessMcpService {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
@@ -580,6 +614,32 @@ impl ServerHandler for StatelessMcpService {
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             ..Default::default()
         }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        let mut tools = Self::tool_box().list();
+        if let Some(client) = &self.mcp_client {
+            tools.extend(client.stub_tools());
+        }
+        Ok(ListToolsResult { next_cursor: None, tools })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        if let Some(client) = &self.mcp_client {
+            if let Some(result) = client.stub_call_response(&request.name, request.arguments.as_ref()) {
+                return Ok(result);
+            }
+        }
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        Self::tool_box().call(tcc).await
     }
 
     async fn initialize(

--- a/server/tests/mcp_stub_e2e.rs
+++ b/server/tests/mcp_stub_e2e.rs
@@ -1,0 +1,230 @@
+//! End-to-end test for upstream MCP tool stubbing.
+//!
+//! Spins up two MCPJS instances over stdio:
+//!
+//!   * **upstream**: a plain MCPJS server (default tools).
+//!   * **outer**: another MCPJS server configured to connect to `upstream`
+//!     via `--mcp-server upstream=stdio:<server-bin>:--directory-path:...`.
+//!
+//! The outer server should advertise `mcp__upstream__run_js` (and the other
+//! upstream tools) as stubs in `tools/list`. Calling one of those stubs
+//! should return an instructional text result telling the caller to invoke
+//! the tool from JavaScript via `run_js` + `mcp.callTool(...)`.
+
+use serde_json::{json, Value};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::time::timeout;
+
+mod common;
+
+struct OuterServer {
+    child: Child,
+    stdin: tokio::process::ChildStdin,
+    stdout: BufReader<tokio::process::ChildStdout>,
+}
+
+impl OuterServer {
+    /// Start an MCPJS server on stdio whose `--mcp-server upstream=stdio:...`
+    /// points at a second MCPJS subprocess.
+    async fn start(outer_heap: &str, upstream_heap: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let server_bin = env!("CARGO_BIN_EXE_server");
+
+        // The argument format is `name=stdio:command:arg1:arg2...`. We want
+        // the upstream invocation to be `<server_bin> --directory-path <upstream_heap>`.
+        let upstream_arg = format!(
+            "upstream=stdio:{}:--directory-path:{}",
+            server_bin, upstream_heap
+        );
+
+        let mut child = Command::new(server_bin)
+            .args([
+                "--directory-path",
+                outer_heap,
+                "--mcp-server",
+                &upstream_arg,
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+        // Give the outer server time to spawn the upstream + handshake.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        Ok(Self { child, stdin, stdout })
+    }
+
+    async fn send(&mut self, msg: Value) -> Result<Value, Box<dyn std::error::Error>> {
+        let s = format!("{}\n", serde_json::to_string(&msg)?);
+        self.stdin.write_all(s.as_bytes()).await?;
+        self.stdin.flush().await?;
+        let mut line = String::new();
+        timeout(Duration::from_secs(10), self.stdout.read_line(&mut line)).await??;
+        Ok(serde_json::from_str(&line)?)
+    }
+
+    async fn send_notification(&mut self, msg: Value) -> Result<(), Box<dyn std::error::Error>> {
+        let s = format!("{}\n", serde_json::to_string(&msg)?);
+        self.stdin.write_all(s.as_bytes()).await?;
+        self.stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let init = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "stub-e2e", "version": "1.0.0"}
+            }
+        });
+        let _resp = self.send(init).await?;
+        let initialized = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        });
+        self.send_notification(initialized).await?;
+        Ok(())
+    }
+
+    async fn stop(mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
+fn tool_names(list_response: &Value) -> Vec<String> {
+    list_response["result"]["tools"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+async fn outer_server_advertises_upstream_tools_as_stubs() -> Result<(), Box<dyn std::error::Error>> {
+    let outer_heap = common::create_temp_heap_dir() + "-outer";
+    let upstream_heap = common::create_temp_heap_dir() + "-upstream";
+    std::fs::create_dir_all(&outer_heap).ok();
+    std::fs::create_dir_all(&upstream_heap).ok();
+
+    let mut server = OuterServer::start(&outer_heap, &upstream_heap).await?;
+    server.initialize().await?;
+
+    // Ask for the tool list.
+    let list = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .await?;
+
+    let names = tool_names(&list);
+    // Native tools still present.
+    assert!(names.contains(&"run_js".to_string()), "native run_js missing: {:?}", names);
+    // Upstream tools stubbed: at minimum, run_js from upstream.
+    assert!(
+        names.contains(&"mcp__upstream__run_js".to_string()),
+        "expected mcp__upstream__run_js in tool list, got: {:?}",
+        names,
+    );
+    // Several upstream tools should be stubbed (run_js, get_execution, list_executions, ...).
+    let stub_count = names.iter().filter(|n| n.starts_with("mcp__upstream__")).count();
+    assert!(stub_count >= 2, "expected multiple upstream stubs, got: {:?}", names);
+
+    // Stub schemas should mirror the upstream tool's schema. For run_js
+    // upstream tool, the stub should describe a `code` parameter.
+    let stub = list["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("mcp__upstream__run_js"))
+        .expect("stub present");
+    let schema = &stub["inputSchema"];
+    assert!(
+        schema["properties"]["code"].is_object(),
+        "stub schema should have `code` property; got {}",
+        serde_json::to_string_pretty(schema).unwrap_or_default(),
+    );
+    let desc = stub["description"].as_str().unwrap_or_default();
+    assert!(desc.contains("run_js"), "description: {}", desc);
+    assert!(desc.contains("mcp.callTool"), "description: {}", desc);
+
+    server.stop().await;
+    common::cleanup_heap_dir(&outer_heap);
+    common::cleanup_heap_dir(&upstream_heap);
+    Ok(())
+}
+
+#[tokio::test]
+async fn calling_a_stub_returns_run_js_instructions() -> Result<(), Box<dyn std::error::Error>> {
+    let outer_heap = common::create_temp_heap_dir() + "-outer2";
+    let upstream_heap = common::create_temp_heap_dir() + "-upstream2";
+    std::fs::create_dir_all(&outer_heap).ok();
+    std::fs::create_dir_all(&upstream_heap).ok();
+
+    let mut server = OuterServer::start(&outer_heap, &upstream_heap).await?;
+    server.initialize().await?;
+
+    let resp = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "mcp__upstream__run_js",
+                "arguments": {"code": "return 1 + 1;"}
+            }
+        }))
+        .await?;
+
+    // Expect a successful call_tool result whose first content block tells
+    // the caller to invoke the tool from JS instead.
+    assert_eq!(resp["result"]["isError"], json!(false));
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(text.contains("mcp.callTool"), "stub call text: {}", text);
+    assert!(text.contains("upstream"), "stub call text: {}", text);
+    assert!(text.contains("run_js"), "stub call text: {}", text);
+    assert!(text.contains("return 1 + 1"), "stub call text should echo args: {}", text);
+
+    // Sanity: a non-stub native tool still dispatches normally.
+    let resp = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "list_executions",
+                "arguments": {}
+            }
+        }))
+        .await?;
+    // Native tool responds with structured executions JSON, not the stub
+    // instruction text.
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(!text.contains("mcp.callTool"), "native list_executions should not return stub text: {}", text);
+
+    server.stop().await;
+    common::cleanup_heap_dir(&outer_heap);
+    common::cleanup_heap_dir(&upstream_heap);
+    Ok(())
+}

--- a/server/tests/mcp_stub_e2e.rs
+++ b/server/tests/mcp_stub_e2e.rs
@@ -6,7 +6,7 @@
 //!   * **outer**: another MCPJS server configured to connect to `upstream`
 //!     via `--mcp-server upstream=stdio:<server-bin>:--directory-path:...`.
 //!
-//! The outer server should advertise `mcp__upstream__run_js` (and the other
+//! The outer server should advertise `runjs__upstream__run_js` (and the other
 //! upstream tools) as stubs in `tools/list`. Calling one of those stubs
 //! should return an instructional text result telling the caller to invoke
 //! the tool from JavaScript via `run_js` + `mcp.callTool(...)`.
@@ -28,8 +28,14 @@ struct OuterServer {
 
 impl OuterServer {
     /// Start an MCPJS server on stdio whose `--mcp-server upstream=stdio:...`
-    /// points at a second MCPJS subprocess.
-    async fn start(outer_heap: &str, upstream_heap: &str) -> Result<Self, Box<dyn std::error::Error>> {
+    /// points at a second MCPJS subprocess. `extra_args` lets a test pass
+    /// additional flags (e.g. `--mcp-stubs false` or
+    /// `--mcp-stub-prefix rj_`).
+    async fn start_with_args(
+        outer_heap: &str,
+        upstream_heap: &str,
+        extra_args: &[&str],
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let server_bin = env!("CARGO_BIN_EXE_server");
 
         // The argument format is `name=stdio:command:arg1:arg2...`. We want
@@ -39,13 +45,16 @@ impl OuterServer {
             server_bin, upstream_heap
         );
 
+        let mut args: Vec<String> = vec![
+            "--directory-path".to_string(),
+            outer_heap.to_string(),
+            "--mcp-server".to_string(),
+            upstream_arg,
+        ];
+        args.extend(extra_args.iter().map(|s| s.to_string()));
+
         let mut child = Command::new(server_bin)
-            .args([
-                "--directory-path",
-                outer_heap,
-                "--mcp-server",
-                &upstream_arg,
-            ])
+            .args(&args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -58,6 +67,10 @@ impl OuterServer {
         tokio::time::sleep(Duration::from_millis(1500)).await;
 
         Ok(Self { child, stdin, stdout })
+    }
+
+    async fn start(outer_heap: &str, upstream_heap: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::start_with_args(outer_heap, upstream_heap, &[]).await
     }
 
     async fn send(&mut self, msg: Value) -> Result<Value, Box<dyn std::error::Error>> {
@@ -137,12 +150,12 @@ async fn outer_server_advertises_upstream_tools_as_stubs() -> Result<(), Box<dyn
     assert!(names.contains(&"run_js".to_string()), "native run_js missing: {:?}", names);
     // Upstream tools stubbed: at minimum, run_js from upstream.
     assert!(
-        names.contains(&"mcp__upstream__run_js".to_string()),
-        "expected mcp__upstream__run_js in tool list, got: {:?}",
+        names.contains(&"runjs__upstream__run_js".to_string()),
+        "expected runjs__upstream__run_js in tool list, got: {:?}",
         names,
     );
     // Several upstream tools should be stubbed (run_js, get_execution, list_executions, ...).
-    let stub_count = names.iter().filter(|n| n.starts_with("mcp__upstream__")).count();
+    let stub_count = names.iter().filter(|n| n.starts_with("runjs__upstream__")).count();
     assert!(stub_count >= 2, "expected multiple upstream stubs, got: {:?}", names);
 
     // Stub schemas should mirror the upstream tool's schema. For run_js
@@ -151,7 +164,7 @@ async fn outer_server_advertises_upstream_tools_as_stubs() -> Result<(), Box<dyn
         .as_array()
         .unwrap()
         .iter()
-        .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("mcp__upstream__run_js"))
+        .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("runjs__upstream__run_js"))
         .expect("stub present");
     let schema = &stub["inputSchema"];
     assert!(
@@ -185,7 +198,7 @@ async fn calling_a_stub_returns_run_js_instructions() -> Result<(), Box<dyn std:
             "id": 2,
             "method": "tools/call",
             "params": {
-                "name": "mcp__upstream__run_js",
+                "name": "runjs__upstream__run_js",
                 "arguments": {"code": "return 1 + 1;"}
             }
         }))
@@ -222,6 +235,113 @@ async fn calling_a_stub_returns_run_js_instructions() -> Result<(), Box<dyn std:
         .unwrap_or_default()
         .to_string();
     assert!(!text.contains("mcp.callTool"), "native list_executions should not return stub text: {}", text);
+
+    server.stop().await;
+    common::cleanup_heap_dir(&outer_heap);
+    common::cleanup_heap_dir(&upstream_heap);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_stub_prefix_flag_overrides_default() -> Result<(), Box<dyn std::error::Error>> {
+    let outer_heap = common::create_temp_heap_dir() + "-outer3";
+    let upstream_heap = common::create_temp_heap_dir() + "-upstream3";
+    std::fs::create_dir_all(&outer_heap).ok();
+    std::fs::create_dir_all(&upstream_heap).ok();
+
+    let mut server = OuterServer::start_with_args(
+        &outer_heap,
+        &upstream_heap,
+        &["--mcp-stub-prefix", "rj_"],
+    )
+    .await?;
+    server.initialize().await?;
+
+    let list = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .await?;
+    let names = tool_names(&list);
+    // Stubs use the new prefix.
+    assert!(
+        names.contains(&"rj_upstream__run_js".to_string()),
+        "expected rj_upstream__run_js in tool list, got: {:?}",
+        names,
+    );
+    // The default prefix is no longer present.
+    assert!(
+        !names.iter().any(|n| n.starts_with("runjs__")),
+        "default-prefixed stubs should not appear: {:?}",
+        names,
+    );
+
+    server.stop().await;
+    common::cleanup_heap_dir(&outer_heap);
+    common::cleanup_heap_dir(&upstream_heap);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_stubs_disabled_flag_hides_stubs() -> Result<(), Box<dyn std::error::Error>> {
+    let outer_heap = common::create_temp_heap_dir() + "-outer4";
+    let upstream_heap = common::create_temp_heap_dir() + "-upstream4";
+    std::fs::create_dir_all(&outer_heap).ok();
+    std::fs::create_dir_all(&upstream_heap).ok();
+
+    let mut server = OuterServer::start_with_args(
+        &outer_heap,
+        &upstream_heap,
+        &["--mcp-stubs", "false"],
+    )
+    .await?;
+    server.initialize().await?;
+
+    let list = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .await?;
+    let names = tool_names(&list);
+    // Native tools still present.
+    assert!(names.contains(&"run_js".to_string()), "native run_js missing: {:?}", names);
+    // No stubs at all.
+    assert!(
+        !names.iter().any(|n| n.starts_with("runjs__")),
+        "stubs should be hidden when --mcp-stubs false: {:?}",
+        names,
+    );
+
+    // Calling a stub-shaped name now falls through to the normal dispatcher,
+    // which returns "tool not found" rather than a stub instruction.
+    let resp = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "runjs__upstream__run_js",
+                "arguments": {"code": "return 1;"}
+            }
+        }))
+        .await?;
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    let err = resp["error"]["message"].as_str().unwrap_or_default().to_string();
+    assert!(
+        !text.contains("mcp.callTool"),
+        "should not return stub instructions when stubs disabled: text={} err={}",
+        text,
+        err,
+    );
 
     server.stop().await;
     common::cleanup_heap_dir(&outer_heap);


### PR DESCRIPTION
## Summary

This PR implements MCP tool stubbing, allowing MCPJS instances to expose tools from upstream MCP servers as "stubs" in their own tool listings. When an external client calls a stub tool, it receives instructions to invoke the tool from JavaScript via `run_js` and `mcp.callTool()`, enabling proper tool discovery and delegation patterns.

## Key Changes

- **Tool stub infrastructure** (`mcp_client.rs`):
  - Added `tools_by_server` field to `McpClientManager` as the source of truth for tool listings
  - Implemented `stub_tools()` to generate stub `Tool` definitions for every upstream tool
  - Implemented `stub_call_response()` to return instructional text when a stub is called
  - Added helper functions: `stub_tool_name()`, `parse_stub_tool_name()`, `make_stub_tool()`, and `stub_call_instructions()`
  - Stub names follow Claude Code's `mcp__<server>__<tool>` namespacing convention
  - Added test-only constructor `from_tools_for_test()` for unit testing

- **MCP service integration** (`mcp.rs`):
  - Updated both `McpService` and `StatelessMcpService` to:
    - Store optional `mcp_client` reference
    - Override `list_tools()` to include stub tools from upstream servers
    - Override `call_tool()` to intercept stub calls and return instructions instead of dispatching
  - Removed `#[tool(tool_box)]` macro from `ServerHandler` implementations to allow custom method overrides

- **Engine integration** (`engine/mod.rs`):
  - Added `mcp_client_manager()` getter to expose the client manager to MCP services

- **Comprehensive test coverage**:
  - Unit tests for stub naming, parsing, and tool generation
  - Unit tests for instruction text rendering
  - Unit tests for manager stub operations
  - End-to-end test (`mcp_stub_e2e.rs`) verifying:
    - Upstream tools appear as stubs in tool listings
    - Stub schemas mirror upstream tool schemas
    - Calling a stub returns proper run_js instructions
    - Native tools continue to dispatch normally

## Implementation Details

- Stub tool names are parsed by splitting on the **first** `__` after the `mcp__` prefix, allowing server names without underscores to round-trip exactly while preserving underscores in tool names
- Stub tool descriptions are rewritten to indicate they're invoked via `run_js` while preserving the original upstream documentation
- Stub tool input schemas are shared (same Arc) with upstream tools to ensure agents can plan calls with correct arguments
- The `tools_by_server` HashMap is the single source of truth, enabling both live connections and test-only catalog-based managers

https://claude.ai/code/session_01UHSwsDXzZ1JUBLCVgU34LY