### PR TITLE
chore: drop macOS x86_64 (Intel) support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,12 +98,6 @@ jobs:
             bin_name: mcp-v8-cli-linux-arm64
             cargo_target_flag: --target aarch64-unknown-linux-gnu
             out_path: target/aarch64-unknown-linux-gnu/release/mcp-v8-cli
-          - name: macOS x86_64
-            os: macos-13
-            target: x86_64-apple-darwin
-            bin_name: mcp-v8-cli-macos-x86_64
-            cargo_target_flag: --target x86_64-apple-darwin
-            out_path: target/x86_64-apple-darwin/release/mcp-v8-cli
           - name: macOS ARM64
             os: macos-14
             target: aarch64-apple-darwin
@@ -270,7 +264,7 @@ jobs:
 
           # CLI binaries: artifact dir = matrix.bin_name (e.g. mcp-v8-cli-linux-x86_64)
           # binary inside is named "mcp-v8-cli" — rename to the dir name
-          for dir in dist/mcp-v8-cli-linux-x86_64 dist/mcp-v8-cli-linux-arm64 dist/mcp-v8-cli-macos-x86_64 dist/mcp-v8-cli-macos-arm64; do
+          for dir in dist/mcp-v8-cli-linux-x86_64 dist/mcp-v8-cli-linux-arm64 dist/mcp-v8-cli-macos-arm64; do
             [ -d "$dir" ] || continue
             name=$(basename "$dir")
             cp "$dir/mcp-v8-cli" "dist/final/$name"

--- a/docs/http-api-and-client.md
+++ b/docs/http-api-and-client.md
@@ -63,7 +63,6 @@ $ curl http://localhost:3000/api/cli
   "assets": [
     { "platform": "linux-x86_64",  "url": "http://localhost:3000/api/cli/linux-x86_64",  "available": true  },
     { "platform": "linux-aarch64", "url": "http://localhost:3000/api/cli/linux-aarch64", "available": true  },
-    { "platform": "macos-x86_64",  "url": "http://localhost:3000/api/cli/macos-x86_64",  "available": true  },
     { "platform": "macos-aarch64", "url": "http://localhost:3000/api/cli/macos-aarch64", "available": true  }
   ]
 }
@@ -76,7 +75,7 @@ $ curl http://localhost:3000/api/cli
 
 Streams the CLI binary directly (no redirect, no GitHub dependency).
 
-Supported platforms: `linux-x86_64`, `linux-aarch64`, `macos-x86_64`, `macos-aarch64`.
+Supported platforms: `linux-x86_64`, `linux-aarch64`, `macos-aarch64`.
 
 ```bash
 # Download and run immediately
@@ -105,9 +104,6 @@ curl -fL http://my-server:3000/api/cli/linux-aarch64 -o mcp-v8-cli && chmod +x m
 
 # macOS ARM64 (Apple Silicon)
 curl -fL http://my-server:3000/api/cli/macos-aarch64 -o mcp-v8-cli && chmod +x mcp-v8-cli
-
-# macOS x86_64 (Intel)
-curl -fL http://my-server:3000/api/cli/macos-x86_64 -o mcp-v8-cli && chmod +x mcp-v8-cli
 ```
 
 **From a GitHub Release:**

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -39,7 +39,8 @@ case "$OS" in
     if [ "$ARCH" = "arm64" ]; then
       PLATFORM="macos-arm64"
     else
-      PLATFORM="macos"
+      echo "Unsupported macOS architecture: $ARCH (only Apple Silicon / arm64 is supported)"
+      exit 1
     fi
     ;;
   *)

--- a/mcp-v8-client/openapi.json
+++ b/mcp-v8-client/openapi.json
@@ -37,13 +37,13 @@
           "cli"
         ],
         "summary": "Download the CLI binary for a specific platform directly from this server.",
-        "description": "The binary is embedded at build time and always matches the running server\nversion. Returns 404 if the server was built without embedded binaries\n(dev/local builds).\n\nSupported platforms: `linux-x86_64`, `linux-aarch64`, `macos-x86_64`, `macos-aarch64`.",
+        "description": "The binary is embedded at build time and always matches the running server\nversion. Returns 404 if the server was built without embedded binaries\n(dev/local builds).\n\nSupported platforms: `linux-x86_64`, `linux-aarch64`, `macos-aarch64`.",
         "operationId": "cli_download_handler",
         "parameters": [
           {
             "name": "platform",
             "in": "path",
-            "description": "Target platform (linux-x86_64 | linux-aarch64 | macos-x86_64 | macos-aarch64)",
+            "description": "Target platform (linux-x86_64 | linux-aarch64 | macos-aarch64)",
             "required": true,
             "schema": {
               "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -37,13 +37,13 @@
           "cli"
         ],
         "summary": "Download the CLI binary for a specific platform directly from this server.",
-        "description": "The binary is embedded at build time and always matches the running server\nversion. Returns 404 if the server was built without embedded binaries\n(dev/local builds).\n\nSupported platforms: `linux-x86_64`, `linux-aarch64`, `macos-x86_64`, `macos-aarch64`.",
+        "description": "The binary is embedded at build time and always matches the running server\nversion. Returns 404 if the server was built without embedded binaries\n(dev/local builds).\n\nSupported platforms: `linux-x86_64`, `linux-aarch64`, `macos-aarch64`.",
         "operationId": "cli_download_handler",
         "parameters": [
           {
             "name": "platform",
             "in": "path",
-            "description": "Target platform (linux-x86_64 | linux-aarch64 | macos-x86_64 | macos-aarch64)",
+            "description": "Target platform (linux-x86_64 | linux-aarch64 | macos-aarch64)",
             "required": true,
             "schema": {
               "type": "string"

--- a/server/build.rs
+++ b/server/build.rs
@@ -11,7 +11,6 @@ fn main() {
     for platform in &[
         "linux-x86_64",
         "linux-aarch64",
-        "macos-x86_64",
         "macos-aarch64",
     ] {
         let env_key = format!(

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -20,7 +20,6 @@ const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 // Each is an empty slice in dev builds (no MCP_V8_CLI_* env vars set).
 static CLI_LINUX_X86_64:  &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/cli-linux-x86_64.bin"));
 static CLI_LINUX_AARCH64: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/cli-linux-aarch64.bin"));
-static CLI_MACOS_X86_64:  &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/cli-macos-x86_64.bin"));
 static CLI_MACOS_AARCH64: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/cli-macos-aarch64.bin"));
 
 struct PlatformCli {
@@ -32,7 +31,6 @@ struct PlatformCli {
 const PLATFORMS: &[PlatformCli] = &[
     PlatformCli { platform: "linux-x86_64",  filename: "mcp-v8-cli-linux-x86_64",  bytes: CLI_LINUX_X86_64  },
     PlatformCli { platform: "linux-aarch64", filename: "mcp-v8-cli-linux-arm64",   bytes: CLI_LINUX_AARCH64 },
-    PlatformCli { platform: "macos-x86_64",  filename: "mcp-v8-cli-macos-x86_64",  bytes: CLI_MACOS_X86_64  },
     PlatformCli { platform: "macos-aarch64", filename: "mcp-v8-cli-macos-arm64",   bytes: CLI_MACOS_AARCH64 },
 ];
 
@@ -443,12 +441,12 @@ async fn cli_index_handler(
 /// version. Returns 404 if the server was built without embedded binaries
 /// (dev/local builds).
 ///
-/// Supported platforms: `linux-x86_64`, `linux-aarch64`, `macos-x86_64`, `macos-aarch64`.
+/// Supported platforms: `linux-x86_64`, `linux-aarch64`, `macos-aarch64`.
 #[utoipa::path(
     get,
     path = "/api/cli/{platform}",
     params(
-        ("platform" = String, Path, description = "Target platform (linux-x86_64 | linux-aarch64 | macos-x86_64 | macos-aarch64)"),
+        ("platform" = String, Path, description = "Target platform (linux-x86_64 | linux-aarch64 | macos-aarch64)"),
     ),
     responses(
         (status = 200, description = "CLI binary (application/octet-stream)"),


### PR DESCRIPTION
macos-13 runners are slow/scarce and block the release workflow indefinitely. Drops the macOS x86_64 CLI build target across release.yml, server/build.rs, server/src/api.rs, openapi.json, install-cli.sh, and docs.