### PR TITLE
fix: arch-specific openssl include dir for zigbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,15 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             clang llvm pkg-config libssl-dev
           echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=/usr" >> $GITHUB_ENV
-          # Also set the target-triple-prefixed variant that openssl-sys checks first
+          # opensslconf.h is in an arch-specific dir on Ubuntu; find it dynamically
+          OPENSSL_ARCH_INCLUDE=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "x86_64-linux-gnu")
+          OPENSSL_INC="/usr/include/${OPENSSL_ARCH_INCLUDE}"
+          echo "OPENSSL_INCLUDE_DIR=${OPENSSL_INC}" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=/usr/lib/${OPENSSL_ARCH_INCLUDE}" >> $GITHUB_ENV
+          # Set generic and target-prefixed variants for openssl-sys
           TARGET_UPPER=$(echo "${{ matrix.target }}" | tr '[:lower:]-' '[:upper:]_')
-          echo "${TARGET_UPPER}_OPENSSL_DIR=/usr" >> $GITHUB_ENV
+          echo "${TARGET_UPPER}_OPENSSL_INCLUDE_DIR=${OPENSSL_INC}" >> $GITHUB_ENV
+          echo "${TARGET_UPPER}_OPENSSL_LIB_DIR=/usr/lib/${OPENSSL_ARCH_INCLUDE}" >> $GITHUB_ENV
 
       # ── Linux: install Zig + cargo-zigbuild for portable glibc floor ──
       - name: Install Zig + cargo-zigbuild (Linux only)
@@ -172,10 +177,15 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             clang llvm pkg-config libssl-dev
           echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=/usr" >> $GITHUB_ENV
-          # Also set the target-triple-prefixed variant that openssl-sys checks first
+          # opensslconf.h is in an arch-specific dir on Ubuntu; find it dynamically
+          OPENSSL_ARCH_INCLUDE=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "x86_64-linux-gnu")
+          OPENSSL_INC="/usr/include/${OPENSSL_ARCH_INCLUDE}"
+          echo "OPENSSL_INCLUDE_DIR=${OPENSSL_INC}" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=/usr/lib/${OPENSSL_ARCH_INCLUDE}" >> $GITHUB_ENV
+          # Set generic and target-prefixed variants for openssl-sys
           TARGET_UPPER=$(echo "${{ matrix.target }}" | tr '[:lower:]-' '[:upper:]_')
-          echo "${TARGET_UPPER}_OPENSSL_DIR=/usr" >> $GITHUB_ENV
+          echo "${TARGET_UPPER}_OPENSSL_INCLUDE_DIR=${OPENSSL_INC}" >> $GITHUB_ENV
+          echo "${TARGET_UPPER}_OPENSSL_LIB_DIR=/usr/lib/${OPENSSL_ARCH_INCLUDE}" >> $GITHUB_ENV
 
       - name: Install Zig + cargo-zigbuild (Linux only)
         if: ${{ matrix.use_zigbuild }}
@@ -250,10 +260,15 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             clang llvm pkg-config libssl-dev
           echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=/usr" >> $GITHUB_ENV
-          # Also set the target-triple-prefixed variant that openssl-sys checks first
+          # opensslconf.h is in an arch-specific dir on Ubuntu; find it dynamically
+          OPENSSL_ARCH_INCLUDE=$(dpkg-architecture -qDEB_HOST_MULTIARCH 2>/dev/null || echo "x86_64-linux-gnu")
+          OPENSSL_INC="/usr/include/${OPENSSL_ARCH_INCLUDE}"
+          echo "OPENSSL_INCLUDE_DIR=${OPENSSL_INC}" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=/usr/lib/${OPENSSL_ARCH_INCLUDE}" >> $GITHUB_ENV
+          # Set generic and target-prefixed variants for openssl-sys
           TARGET_UPPER=$(echo "${{ matrix.target }}" | tr '[:lower:]-' '[:upper:]_')
-          echo "${TARGET_UPPER}_OPENSSL_DIR=/usr" >> $GITHUB_ENV
+          echo "${TARGET_UPPER}_OPENSSL_INCLUDE_DIR=${OPENSSL_INC}" >> $GITHUB_ENV
+          echo "${TARGET_UPPER}_OPENSSL_LIB_DIR=/usr/lib/${OPENSSL_ARCH_INCLUDE}" >> $GITHUB_ENV
 
       - name: Install Zig + cargo-zigbuild (Linux only)
         if: ${{ matrix.use_zigbuild }}


### PR DESCRIPTION
Use dpkg-architecture to find the correct /usr/include/<arch>-linux-gnu/openssl include path for openssl-sys.