### PR TITLE
fix: native-tls/vendored for static openssl in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
           # is incompatible with our 2.17 glibc floor target. Vendored compiles
           # openssl from source as a static lib with no external glibc deps.
           echo "OPENSSL_VENDORED=1" >> $GITHUB_ENV
+          # Also tell the linker where system libs live for any crate that emits
+          # cargo:rustc-link-lib=ssl outside of openssl-sys (e.g. ring)
+          echo "RUSTFLAGS=-L/usr/lib/${ARCH_TRIPLE}" >> $GITHUB_ENV
 
       # ── Linux: install Zig + cargo-zigbuild for portable glibc floor ──
       - name: Install Zig + cargo-zigbuild (Linux only)
@@ -194,6 +197,9 @@ jobs:
           # is incompatible with our 2.17 glibc floor target. Vendored compiles
           # openssl from source as a static lib with no external glibc deps.
           echo "OPENSSL_VENDORED=1" >> $GITHUB_ENV
+          # Also tell the linker where system libs live for any crate that emits
+          # cargo:rustc-link-lib=ssl outside of openssl-sys (e.g. ring)
+          echo "RUSTFLAGS=-L/usr/lib/${ARCH_TRIPLE}" >> $GITHUB_ENV
 
       - name: Install Zig + cargo-zigbuild (Linux only)
         if: ${{ matrix.use_zigbuild }}
@@ -281,6 +287,9 @@ jobs:
           # is incompatible with our 2.17 glibc floor target. Vendored compiles
           # openssl from source as a static lib with no external glibc deps.
           echo "OPENSSL_VENDORED=1" >> $GITHUB_ENV
+          # Also tell the linker where system libs live for any crate that emits
+          # cargo:rustc-link-lib=ssl outside of openssl-sys (e.g. ring)
+          echo "RUSTFLAGS=-L/usr/lib/${ARCH_TRIPLE}" >> $GITHUB_ENV
 
       - name: Install Zig + cargo-zigbuild (Linux only)
         if: ${{ matrix.use_zigbuild }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,7 @@ jobs:
           # is incompatible with our 2.17 glibc floor target. Vendored compiles
           # openssl from source as a static lib with no external glibc deps.
           echo "OPENSSL_VENDORED=1" >> $GITHUB_ENV
-          # Also tell the linker where system libs live for any crate that emits
-          # cargo:rustc-link-lib=ssl outside of openssl-sys (e.g. ring)
-          echo "RUSTFLAGS=-L/usr/lib/${ARCH_TRIPLE}" >> $GITHUB_ENV
+
 
       # ── Linux: install Zig + cargo-zigbuild for portable glibc floor ──
       - name: Install Zig + cargo-zigbuild (Linux only)
@@ -197,9 +195,7 @@ jobs:
           # is incompatible with our 2.17 glibc floor target. Vendored compiles
           # openssl from source as a static lib with no external glibc deps.
           echo "OPENSSL_VENDORED=1" >> $GITHUB_ENV
-          # Also tell the linker where system libs live for any crate that emits
-          # cargo:rustc-link-lib=ssl outside of openssl-sys (e.g. ring)
-          echo "RUSTFLAGS=-L/usr/lib/${ARCH_TRIPLE}" >> $GITHUB_ENV
+
 
       - name: Install Zig + cargo-zigbuild (Linux only)
         if: ${{ matrix.use_zigbuild }}
@@ -287,9 +283,7 @@ jobs:
           # is incompatible with our 2.17 glibc floor target. Vendored compiles
           # openssl from source as a static lib with no external glibc deps.
           echo "OPENSSL_VENDORED=1" >> $GITHUB_ENV
-          # Also tell the linker where system libs live for any crate that emits
-          # cargo:rustc-link-lib=ssl outside of openssl-sys (e.g. ring)
-          echo "RUSTFLAGS=-L/usr/lib/${ARCH_TRIPLE}" >> $GITHUB_ENV
+
 
       - name: Install Zig + cargo-zigbuild (Linux only)
         if: ${{ matrix.use_zigbuild }}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,6 +46,7 @@ rand = "0.8"
 http-body-util = "0.1"
 regorus = "0.5"
 reqwest = { version = "0.12", features = ["json"] }
+native-tls = { version = "0.2", features = ["vendored"] }
 url = "2"
 futures = "0.3"
 wasmparser = "0.225"


### PR DESCRIPTION
native-tls requests libssl/libcrypto dynamically; vendored feature compiles openssl from source. Removes RUSTFLAGS=-L.