### PR TITLE
explore: musl static server binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,56 @@ jobs:
           name: ${{ matrix.bin_name }}
           path: target/${{ matrix.target }}/release/mcp-v8-cli
 
+  # ── Server musl static builds (exploratory) ──────────────────────────────
+  # Uses gnu-target rusty_v8 prebuilts with musl linker — fully static binaries.
+  # continue-on-error: true so failures don't block the release.
+  build-server-musl:
+    name: Server (musl) – ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true   # exploratory — don't block release
+    strategy:
+      matrix:
+        include:
+          - name: Linux x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            rusty_v8_target: x86_64-unknown-linux-gnu
+            bin_name: mcp-v8-linux-musl
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            rusty_v8_target: aarch64-unknown-linux-gnu
+            bin_name: mcp-v8-linux-arm64-musl
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install musl + build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            musl-tools clang llvm pkg-config perl
+          echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
+          echo "OPENSSL_STATIC=1" >> $GITHUB_ENV
+          echo "OPENSSL_VENDORED=1" >> $GITHUB_ENV
+          echo "CC_aarch64_unknown_linux_musl=clang" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=clang" >> $GITHUB_ENV
+      - name: Fetch rusty_v8 static library (gnu target)
+        run: |
+          URL="https://github.com/denoland/rusty_v8/releases/download/v${RUSTY_V8_VERSION}/librusty_v8_release_${{ matrix.rusty_v8_target }}.a.gz"
+          curl -fL "$URL" -o librusty_v8.a.gz
+          gunzip librusty_v8.a.gz
+          echo "RUSTY_V8_ARCHIVE=$(pwd)/librusty_v8.a" >> $GITHUB_ENV
+      - name: Build server (musl)
+        run: cargo build --release -p server --target ${{ matrix.target }}
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.bin_name }}
+          path: target/${{ matrix.target }}/release/server
+
   # ── Publish mcp-v8-client to crates.io ────────────────────────────────────
   publish-crate:
     name: Publish mcp-v8-client to crates.io
@@ -109,7 +159,8 @@ jobs:
 
   # ── Assemble GitHub Release ────────────────────────────────────────────────
   release:
-    needs: build-cli
+    needs: [build-cli, build-server-musl]
+    if: always() && needs.build-cli.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -129,6 +180,13 @@ jobs:
             [ -d "$dir" ] || continue
             name=$(basename "$dir")
             cp "$dir/mcp-v8-cli" "dist/final/$name"
+          done
+
+          # Server musl binaries (exploratory — include if present, skip if missing)
+          for entry in mcp-v8-linux-musl mcp-v8-linux-arm64-musl; do
+            dir="dist/$entry"
+            [ -d "$dir" ] || continue
+            cp "$dir/server" "dist/final/$entry" || continue
           done
 
           # Include openapi.json from the repo


### PR DESCRIPTION
## Summary

Exploratory PR to test building fully static Linux server binaries using musl targets instead of glibc+zigbuild.

## Approach

Adds a new `build-server-musl` job in `.github/workflows/release.yml`:

- **Targets:** `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`
- **rusty_v8 prebuilts:** Since no `-musl` variants exist on denoland releases, we fetch the `-gnu` prebuilt `.a` and set `RUSTY_V8_ARCHIVE` to point at it — the static archive itself is target-agnostic at the symbol level, so the musl linker can consume it.
- **OpenSSL:** Fully vendored and statically linked (`OPENSSL_STATIC=1`, `OPENSSL_VENDORED=1`)
- **Cross-compile (ARM64):** Uses `clang` as the musl cross-linker via `CC_aarch64_unknown_linux_musl` and `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER`
- **`continue-on-error: true`** — exploratory; failures do not block the release workflow
- **`release` job** updated with `needs: [build-cli, build-server-musl]`, `if: always() && needs.build-cli.result == 'success'`, and graceful inclusion of musl artifacts when present

## Known risk

`native-tls` with `vendored` feature may not fully support musl; if the build fails on that, the next step would be switching `reqwest` to `rustls-tls` and dropping `native-tls` entirely.