### PR TITLE
explore: switch server to rustls, reinstate portable binary builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,70 @@ jobs:
           name: ${{ matrix.bin_name }}
           path: target/${{ matrix.target }}/release/mcp-v8-cli
 
+  # ── Server binary builds ──────────────────────────────────────────────────
+  # Portable server binaries built with rustls (no OpenSSL / no native-tls).
+  # Linux targets cross-compiled via cargo-zigbuild for glibc compatibility.
+  build-server:
+    name: Server – ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Linux x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            rusty_v8_target: x86_64-unknown-linux-gnu
+            bin_name: mcp-v8-linux
+            use_zigbuild: true
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            rusty_v8_target: aarch64-unknown-linux-gnu
+            bin_name: mcp-v8-linux-arm64
+            use_zigbuild: true
+          - name: macOS ARM64
+            os: macos-14
+            target: aarch64-apple-darwin
+            rusty_v8_target: aarch64-apple-darwin
+            bin_name: mcp-v8-macos-arm64
+            use_zigbuild: false
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install build dependencies (Linux only)
+        if: ${{ matrix.use_zigbuild }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends clang llvm pkg-config perl
+          echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
+      - name: Install Zig + cargo-zigbuild (Linux only)
+        if: ${{ matrix.use_zigbuild }}
+        run: |
+          pip install ziglang --quiet
+          cargo install cargo-zigbuild --locked --quiet
+      - name: Fetch rusty_v8 static library
+        run: |
+          URL="https://github.com/denoland/rusty_v8/releases/download/v${RUSTY_V8_VERSION}/librusty_v8_release_${{ matrix.rusty_v8_target }}.a.gz"
+          curl -fL "$URL" -o librusty_v8.a.gz && gunzip librusty_v8.a.gz
+          echo "RUSTY_V8_ARCHIVE=$(pwd)/librusty_v8.a" >> $GITHUB_ENV
+      - name: Build server – Linux (cargo-zigbuild)
+        if: ${{ matrix.use_zigbuild }}
+        run: |
+          cargo zigbuild --release -p server \
+            --target ${{ matrix.target }}.${{ env.GLIBC_FLOOR }}
+      - name: Build server – macOS (cargo)
+        if: ${{ !matrix.use_zigbuild }}
+        run: cargo build --release -p server --target ${{ matrix.target }}
+      - name: Upload server binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.bin_name }}
+          path: target/${{ matrix.target }}/release/server
+
   # ── Publish mcp-v8-client to crates.io ────────────────────────────────────
   publish-crate:
     name: Publish mcp-v8-client to crates.io
@@ -109,7 +173,7 @@ jobs:
 
   # ── Assemble GitHub Release ────────────────────────────────────────────────
   release:
-    needs: build-cli
+    needs: [build-cli, build-server]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -129,6 +193,13 @@ jobs:
             [ -d "$dir" ] || continue
             name=$(basename "$dir")
             cp "$dir/mcp-v8-cli" "dist/final/$name"
+          done
+
+          # Server binaries (artifact dir name = bin_name, file inside = "server")
+          for dir in dist/mcp-v8-linux dist/mcp-v8-linux-arm64 dist/mcp-v8-macos-arm64; do
+            [ -d "$dir" ] || continue
+            name=$(basename "$dir")
+            cp "$dir/server" "dist/final/$name"
           done
 
           # Include openapi.json from the repo

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -45,8 +45,7 @@ tokio-util = "0.7"
 rand = "0.8"
 http-body-util = "0.1"
 regorus = "0.5"
-reqwest = { version = "0.12", features = ["json"] }
-native-tls = { version = "0.2", features = ["vendored"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 url = "2"
 futures = "0.3"
 wasmparser = "0.225"


### PR DESCRIPTION
## Summary

Eliminates OpenSSL from the server build by switching from `native-tls` (vendored) to `rustls`. This removes the root cause of zigbuild + ARM64 failures and reinstates portable server binary builds in CI.

## Changes

### `server/Cargo.toml`
- Replaced `reqwest` (default TLS = native-tls) + explicit `native-tls = { features = ["vendored"] }` with:
  ```toml
  reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
  ```
- No more OpenSSL/native-tls anywhere in the server crate. The AWS SDK (0.0.26-alpha Smithy) already uses rustls internally.

### `.github/workflows/release.yml`
- Added `build-server` job with three matrix targets:
  - **Linux x86_64** — `cargo zigbuild` → glibc ≥ 2.17 portable binary
  - **Linux ARM64** — `cargo zigbuild` on `ubuntu-24.04-arm` → glibc ≥ 2.17 portable binary
  - **macOS ARM64** — plain `cargo build` on `macos-14`
- Each Linux build fetches the matching `librusty_v8` static library before compiling.
- Updated the `release` job:
  - `needs: [build-cli, build-server]`
  - Renames/organizes server artifacts (`mcp-v8-linux`, `mcp-v8-linux-arm64`, `mcp-v8-macos-arm64`) into the release alongside CLI binaries.

## Why rustls fixes the ARM64/zigbuild problem

`native-tls` with `vendored` pulls in OpenSSL, which requires `pkg-config` and C compilation with headers that don't cross-compile cleanly under zigbuild on ARM64. `rustls` is pure Rust — no C deps, no pkg-config, no cross-compilation friction.