### PR TITLE
explore: native runner server builds (plain cargo, no zigbuild)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,62 @@ jobs:
           name: ${{ matrix.bin_name }}
           path: target/${{ matrix.target }}/release/mcp-v8-cli
 
+  # ── Server binary builds (mcp-v8) ─────────────────────────────────────────
+  # Native runners — plain cargo build, no cross-compilation, no zigbuild.
+  # Binaries link against the runner's system glibc (~2.35 on ubuntu-latest).
+  # Tradeoff: won't run on RHEL7-era systems — fine for an alpha.
+  build-server:
+    name: Server – ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Linux x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            rusty_v8_target: x86_64-unknown-linux-gnu
+            bin_name: mcp-v8-linux
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            rusty_v8_target: aarch64-unknown-linux-gnu
+            bin_name: mcp-v8-linux-arm64
+          - name: macOS ARM64
+            os: macos-14
+            target: aarch64-apple-darwin
+            rusty_v8_target: aarch64-apple-darwin
+            bin_name: mcp-v8-macos-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install build dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            clang llvm pkg-config perl libssl-dev
+          echo "LIBCLANG_PATH=$(llvm-config --libdir)" >> $GITHUB_ENV
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install llvm
+          echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> $GITHUB_ENV
+      - name: Fetch rusty_v8 static library
+        run: |
+          URL="https://github.com/denoland/rusty_v8/releases/download/v${RUSTY_V8_VERSION}/librusty_v8_release_${{ matrix.rusty_v8_target }}.a.gz"
+          curl -fL "$URL" -o librusty_v8.a.gz && gunzip librusty_v8.a.gz
+          echo "RUSTY_V8_ARCHIVE=$(pwd)/librusty_v8.a" >> $GITHUB_ENV
+      - name: Build server
+        run: cargo build --release -p server --target ${{ matrix.target }}
+      - name: Upload server binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.bin_name }}
+          path: target/${{ matrix.target }}/release/server
+
   # ── Publish mcp-v8-client to crates.io ────────────────────────────────────
   publish-crate:
     name: Publish mcp-v8-client to crates.io
@@ -109,7 +165,7 @@ jobs:
 
   # ── Assemble GitHub Release ────────────────────────────────────────────────
   release:
-    needs: build-cli
+    needs: [build-cli, build-server]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -129,6 +185,13 @@ jobs:
             [ -d "$dir" ] || continue
             name=$(basename "$dir")
             cp "$dir/mcp-v8-cli" "dist/final/$name"
+          done
+
+          # Server binaries (artifact dir name = bin_name, file inside = "server")
+          for dir in dist/mcp-v8-linux dist/mcp-v8-linux-arm64 dist/mcp-v8-macos-arm64; do
+            [ -d "$dir" ] || continue
+            name=$(basename "$dir")
+            cp "$dir/server" "dist/final/$name"
           done
 
           # Include openapi.json from the repo


### PR DESCRIPTION
## Summary

Adds a `build-server` job that builds the server binary on **native runners** using plain `cargo build`. No cross-compilation, no zigbuild, no glibc floor targeting.

## Approach

- **Linux x86_64** → `ubuntu-latest` (glibc ~2.35)
- **Linux ARM64** → `ubuntu-24.04-arm` (glibc ~2.35)
- **macOS ARM64** → `macos-14`

All three use a plain `cargo build --release -p server --target <target>` with the targets native toolchain.

## What stays the same

- `rusty_v8` static lib is still pre-fetched from `denoland/rusty_v8` releases (`v145.0.0`) via `RUSTY_V8_ARCHIVE`
- OpenSSL is vendored via `native-tls` — no system OpenSSL version constraint
- CLI builds are unchanged (still use zigbuild for glibc 2.17 floor)

## Tradeoff

Binaries link against the runners system glibc (~2.35). They wont run on RHEL7/CentOS7-era systems (glibc < 2.35). This is acceptable for an alpha.

## Changes

- Added `build-server` job with 3-way matrix (Linux x86_64, Linux ARM64, macOS ARM64)
- Updated `release` job `needs` from `build-cli` to `[build-cli, build-server]`
- Collect server binaries (`mcp-v8-linux`, `mcp-v8-linux-arm64`, `mcp-v8-macos-arm64`) in the release step alongside CLI binaries