### PR TITLE
fix: server version tracks git tag (/api/version returns real tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,8 @@ jobs:
           echo "MCP_V8_CLI_LINUX_X86_64=$(pwd)/cli-bins/linux-x86_64/mcp-v8-cli"   >> $GITHUB_ENV
           echo "MCP_V8_CLI_LINUX_AARCH64=$(pwd)/cli-bins/linux-arm64/mcp-v8-cli"   >> $GITHUB_ENV
           echo "MCP_V8_CLI_MACOS_AARCH64=$(pwd)/cli-bins/macos-arm64/mcp-v8-cli"   >> $GITHUB_ENV
+          # Strip leading 'v' from tag for CARGO_PKG_VERSION (e.g. v0.10.21 → 0.10.21)
+          echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}"                               >> $GITHUB_ENV
 
       - name: Build server – Linux (cargo-zigbuild, glibc ${{ env.GLIBC_FLOOR_SERVER }})
         if: ${{ matrix.use_zigbuild }}

--- a/server/build.rs
+++ b/server/build.rs
@@ -1,6 +1,36 @@
-use std::{env, fs, path::Path};
+use std::{env, fs, path::Path, process::Command};
 
 fn main() {
+    // Override CARGO_PKG_VERSION with the git tag if RELEASE_VERSION is set
+    // (injected by the release workflow as the tag name, e.g. "0.10.21").
+    // Falls back to git describe, then to the Cargo.toml version.
+    let version = env::var("RELEASE_VERSION")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(|| {
+            // Try git describe --tags --exact-match (clean tag builds)
+            Command::new("git")
+                .args(["describe", "--tags", "--exact-match"])
+                .output()
+                .ok()
+                .and_then(|o| {
+                    if o.status.success() {
+                        String::from_utf8(o.stdout).ok().map(|s| s.trim().trim_start_matches('v').to_string())
+                    } else {
+                        None
+                    }
+                })
+        });
+
+    if let Some(v) = version {
+        // Cargo uses CARGO_PKG_VERSION from the env if set before the build
+        // but the canonical way to override what env!("CARGO_PKG_VERSION") returns
+        // is to emit a rustc-env instruction from build.rs.
+        println!("cargo:rustc-env=CARGO_PKG_VERSION={}", v);
+    }
+
+    println!("cargo:rerun-if-env-changed=RELEASE_VERSION");
+
     // Embed the CLI binary if MCP_V8_CLI_BINARY is set.
     // If not set (local/dev builds), we write an empty file so the
     // include_bytes! in api.rs compiles without error; the /api/cli/{platform}


### PR DESCRIPTION
## Problem

`/api/version` returns `0.1.0` because `server/Cargo.toml` version is hardcoded.

## Fix

`server/build.rs` now emits `cargo:rustc-env=CARGO_PKG_VERSION=<tag>` overriding what `env!("CARGO_PKG_VERSION")` resolves to at compile time:

1. `RELEASE_VERSION` env var — injected by the release workflow as the tag name minus `v` (e.g. `0.10.21`)
2. `git describe --tags --exact-match` — fallback for local tagged builds
3. `Cargo.toml` `0.1.0` — dev/untagged builds

No change to `Cargo.toml` version needed.