### PR TITLE
fix: remove 64MB upper bound on --heap-memory-max

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ println!("execution_id: {}", resp.into_inner().execution_id);
 
 ### Execution Limits
 
-- `--heap-memory-max <megabytes>`: Maximum V8 heap memory per isolate in megabytes (1–64, default: 8).
+- `--heap-memory-max <megabytes>`: Maximum V8 heap memory per isolate in megabytes (default: 8, minimum: 1).
 - `--execution-timeout <seconds>`: Maximum execution timeout in seconds (1–300, default: 30).
 - `--max-concurrent-executions <n>`: Maximum number of concurrent V8 executions (default: CPU core count). Controls how many JavaScript executions can run in parallel.
 
@@ -353,7 +353,7 @@ Both modes return position info in both coordinate systems for cross-referencing
 
 | Tool | Description |
 |------|-------------|
-| `run_js` | Submit JavaScript/TypeScript code for async execution. Returns an `execution_id` immediately. Parameters: `code` (required), `heap_memory_max_mb` (optional, 4–64, default: 8), `execution_timeout_secs` (optional, 1–300, default: 30). |
+| `run_js` | Submit JavaScript/TypeScript code for async execution. Returns an `execution_id` immediately. Parameters: `code` (required), `heap_memory_max_mb` (optional, minimum: 4, default: 8), `execution_timeout_secs` (optional, 1–300, default: 30). |
 | `get_execution` | Poll execution status and result. Returns `execution_id`, `status`, `result` (if completed), `error` (if failed), `started_at`, `completed_at`. |
 | `get_execution_output` | Read paginated console output. Supports line-based (`line_offset` + `line_limit`) or byte-based (`byte_offset` + `byte_limit`) pagination. |
 | `cancel_execution` | Terminate a running V8 execution. |

--- a/server/README.md
+++ b/server/README.md
@@ -180,7 +180,7 @@ println!("execution_id: {}", resp.into_inner().execution_id);
 
 ### Execution Limits
 
-- `--heap-memory-max <megabytes>`: Maximum V8 heap memory per isolate in megabytes (1–64, default: 8).
+- `--heap-memory-max <megabytes>`: Maximum V8 heap memory per isolate in megabytes (default: 8, minimum: 1).
 - `--execution-timeout <seconds>`: Maximum execution timeout in seconds (1–300, default: 30).
 - `--max-concurrent-executions <n>`: Maximum number of concurrent V8 executions (default: CPU core count). Controls how many JavaScript executions can run in parallel.
 
@@ -353,7 +353,7 @@ Both modes return position info in both coordinate systems for cross-referencing
 
 | Tool | Description |
 |------|-------------|
-| `run_js` | Submit JavaScript/TypeScript code for async execution. Returns an `execution_id` immediately. Parameters: `code` (required), `heap_memory_max_mb` (optional, 4–64, default: 8), `execution_timeout_secs` (optional, 1–300, default: 30). |
+| `run_js` | Submit JavaScript/TypeScript code for async execution. Returns an `execution_id` immediately. Parameters: `code` (required), `heap_memory_max_mb` (optional, minimum: 4, default: 8), `execution_timeout_secs` (optional, 1–300, default: 30). |
 | `get_execution` | Poll execution status and result. Returns `execution_id`, `status`, `result` (if completed), `error` (if failed), `started_at`, `completed_at`. |
 | `get_execution_output` | Read paginated console output. Supports line-based (`line_offset` + `line_limit`) or byte-based (`byte_offset` + `byte_limit`) pagination. |
 | `cancel_execution` | Terminate a running V8 execution. |

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -70,8 +70,8 @@ struct Cli {
     #[arg(long, conflicts_with = "http_port")]
     sse_port: Option<u16>,
 
-    /// Maximum V8 heap memory per isolate in megabytes (default: 8, max: 64)
-    #[arg(long, default_value = "8", value_parser = clap::value_parser!(u64).range(1..=64))]
+    /// Maximum V8 heap memory per isolate in megabytes (default: 8)
+    #[arg(long, default_value = "8", value_parser = clap::value_parser!(u64).range(1..))]
     heap_memory_max: u64,
 
     /// Maximum execution timeout in seconds (default: 30, max: 300)

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -8,7 +8,7 @@ params:
 - code: the javascript or typescript code to run
 - heap (optional): content hash (SHA-256 hex string) from a previous execution to resume that session, or omit for a fresh session
 - session (optional): a human-readable session name. When provided, a log entry is written recording the input heap, output heap, executed code, and timestamp. Use list_sessions and list_session_snapshots to browse session history.
-- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (4–64, default: 8). Override the server default for this execution.
+- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (minimum: 4, default: 8). Override the server default for this execution.
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 - tags (optional): a JSON object of key-value string pairs to associate with the resulting heap snapshot. Tags can be used to label, categorize, or annotate heaps for later retrieval. Use get_heap_tags, set_heap_tags, delete_heap_tags, and query_heaps_by_tags to manage tags independently.
 

--- a/server/src/run_js_tool_secure.md
+++ b/server/src/run_js_tool_secure.md
@@ -7,7 +7,7 @@ TypeScript support is type removal only — types are stripped before execution,
 params:
 - code: the javascript or typescript code to run
 - heap (optional): content hash (SHA-256 hex string) from a previous execution to resume that session, or omit for a fresh session
-- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (4–64, default: 8). Override the server default for this execution.
+- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (minimum: 4, default: 8). Override the server default for this execution.
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 - tags (optional): a JSON object of key-value string pairs to associate with the resulting heap snapshot. Tags can be used to label, categorize, or annotate heaps for later retrieval. Use get_heap_tags, set_heap_tags, delete_heap_tags, and query_heaps_by_tags to manage tags independently.
 

--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -6,7 +6,7 @@ TypeScript support is type removal only — types are stripped before execution,
 
 params:
 - code: the javascript or typescript code to run
-- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (4–64, default: 8). Override the server default for this execution.
+- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (minimum: 4, default: 8). Override the server default for this execution.
 - execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
 
 returns:


### PR DESCRIPTION
## Summary
- Remove the `1..=64` upper bound on the `--heap-memory-max` CLI flag, changing it to `1..` (minimum 1, no maximum)
- The V8 engine itself has no 64MB cap — only the clap CLI parser enforced it, which broke deployments needing larger heaps (e.g. `--heap-memory-max 256`)
- Updated all docs (READMEs, tool descriptions) to reflect the removed cap

## Test plan
- [ ] `cargo build` compiles without warnings
- [ ] `server --heap-memory-max 256 --stateless --http-port 3456` starts successfully
- [ ] `server --heap-memory-max 0` still rejected (below minimum of 1)
- [ ] Existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)