### PR TITLE
Fix mermaid diagram rendering on sub-pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,16 @@ theme:
     name: mkdocs
 plugins:
   - search
-  - mermaid2:
-      javascript: js/mermaid.min.js
+  # The vendored mermaid library is loaded via extra_javascript (below), not
+  # the plugin's `javascript:` option. The pinned mkdocs-mermaid2-plugin
+  # (v1.1.0) emits the library <script src> using the configured path
+  # verbatim, so a relative path like `js/mermaid.min.js` resolves against the
+  # current page and 404s on every sub-page (e.g. /concepts/...), leaving
+  # diagrams unrendered. Listing the library under extra_javascript lets mkdocs
+  # compute the correct per-page URL; the plugin then skips its own injection
+  # because the filename contains "mermaid". This is version-independent and
+  # also works under newer plugin releases.
+  - mermaid2
 nav:
   - Home: index.md
 
@@ -71,3 +79,4 @@ extra_css:
     - stylesheets/footer-nav.css
 extra_javascript:
     - js/footer-nav.js
+    - js/mermaid.min.js


### PR DESCRIPTION
## Summary
Fixed an issue where mermaid diagrams were not rendering on documentation sub-pages by changing how the mermaid library is loaded in the mkdocs configuration.

## Key Changes
- Removed the `javascript:` configuration option from the `mermaid2` plugin that was using a relative path (`js/mermaid.min.js`)
- Added the mermaid library to the `extra_javascript` section instead, allowing mkdocs to compute correct per-page URLs
- Added detailed comments explaining the issue and the solution

## Implementation Details
The previous configuration caused the mermaid library script tag to be emitted with a relative path that resolved against the current page. This worked on the home page but resulted in 404s on sub-pages (e.g., `/concepts/...`), leaving diagrams unrendered.

By moving the library to `extra_javascript`, mkdocs automatically computes the correct absolute URL for each page. The mermaid2 plugin detects the "mermaid" filename and skips its own injection, avoiding duplicate script tags. This approach is version-independent and works with both the pinned v1.1.0 and newer plugin releases.

https://claude.ai/code/session_01LszEPQqv6RWCwqjEVqs8Bk