### PR TITLE
Add WASM module stubs on the MCP surface

### DIFF
--- a/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateful.rs
@@ -62,6 +62,7 @@ fuzz_target!(|input: StatefulInput| {
             name: format!("m{}", i),
             bytes: m.bytes,
             max_memory_bytes: None,
+            description: None,
         })
         .collect();
 

--- a/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
+++ b/server/fuzz/fuzz_targets/fuzz_execute_stateless.rs
@@ -49,6 +49,7 @@ fuzz_target!(|input: StatelessInput| {
             name: format!("m{}", i),
             bytes: m.bytes,
             max_memory_bytes: None,
+            description: None,
         })
         .collect();
 

--- a/server/fuzz/fuzz_targets/fuzz_wasm_compile.rs
+++ b/server/fuzz/fuzz_targets/fuzz_wasm_compile.rs
@@ -37,6 +37,7 @@ fuzz_target!(|data: &[u8]| {
         name: "m".to_string(),
         bytes: data.to_vec(),
         max_memory_bytes: Some(8 * 1024 * 1024),
+        description: None,
     }];
 
     // We don't care about the result; we care that V8 doesn't crash.

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -127,6 +127,27 @@ pub struct Cli {
     #[arg(long = "wasm-default-max-memory", default_value = "16m", help_heading = "WASM")]
     pub wasm_default_max_memory: String,
 
+    /// Expose pre-loaded WASM modules on the MCPJS server itself as
+    /// `<prefix>wasm__<name>` stubs. When `true` (the default whenever at
+    /// least one WASM module is loaded), an external client of MCPJS can
+    /// discover the module via tools/list and tool search; calling a stub
+    /// returns instructional text telling the caller to use the module from
+    /// JavaScript via run_js (the module is available as the `__wasm_<name>`
+    /// global). Pass `--wasm-stubs false` to disable.
+    #[arg(long = "wasm-stubs", default_value = "true", num_args = 1, help_heading = "WASM")]
+    pub wasm_stubs: bool,
+
+    /// Prefix applied to WASM stub tool names. Defaults to `runjs__` so it is
+    /// obvious to a calling agent that these modules execute through the JS
+    /// runtime rather than dispatching directly. Has no effect when
+    /// --wasm-stubs is false.
+    #[arg(
+        long = "wasm-stub-prefix",
+        default_value = crate::engine::wasm_stub::DEFAULT_WASM_STUB_PREFIX,
+        help_heading = "WASM"
+    )]
+    pub wasm_stub_prefix: String,
+
     /// Inject headers into fetch requests matching host/method rules.
     /// Format: host=<host>,header=<name>,value=<val>[,methods=GET;POST]
     /// Can be specified multiple times.

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -116,7 +116,8 @@ pub struct Cli {
 
     /// Path to a JSON config file mapping global names to .wasm file paths or objects.
     /// String value: {"name": "/path/to/module.wasm"}
-    /// Object value: {"name": {"path": "/path/to/module.wasm", "max_memory_bytes": 16777216}}
+    /// Object value: {"name": {"path": "/path/to/module.wasm", "max_memory_bytes": 16777216, "description": "what the module does"}}
+    /// The optional "description" sets the MCP stub tool's description.
     #[arg(long = "wasm-config", value_name = "PATH", help_heading = "WASM")]
     pub wasm_config: Option<String>,
 
@@ -147,6 +148,15 @@ pub struct Cli {
         help_heading = "WASM"
     )]
     pub wasm_stub_prefix: String,
+
+    /// Set the MCP stub tool description for a loaded WASM module. Format:
+    /// name=description text. The text is shown to downstream agents alongside
+    /// the auto-generated usage hint (globals, exports, instantiation), helping
+    /// them decide when to use the module. Can be specified multiple times.
+    /// Overrides a "description" set inline via --wasm-config. The named module
+    /// must be loaded with --wasm-module or --wasm-config.
+    #[arg(long = "wasm-stub-description", value_name = "NAME=TEXT", help_heading = "WASM")]
+    pub wasm_stub_descriptions: Vec<String>,
 
     /// Inject headers into fetch requests matching host/method rules.
     /// Format: host=<host>,header=<name>,value=<val>[,methods=GET;POST]

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -1135,6 +1135,10 @@ pub struct WasmModule {
     /// Max native memory (bytes) this module may declare (linear memory + tables).
     /// Defaults to wasm_default_max_bytes when None.
     pub max_memory_bytes: Option<usize>,
+    /// Optional operator-supplied description used for the module's MCP stub
+    /// tool. When set, it is shown to downstream agents alongside the
+    /// auto-generated usage hint. Defaults to None (auto-generated text only).
+    pub description: Option<String>,
 }
 
 #[derive(Clone)]

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -11,6 +11,7 @@ pub mod opa;
 pub mod session_log;
 pub mod subprocess;
 pub mod timers;
+pub mod wasm_stub;
 
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -1153,6 +1154,9 @@ pub struct Engine {
     wasm_default_max_bytes: usize,
     /// WASM modules to inject as globals before every execution.
     wasm_modules: Arc<Vec<WasmModule>>,
+    /// Controls whether loaded WASM modules are advertised as stub tools on
+    /// the MCP surface, and under what name prefix.
+    wasm_stub_config: wasm_stub::WasmStubConfig,
     /// OPA-gated fetch configuration. When Some, `fetch()` is injected into the JS runtime.
     fetch_config: Option<Arc<fetch::FetchConfig>>,
     /// Policy-gated filesystem configuration. When Some, `fs` is injected into the JS runtime.
@@ -1253,6 +1257,7 @@ impl Engine {
             snapshot_mutex: Arc::new(tokio::sync::Mutex::new(())),
             wasm_default_max_bytes: DEFAULT_WASM_MAX_BYTES,
             wasm_modules: Arc::new(Vec::new()),
+            wasm_stub_config: wasm_stub::WasmStubConfig::default(),
             fetch_config: None,
             fs_config: None,
             execution_registry: None,
@@ -1284,6 +1289,7 @@ impl Engine {
             snapshot_mutex: Arc::new(tokio::sync::Mutex::new(())),
             wasm_default_max_bytes: DEFAULT_WASM_MAX_BYTES,
             wasm_modules: Arc::new(Vec::new()),
+            wasm_stub_config: wasm_stub::WasmStubConfig::default(),
             fetch_config: None,
             fs_config: None,
             execution_registry: None,
@@ -1307,6 +1313,31 @@ impl Engine {
     pub fn with_wasm_modules(mut self, modules: Vec<WasmModule>) -> Self {
         self.wasm_modules = Arc::new(modules);
         self
+    }
+
+    /// Configure how loaded WASM modules are advertised as stub tools on the
+    /// MCP surface.
+    pub fn with_wasm_stub_config(mut self, config: wasm_stub::WasmStubConfig) -> Self {
+        self.wasm_stub_config = config;
+        self
+    }
+
+    /// Generate stub `Tool` definitions for every loaded WASM module. Used by
+    /// the MCP server side to expose modules for discovery. Returns an empty
+    /// vec when WASM stubbing is disabled or no modules are loaded.
+    pub fn wasm_stub_tools(&self) -> Vec<rmcp::model::Tool> {
+        wasm_stub::stub_tools(&self.wasm_modules, &self.wasm_stub_config)
+    }
+
+    /// If `name` is a stub for a loaded WASM module, build the instructional
+    /// `CallToolResult` telling the caller to use the module via `run_js`.
+    /// Returns `None` if stubs are disabled or `name` matches no module.
+    pub fn wasm_stub_call_response(
+        &self,
+        name: &str,
+        arguments: Option<&serde_json::Map<String, serde_json::Value>>,
+    ) -> Option<rmcp::model::CallToolResult> {
+        wasm_stub::stub_call_response(&self.wasm_modules, &self.wasm_stub_config, name, arguments)
     }
 
     /// Enable OPA-gated fetch() in the JS runtime.

--- a/server/src/engine/wasm_stub.rs
+++ b/server/src/engine/wasm_stub.rs
@@ -1,0 +1,475 @@
+//! WASM module stubs for the MCPJS MCP surface.
+//!
+//! Pre-loaded WASM modules (`--wasm-module`, `--wasm-config`) are injected
+//! into the JavaScript runtime as globals (`__wasm_<name>`, and for
+//! import-free modules an instantiated `<name>` exports object). On their own
+//! they are invisible to a downstream MCP client: the agent has no way to know
+//! a module is available without reading server configuration.
+//!
+//! Mirroring the upstream MCP server tool stubs (see `mcp_client.rs`), this
+//! module lets MCPJS advertise each loaded WASM module as a stub tool on its
+//! own MCP surface. The stub:
+//!
+//!   * appears in `tools/list` / tool search with a name like
+//!     `runjs__wasm__<name>`,
+//!   * carries a description explaining the module's globals, exports, and
+//!     whether it needs an imports object, and
+//!   * when called, returns instructional text telling the agent to use the
+//!     module from JavaScript via `run_js` rather than executing directly.
+//!
+//! The stub is intentionally not an executable proxy — WASM exports have no
+//! MCP-level schema, so the agent drives them through `run_js`.
+
+use rmcp::model::{CallToolResult, Content, Tool};
+use serde_json::json;
+use std::sync::Arc;
+
+use super::WasmModule;
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+/// Default prefix for WASM stub tool names. Shared with the MCP tool stubs:
+/// `runjs__` signals to a calling agent that the capability executes through
+/// the JavaScript runtime rather than dispatching directly.
+pub const DEFAULT_WASM_STUB_PREFIX: &str = "runjs__";
+
+/// Infix that distinguishes WASM module stubs from upstream MCP server stubs.
+/// A full stub name is `<prefix>wasm__<module>`, e.g. `runjs__wasm__sqlite`.
+const WASM_INFIX: &str = "wasm__";
+
+/// Configuration for the auto-generated WASM module stubs MCPJS exposes to its
+/// own clients. The default prefix `runjs__` makes it obvious that these tools
+/// execute indirectly through the JavaScript runtime (`run_js`).
+#[derive(Debug, Clone)]
+pub struct WasmStubConfig {
+    pub prefix: String,
+    pub enabled: bool,
+}
+
+impl Default for WasmStubConfig {
+    fn default() -> Self {
+        Self {
+            prefix: DEFAULT_WASM_STUB_PREFIX.to_string(),
+            enabled: true,
+        }
+    }
+}
+
+// ── Stub name helpers ────────────────────────────────────────────────────
+
+/// Build the stub tool name for a WASM module under the given `prefix`.
+pub fn wasm_stub_tool_name(prefix: &str, module: &str) -> String {
+    format!("{}{}{}", prefix, WASM_INFIX, module)
+}
+
+/// Inverse of `wasm_stub_tool_name`. Returns the module name, or `None` if
+/// `name` does not start with `prefix` followed by the `wasm__` infix, or if
+/// the remaining module segment is empty. An empty `prefix` is treated as "no
+/// stub recognition" and always returns `None`.
+pub fn parse_wasm_stub_tool_name(prefix: &str, name: &str) -> Option<String> {
+    if prefix.is_empty() {
+        return None;
+    }
+    let rest = name.strip_prefix(prefix)?;
+    let module = rest.strip_prefix(WASM_INFIX)?;
+    if module.is_empty() {
+        return None;
+    }
+    Some(module.to_string())
+}
+
+// ── Module introspection ─────────────────────────────────────────────────
+
+/// Lightweight summary of a WASM module's surface, parsed from its bytes.
+struct ModuleSurface {
+    has_imports: bool,
+    exports: Vec<String>,
+}
+
+/// Parse export names and detect imports without instantiating the module.
+/// Parse failures degrade gracefully (treated as "no imports, no exports")
+/// because the bytes were already validated when the module was loaded.
+fn module_surface(bytes: &[u8]) -> ModuleSurface {
+    use wasmparser::{Parser, Payload};
+
+    let mut has_imports = false;
+    let mut exports = Vec::new();
+    for payload in Parser::new(0).parse_all(bytes) {
+        match payload {
+            Ok(Payload::ImportSection(reader)) => {
+                if reader.count() > 0 {
+                    has_imports = true;
+                }
+            }
+            Ok(Payload::ExportSection(reader)) => {
+                for export in reader.into_iter().flatten() {
+                    exports.push(export.name.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    ModuleSurface {
+        has_imports,
+        exports,
+    }
+}
+
+// ── Stub tool / response construction ────────────────────────────────────
+
+/// Build a stub `Tool` describing a loaded WASM module. Calling the tool only
+/// returns usage instructions; it does not execute the module.
+pub fn make_wasm_stub_tool(prefix: &str, module: &WasmModule) -> Tool {
+    let stub_name = wasm_stub_tool_name(prefix, &module.name);
+    let surface = module_surface(&module.bytes);
+    let description = stub_description(&module.name, &surface);
+
+    // WASM exports have no MCP-level argument schema, so the stub advertises an
+    // empty object schema. Arguments passed to the stub are echoed back into
+    // the run_js instructions, but the agent drives the module from JS.
+    let input_schema = json!({
+        "type": "object",
+        "properties": {},
+    });
+    let input_schema = Arc::new(
+        input_schema
+            .as_object()
+            .cloned()
+            .expect("object literal is an object"),
+    );
+
+    Tool {
+        name: stub_name.into(),
+        description: Some(description.into()),
+        input_schema,
+        // Stubs are discovery mechanisms, not executable tools, so they carry
+        // no behavioral annotations (mirrors the MCP tool stubs).
+        annotations: None,
+    }
+}
+
+/// Human-readable description placed on the stub tool, explaining how to use
+/// the module from JavaScript.
+fn stub_description(name: &str, surface: &ModuleSurface) -> String {
+    let module_global = format!("__wasm_{}", name);
+    let mut desc = format!(
+        "[stub for pre-loaded WASM module {name} — use it from JavaScript via \
+         the run_js tool. Calling this tool directly only returns instructions; \
+         it does not execute the module.]\n\n\
+         The compiled WebAssembly.Module is available as the global \
+         `{module_global}`.",
+        name = name,
+        module_global = module_global,
+    );
+
+    if surface.has_imports {
+        desc.push_str(&format!(
+            " This module declares imports, so instantiate it with an imports \
+             object in JS:\n  const instance = new WebAssembly.Instance({module_global}, imports);\n  \
+             instance.exports.<fn>(...);",
+            module_global = module_global,
+        ));
+    } else {
+        desc.push_str(&format!(
+            " This module has no imports, so its exports are also auto-instantiated \
+             and bound to the global `{name}`:\n  {name}.<fn>(...);\nor instantiate \
+             the module manually:\n  const instance = new WebAssembly.Instance({module_global});\n  \
+             instance.exports.<fn>(...);",
+            name = name,
+            module_global = module_global,
+        ));
+    }
+
+    if !surface.exports.is_empty() {
+        desc.push_str(&format!("\n\nExports: {}.", surface.exports.join(", ")));
+    }
+
+    desc
+}
+
+/// Render the instructional text returned when a client calls a WASM stub.
+pub fn wasm_stub_instructions(
+    module: &WasmModule,
+    arguments: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> String {
+    let surface = module_surface(&module.bytes);
+    let module_global = format!("__wasm_{}", module.name);
+
+    let example = if surface.has_imports {
+        format!(
+            "const instance = new WebAssembly.Instance({module_global}, {{ /* imports */ }});\n\
+             const result = instance.exports.someFunction(/* args */);\n\
+             console.log(result);",
+            module_global = module_global,
+        )
+    } else {
+        format!(
+            "// Exports are auto-bound to the global `{name}`:\n\
+             const result = {name}.someFunction(/* args */);\n\
+             console.log(result);",
+            name = module.name,
+        )
+    };
+
+    let mut text = format!(
+        "This tool is a stub for the WASM module {name:?}. Execute it from \
+         JavaScript via the `run_js` tool, e.g.:\n\n{example}\n",
+        name = module.name,
+        example = example,
+    );
+
+    if !surface.exports.is_empty() {
+        text.push_str(&format!(
+            "\nAvailable exports: {}.\n",
+            surface.exports.join(", ")
+        ));
+    }
+
+    if let Some(args) = arguments {
+        if !args.is_empty() {
+            let pretty = serde_json::to_string_pretty(&serde_json::Value::Object(args.clone()))
+                .unwrap_or_else(|_| "{}".into());
+            text.push_str(&format!(
+                "\nArguments you passed to this stub were:\n{}\nPass them to the \
+                 relevant export(s) inside run_js.\n",
+                pretty
+            ));
+        }
+    }
+
+    text
+}
+
+// ── Collection-level helpers ─────────────────────────────────────────────
+
+/// Generate stub `Tool` definitions for every loaded WASM module. Returns an
+/// empty vec when stub exposure is disabled in the config.
+pub fn stub_tools(modules: &[WasmModule], config: &WasmStubConfig) -> Vec<Tool> {
+    if !config.enabled {
+        return Vec::new();
+    }
+    modules
+        .iter()
+        .map(|m| make_wasm_stub_tool(&config.prefix, m))
+        .collect()
+}
+
+/// If `name` is a stub for a known WASM module, build the instructional
+/// `CallToolResult`. Returns `None` if stubs are disabled or if `name` does
+/// not match any known module — callers should fall through to their normal
+/// tool dispatcher in that case.
+pub fn stub_call_response(
+    modules: &[WasmModule],
+    config: &WasmStubConfig,
+    name: &str,
+    arguments: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Option<CallToolResult> {
+    if !config.enabled {
+        return None;
+    }
+    let module_name = parse_wasm_stub_tool_name(&config.prefix, name)?;
+    let module = modules.iter().find(|m| m.name == module_name)?;
+    Some(CallToolResult::success(vec![Content::text(
+        wasm_stub_instructions(module, arguments),
+    )]))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Import-free WASM module exporting `add(i32, i32) -> i32`. Hand-assembled
+    /// bytes (same style as `server/tests/wasm.rs`) so tests need no extra deps.
+    fn module_with_export() -> Vec<u8> {
+        vec![
+            0x00, 0x61, 0x73, 0x6d, // magic
+            0x01, 0x00, 0x00, 0x00, // version
+            0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, // type: (i32,i32)->i32
+            0x03, 0x02, 0x01, 0x00, // function section
+            0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, // export "add"
+            0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b, // body
+        ]
+    }
+
+    /// Module importing `env.log(i32)` and exporting `run(i32)` — requires an
+    /// imports object, so it exercises the `has_imports` branch.
+    fn module_with_import() -> Vec<u8> {
+        vec![
+            0x00, 0x61, 0x73, 0x6d, // magic
+            0x01, 0x00, 0x00, 0x00, // version
+            0x01, 0x05, 0x01, 0x60, 0x01, 0x7f, 0x00, // type: (i32)->()
+            // import section: env.log : func type 0
+            0x02, 0x0b, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x03, 0x6c, 0x6f, 0x67, 0x00, 0x00,
+            0x03, 0x02, 0x01, 0x00, // function section: one func of type 0
+            // export "run" -> func index 1
+            0x07, 0x07, 0x01, 0x03, 0x72, 0x75, 0x6e, 0x00, 0x01,
+            // code: local.get 0; call 0; end
+            0x0a, 0x08, 0x01, 0x06, 0x00, 0x20, 0x00, 0x10, 0x00, 0x0b,
+        ]
+    }
+
+    fn module(name: &str, bytes: Vec<u8>) -> WasmModule {
+        WasmModule {
+            name: name.to_string(),
+            bytes,
+            max_memory_bytes: None,
+        }
+    }
+
+    #[test]
+    fn default_prefix_is_runjs() {
+        assert_eq!(WasmStubConfig::default().prefix, "runjs__");
+        assert_eq!(DEFAULT_WASM_STUB_PREFIX, "runjs__");
+        assert!(WasmStubConfig::default().enabled);
+    }
+
+    #[test]
+    fn stub_name_round_trips() {
+        let n = wasm_stub_tool_name("runjs__", "sqlite");
+        assert_eq!(n, "runjs__wasm__sqlite");
+        assert_eq!(
+            parse_wasm_stub_tool_name("runjs__", &n),
+            Some("sqlite".to_string())
+        );
+    }
+
+    #[test]
+    fn stub_name_round_trips_with_custom_prefix() {
+        let n = wasm_stub_tool_name("rj_", "math");
+        assert_eq!(n, "rj_wasm__math");
+        assert_eq!(parse_wasm_stub_tool_name("rj_", &n), Some("math".to_string()));
+        // Default prefix does not match a custom-prefixed name.
+        assert_eq!(parse_wasm_stub_tool_name("runjs__", &n), None);
+    }
+
+    #[test]
+    fn parse_rejects_non_stub_names() {
+        // Native MCPJS tools.
+        assert_eq!(parse_wasm_stub_tool_name("runjs__", "run_js"), None);
+        // MCP server stubs (no `wasm__` infix).
+        assert_eq!(
+            parse_wasm_stub_tool_name("runjs__", "runjs__github__create_issue"),
+            None
+        );
+        // Right prefix + infix but empty module segment.
+        assert_eq!(parse_wasm_stub_tool_name("runjs__", "runjs__wasm__"), None);
+        // Empty prefix means "no recognition".
+        assert_eq!(parse_wasm_stub_tool_name("", "wasm__math"), None);
+    }
+
+    #[test]
+    fn module_surface_detects_exports_and_no_imports() {
+        let surface = module_surface(&module_with_export());
+        assert!(!surface.has_imports);
+        assert_eq!(surface.exports, vec!["add".to_string()]);
+    }
+
+    #[test]
+    fn module_surface_detects_imports() {
+        let surface = module_surface(&module_with_import());
+        assert!(surface.has_imports);
+        assert_eq!(surface.exports, vec!["run".to_string()]);
+    }
+
+    #[test]
+    fn make_stub_tool_for_import_free_module() {
+        let m = module("math", module_with_export());
+        let stub = make_wasm_stub_tool("runjs__", &m);
+        assert_eq!(stub.name, "runjs__wasm__math");
+        let desc = stub.description.unwrap();
+        assert!(desc.contains("__wasm_math"), "desc: {}", desc);
+        assert!(desc.contains("run_js"), "desc: {}", desc);
+        // Import-free modules mention the auto-bound global and exports.
+        assert!(desc.contains("auto-instantiated"), "desc: {}", desc);
+        assert!(desc.contains("add"), "desc should list exports: {}", desc);
+        // Empty object schema.
+        let schema = serde_json::to_value(stub.input_schema.as_ref()).unwrap();
+        assert_eq!(schema["type"], json!("object"));
+    }
+
+    #[test]
+    fn make_stub_tool_for_importing_module() {
+        let m = module("logger", module_with_import());
+        let stub = make_wasm_stub_tool("runjs__", &m);
+        let desc = stub.description.unwrap();
+        assert!(desc.contains("imports object"), "desc: {}", desc);
+        assert!(desc.contains("WebAssembly.Instance"), "desc: {}", desc);
+    }
+
+    #[test]
+    fn stub_tools_lists_every_module() {
+        let modules = vec![
+            module("math", module_with_export()),
+            module("logger", module_with_import()),
+        ];
+        let mut names: Vec<String> = stub_tools(&modules, &WasmStubConfig::default())
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "runjs__wasm__logger".to_string(),
+                "runjs__wasm__math".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn stub_tools_empty_when_disabled() {
+        let modules = vec![module("math", module_with_export())];
+        let config = WasmStubConfig {
+            prefix: "runjs__".to_string(),
+            enabled: false,
+        };
+        assert!(stub_tools(&modules, &config).is_empty());
+        assert!(stub_call_response(&modules, &config, "runjs__wasm__math", None).is_none());
+    }
+
+    #[test]
+    fn stub_call_response_matches_known_module() {
+        let modules = vec![module("math", module_with_export())];
+        let config = WasmStubConfig::default();
+        let mut args = serde_json::Map::new();
+        args.insert("x".into(), json!(1));
+        let resp = stub_call_response(&modules, &config, "runjs__wasm__math", Some(&args))
+            .expect("known module should match");
+        assert_eq!(resp.is_error, Some(false));
+        let text = serde_json::to_value(&resp.content[0]).unwrap();
+        let text = text["text"].as_str().unwrap_or_default();
+        assert!(text.contains("run_js"), "text: {}", text);
+        assert!(text.contains("math"), "text: {}", text);
+        assert!(text.contains("add"), "text should list exports: {}", text);
+        assert!(text.contains("\"x\""), "text should echo args: {}", text);
+    }
+
+    #[test]
+    fn stub_call_response_returns_none_for_unknowns() {
+        let modules = vec![module("math", module_with_export())];
+        let config = WasmStubConfig::default();
+        // Native tool name.
+        assert!(stub_call_response(&modules, &config, "run_js", None).is_none());
+        // Stub-shaped but unknown module.
+        assert!(stub_call_response(&modules, &config, "runjs__wasm__other", None).is_none());
+        // MCP server stub shape (no wasm__ infix).
+        assert!(
+            stub_call_response(&modules, &config, "runjs__github__create_issue", None).is_none()
+        );
+    }
+
+    #[test]
+    fn stub_call_response_honours_custom_prefix() {
+        let modules = vec![module("math", module_with_export())];
+        let config = WasmStubConfig {
+            prefix: "rj_".to_string(),
+            enabled: true,
+        };
+        assert!(stub_call_response(&modules, &config, "rj_wasm__math", None).is_some());
+        // Default-prefix name no longer recognised.
+        assert!(stub_call_response(&modules, &config, "runjs__wasm__math", None).is_none());
+    }
+}

--- a/server/src/engine/wasm_stub.rs
+++ b/server/src/engine/wasm_stub.rs
@@ -122,7 +122,7 @@ fn module_surface(bytes: &[u8]) -> ModuleSurface {
 pub fn make_wasm_stub_tool(prefix: &str, module: &WasmModule) -> Tool {
     let stub_name = wasm_stub_tool_name(prefix, &module.name);
     let surface = module_surface(&module.bytes);
-    let description = stub_description(&module.name, &surface);
+    let description = stub_description(&module.name, &surface, module.description.as_deref());
 
     // WASM exports have no MCP-level argument schema, so the stub advertises an
     // empty object schema. Arguments passed to the stub are echoed back into
@@ -149,18 +149,30 @@ pub fn make_wasm_stub_tool(prefix: &str, module: &WasmModule) -> Tool {
 }
 
 /// Human-readable description placed on the stub tool, explaining how to use
-/// the module from JavaScript.
-fn stub_description(name: &str, surface: &ModuleSurface) -> String {
+/// the module from JavaScript. An operator-supplied `custom` description (from
+/// `--wasm-stub-description` / `--wasm-config`) is shown prominently right
+/// after the stub header, before the auto-generated usage hint.
+fn stub_description(name: &str, surface: &ModuleSurface, custom: Option<&str>) -> String {
     let module_global = format!("__wasm_{}", name);
     let mut desc = format!(
         "[stub for pre-loaded WASM module {name} — use it from JavaScript via \
          the run_js tool. Calling this tool directly only returns instructions; \
-         it does not execute the module.]\n\n\
-         The compiled WebAssembly.Module is available as the global \
-         `{module_global}`.",
+         it does not execute the module.]",
         name = name,
-        module_global = module_global,
     );
+
+    if let Some(custom) = custom {
+        let custom = custom.trim();
+        if !custom.is_empty() {
+            desc.push_str(&format!("\n\n{}", custom));
+        }
+    }
+
+    desc.push_str(&format!(
+        "\n\nThe compiled WebAssembly.Module is available as the global \
+         `{module_global}`.",
+        module_global = module_global,
+    ));
 
     if surface.has_imports {
         desc.push_str(&format!(
@@ -316,6 +328,7 @@ mod tests {
             name: name.to_string(),
             bytes,
             max_memory_bytes: None,
+            description: None,
         }
     }
 
@@ -388,6 +401,24 @@ mod tests {
         // Empty object schema.
         let schema = serde_json::to_value(stub.input_schema.as_ref()).unwrap();
         assert_eq!(schema["type"], json!("object"));
+    }
+
+    #[test]
+    fn make_stub_tool_includes_custom_description() {
+        let mut m = module("math", module_with_export());
+        m.description = Some("Fast fixed-point arithmetic helpers.".to_string());
+        let stub = make_wasm_stub_tool("runjs__", &m);
+        let desc = stub.description.unwrap();
+        // Operator description appears prominently...
+        assert!(
+            desc.contains("Fast fixed-point arithmetic helpers."),
+            "desc: {}",
+            desc
+        );
+        // ...but the auto-generated usage hint is still present.
+        assert!(desc.contains("__wasm_math"), "desc: {}", desc);
+        assert!(desc.contains("run_js"), "desc: {}", desc);
+        assert!(desc.contains("add"), "desc: {}", desc);
     }
 
     #[test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Invalid --wasm-default-max-memory: {}", e))?;
     tracing::info!("WASM default max memory: {} bytes ({} MiB)", wasm_default_max_bytes, wasm_default_max_bytes / 1024 / 1024);
 
-    let wasm_modules = load_wasm_modules(&cli.wasm_modules, &cli.wasm_config)?;
+    let wasm_modules = load_wasm_modules(&cli.wasm_modules, &cli.wasm_config, &cli.wasm_stub_descriptions)?;
     if !wasm_modules.is_empty() {
         tracing::info!("Loaded {} WASM module(s): {}", wasm_modules.len(),
             wasm_modules.iter().map(|m| m.name.as_str()).collect::<Vec<_>>().join(", "));
@@ -563,6 +563,7 @@ where
 fn load_wasm_modules(
     cli_modules: &[String],
     config_path: &Option<String>,
+    stub_descriptions: &[String],
 ) -> Result<Vec<WasmModule>> {
     let mut modules = Vec::new();
 
@@ -598,7 +599,7 @@ fn load_wasm_modules(
 
         let bytes = std::fs::read(path)
             .map_err(|e| anyhow::anyhow!("Failed to read WASM file '{}': {}", path, e))?;
-        modules.push(WasmModule { name, bytes, max_memory_bytes });
+        modules.push(WasmModule { name, bytes, max_memory_bytes, description: None });
     }
 
     // Parse --wasm-config JSON file.
@@ -610,8 +611,8 @@ fn load_wasm_modules(
         let config: serde_json::Map<String, serde_json::Value> = serde_json::from_str(&config_str)
             .map_err(|e| anyhow::anyhow!("Invalid JSON in WASM config '{}': {}", config_path, e))?;
         for (name, value) in config {
-            let (path, max_memory_bytes) = if let Some(s) = value.as_str() {
-                (s.to_string(), None)
+            let (path, max_memory_bytes, description) = if let Some(s) = value.as_str() {
+                (s.to_string(), None, None)
             } else if let Some(obj) = value.as_object() {
                 let path = obj.get("path")
                     .and_then(|v| v.as_str())
@@ -625,7 +626,13 @@ fn load_wasm_modules(
                     )))
                     .transpose()?
                     .map(|v| v as usize);
-                (path, max_mem)
+                let description = obj.get("description")
+                    .map(|v| v.as_str().ok_or_else(|| anyhow::anyhow!(
+                        "WASM config \"description\" for '{}' must be a string", name
+                    )))
+                    .transpose()?
+                    .map(|s| s.to_string());
+                (path, max_mem, description)
             } else {
                 anyhow::bail!(
                     "WASM config value for '{}' must be a string path or object, got: {}", name, value
@@ -634,8 +641,24 @@ fn load_wasm_modules(
             validate_wasm_name(&name)?;
             let bytes = std::fs::read(&path)
                 .map_err(|e| anyhow::anyhow!("Failed to read WASM file '{}': {}", path, e))?;
-            modules.push(WasmModule { name, bytes, max_memory_bytes });
+            modules.push(WasmModule { name, bytes, max_memory_bytes, description });
         }
+    }
+
+    // Apply --wasm-stub-description overrides (format: name=description text).
+    // These take precedence over a description set inline in --wasm-config.
+    for entry in stub_descriptions {
+        let (name, desc) = entry.split_once('=')
+            .ok_or_else(|| anyhow::anyhow!(
+                "Invalid --wasm-stub-description format: '{}'. Expected name=description", entry
+            ))?;
+        let name = name.trim();
+        let module = modules.iter_mut().find(|m| m.name == name)
+            .ok_or_else(|| anyhow::anyhow!(
+                "--wasm-stub-description refers to unknown WASM module '{}'. \
+                 Load it first with --wasm-module or --wasm-config.", name
+            ))?;
+        module.description = Some(desc.to_string());
     }
 
     // Check for duplicate names

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -187,7 +187,22 @@ async fn main() -> Result<()> {
     };
 
     let engine = engine.with_wasm_default_max_bytes(wasm_default_max_bytes);
-    let engine = if wasm_modules.is_empty() { engine } else { engine.with_wasm_modules(wasm_modules) };
+    let has_wasm_modules = !wasm_modules.is_empty();
+    let engine = if has_wasm_modules { engine.with_wasm_modules(wasm_modules) } else { engine };
+    let engine = if has_wasm_modules {
+        let wasm_stub_config = engine::wasm_stub::WasmStubConfig {
+            prefix: cli.wasm_stub_prefix.clone(),
+            enabled: cli.wasm_stubs,
+        };
+        tracing::info!(
+            stubs = wasm_stub_config.enabled,
+            prefix = %wasm_stub_config.prefix,
+            "WASM module stubbing"
+        );
+        engine.with_wasm_stub_config(wasm_stub_config)
+    } else {
+        engine
+    };
 
     // ── Policy configuration ─────────────────────────────────────────────
     // Parse --policies-json if provided (inline JSON or file path).

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -596,6 +596,8 @@ impl ServerHandler for McpService {
         if let Some(client) = &self.mcp_client {
             tools.extend(client.stub_tools());
         }
+        // Advertise pre-loaded WASM modules as stubs for discovery.
+        tools.extend(self.engine.wasm_stub_tools());
         Ok(ListToolsResult { next_cursor: None, tools })
     }
 
@@ -608,6 +610,10 @@ impl ServerHandler for McpService {
             if let Some(result) = client.stub_call_response(&request.name, request.arguments.as_ref()) {
                 return Ok(result);
             }
+        }
+        // WASM module stubs return run_js usage instructions instead of dispatching.
+        if let Some(result) = self.engine.wasm_stub_call_response(&request.name, request.arguments.as_ref()) {
+            return Ok(result);
         }
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         Self::tool_box().call(tcc).await
@@ -832,6 +838,8 @@ impl ServerHandler for StatelessMcpService {
         if let Some(client) = &self.mcp_client {
             tools.extend(client.stub_tools());
         }
+        // Advertise pre-loaded WASM modules as stubs for discovery.
+        tools.extend(self.engine.wasm_stub_tools());
         Ok(ListToolsResult { next_cursor: None, tools })
     }
 
@@ -844,6 +852,10 @@ impl ServerHandler for StatelessMcpService {
             if let Some(result) = client.stub_call_response(&request.name, request.arguments.as_ref()) {
                 return Ok(result);
             }
+        }
+        // WASM module stubs return run_js usage instructions instead of dispatching.
+        if let Some(result) = self.engine.wasm_stub_call_response(&request.name, request.arguments.as_ref()) {
+            return Ok(result);
         }
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
         Self::tool_box().call(tcc).await

--- a/server/tests/rss_growth.rs
+++ b/server/tests/rss_growth.rs
@@ -97,6 +97,7 @@ fn test_rss_growth_stateless_with_invalid_wasm() {
                 name: "m".to_string(),
                 bytes: vec![0xde, 0xad, 0xbe, 0xef],
                 max_memory_bytes: None,
+                description: None,
             }];
             let _ = execute_stateless("1", ExecutionConfig::new(heap_bytes).wasm_modules(&modules));
         },

--- a/server/tests/wasm.rs
+++ b/server/tests/wasm.rs
@@ -188,7 +188,7 @@ async fn test_wasm_global_module_add() {
     ensure_v8();
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "math".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None },
+            WasmModule { name: "math".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None, description: None },
         ]);
 
     let result = run_and_wait(&engine, "console.log(math.add(21, 21));").await;
@@ -202,8 +202,8 @@ async fn test_wasm_multiple_global_modules() {
     ensure_v8();
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "adder".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None },
-            WasmModule { name: "multiplier".to_string(), bytes: multiply_wasm_bytes(), max_memory_bytes: None },
+            WasmModule { name: "adder".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None, description: None },
+            WasmModule { name: "multiplier".to_string(), bytes: multiply_wasm_bytes(), max_memory_bytes: None, description: None },
         ]);
 
     let code = "console.log(adder.add(10, 5) + multiplier.multiply(3, 4));";
@@ -218,7 +218,7 @@ async fn test_wasm_global_with_user_code() {
     ensure_v8();
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "calc".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None },
+            WasmModule { name: "calc".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None, description: None },
         ]);
 
     let code = r#"
@@ -263,7 +263,7 @@ async fn test_wasm_load_from_filepath() {
 
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "math".to_string(), bytes, max_memory_bytes: None },
+            WasmModule { name: "math".to_string(), bytes, max_memory_bytes: None, description: None },
         ]);
 
     let result = run_and_wait(&engine, "console.log(math.add(21, 21));").await;
@@ -279,7 +279,7 @@ async fn test_wasm_module_global_exposed_for_no_imports() {
     ensure_v8();
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "math".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None },
+            WasmModule { name: "math".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None, description: None },
         ]);
 
     // __wasm_math should be a WebAssembly.Module
@@ -294,7 +294,7 @@ async fn test_wasm_module_global_manual_instantiation() {
     ensure_v8();
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "math".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None },
+            WasmModule { name: "math".to_string(), bytes: add_wasm_bytes(), max_memory_bytes: None, description: None },
         ]);
 
     let code = r#"
@@ -334,7 +334,7 @@ async fn test_wasm_module_with_imports_not_auto_instantiated() {
     ensure_v8();
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "mymod".to_string(), bytes: wasm_with_import_bytes(), max_memory_bytes: None },
+            WasmModule { name: "mymod".to_string(), bytes: wasm_with_import_bytes(), max_memory_bytes: None, description: None },
         ]);
 
     // The auto-instantiated `mymod` should NOT exist (module has imports)
@@ -349,7 +349,7 @@ async fn test_wasm_module_with_imports_manual_instantiation() {
     ensure_v8();
     let engine = create_test_engine()
         .with_wasm_modules(vec![
-            WasmModule { name: "mymod".to_string(), bytes: wasm_with_import_bytes(), max_memory_bytes: None },
+            WasmModule { name: "mymod".to_string(), bytes: wasm_with_import_bytes(), max_memory_bytes: None, description: None },
         ]);
 
     // Manually instantiate with the required import

--- a/server/tests/wasm_stub_e2e.rs
+++ b/server/tests/wasm_stub_e2e.rs
@@ -1,0 +1,276 @@
+//! End-to-end test for WASM module stubbing on the MCP surface.
+//!
+//! Starts an MCPJS server over stdio with a pre-loaded WASM module
+//! (`--wasm-module math=<fixtures>/add.wasm`). The server should advertise the
+//! module as a `runjs__wasm__math` stub in `tools/list`, and calling that stub
+//! should return instructional text telling the caller to use the module from
+//! JavaScript via `run_js` (the module is exposed as the `__wasm_math` global).
+
+use serde_json::{json, Value};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::time::timeout;
+
+mod common;
+
+struct WasmServer {
+    child: Child,
+    stdin: tokio::process::ChildStdin,
+    stdout: BufReader<tokio::process::ChildStdout>,
+}
+
+impl WasmServer {
+    /// Start an MCPJS server on stdio with `math=<fixtures>/add.wasm` loaded.
+    /// `extra_args` lets a test pass flags like `--wasm-stubs false` or
+    /// `--wasm-stub-prefix rj_`.
+    async fn start_with_args(
+        heap: &str,
+        extra_args: &[&str],
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let server_bin = env!("CARGO_BIN_EXE_server");
+        let wasm_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("add.wasm");
+
+        let mut args: Vec<String> = vec![
+            "--directory-path".to_string(),
+            heap.to_string(),
+            "--wasm-module".to_string(),
+            format!("math={}", wasm_path.display()),
+        ];
+        args.extend(extra_args.iter().map(|s| s.to_string()));
+
+        let mut child = Command::new(server_bin)
+            .args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+        tokio::time::sleep(Duration::from_millis(800)).await;
+
+        Ok(Self { child, stdin, stdout })
+    }
+
+    async fn start(heap: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::start_with_args(heap, &[]).await
+    }
+
+    async fn send(&mut self, msg: Value) -> Result<Value, Box<dyn std::error::Error>> {
+        let s = format!("{}\n", serde_json::to_string(&msg)?);
+        self.stdin.write_all(s.as_bytes()).await?;
+        self.stdin.flush().await?;
+        let mut line = String::new();
+        timeout(Duration::from_secs(10), self.stdout.read_line(&mut line)).await??;
+        Ok(serde_json::from_str(&line)?)
+    }
+
+    async fn send_notification(&mut self, msg: Value) -> Result<(), Box<dyn std::error::Error>> {
+        let s = format!("{}\n", serde_json::to_string(&msg)?);
+        self.stdin.write_all(s.as_bytes()).await?;
+        self.stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let init = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "wasm-stub-e2e", "version": "1.0.0"}
+            }
+        });
+        let _resp = self.send(init).await?;
+        let initialized = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        });
+        self.send_notification(initialized).await?;
+        Ok(())
+    }
+
+    async fn stop(mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
+fn tool_names(list_response: &Value) -> Vec<String> {
+    list_response["result"]["tools"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+async fn server_advertises_wasm_module_as_stub() -> Result<(), Box<dyn std::error::Error>> {
+    let heap = common::create_temp_heap_dir() + "-wasm-stub1";
+    std::fs::create_dir_all(&heap).ok();
+
+    let mut server = WasmServer::start(&heap).await?;
+    server.initialize().await?;
+
+    let list = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .await?;
+
+    let names = tool_names(&list);
+    assert!(names.contains(&"run_js".to_string()), "native run_js missing: {:?}", names);
+    assert!(
+        names.contains(&"runjs__wasm__math".to_string()),
+        "expected runjs__wasm__math stub, got: {:?}",
+        names,
+    );
+
+    // The stub description should hint at run_js usage and the __wasm_ global.
+    let stub = list["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("runjs__wasm__math"))
+        .expect("stub present");
+    let desc = stub["description"].as_str().unwrap_or_default();
+    assert!(desc.contains("run_js"), "description: {}", desc);
+    assert!(desc.contains("__wasm_math"), "description: {}", desc);
+    // add.wasm exports `add`.
+    assert!(desc.contains("add"), "description should list exports: {}", desc);
+
+    server.stop().await;
+    common::cleanup_heap_dir(&heap);
+    Ok(())
+}
+
+#[tokio::test]
+async fn calling_wasm_stub_returns_run_js_instructions() -> Result<(), Box<dyn std::error::Error>> {
+    let heap = common::create_temp_heap_dir() + "-wasm-stub2";
+    std::fs::create_dir_all(&heap).ok();
+
+    let mut server = WasmServer::start(&heap).await?;
+    server.initialize().await?;
+
+    let resp = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "runjs__wasm__math",
+                "arguments": {}
+            }
+        }))
+        .await?;
+
+    assert_eq!(resp["result"]["isError"], json!(false));
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(text.contains("run_js"), "stub call text: {}", text);
+    assert!(text.contains("math"), "stub call text: {}", text);
+
+    server.stop().await;
+    common::cleanup_heap_dir(&heap);
+    Ok(())
+}
+
+#[tokio::test]
+async fn wasm_stub_prefix_flag_overrides_default() -> Result<(), Box<dyn std::error::Error>> {
+    let heap = common::create_temp_heap_dir() + "-wasm-stub3";
+    std::fs::create_dir_all(&heap).ok();
+
+    let mut server = WasmServer::start_with_args(&heap, &["--wasm-stub-prefix", "rj_"]).await?;
+    server.initialize().await?;
+
+    let list = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .await?;
+    let names = tool_names(&list);
+    assert!(
+        names.contains(&"rj_wasm__math".to_string()),
+        "expected rj_wasm__math stub, got: {:?}",
+        names,
+    );
+    assert!(
+        !names.iter().any(|n| n.starts_with("runjs__wasm__")),
+        "default-prefixed wasm stubs should not appear: {:?}",
+        names,
+    );
+
+    server.stop().await;
+    common::cleanup_heap_dir(&heap);
+    Ok(())
+}
+
+#[tokio::test]
+async fn wasm_stubs_disabled_flag_hides_stubs() -> Result<(), Box<dyn std::error::Error>> {
+    let heap = common::create_temp_heap_dir() + "-wasm-stub4";
+    std::fs::create_dir_all(&heap).ok();
+
+    let mut server = WasmServer::start_with_args(&heap, &["--wasm-stubs", "false"]).await?;
+    server.initialize().await?;
+
+    let list = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .await?;
+    let names = tool_names(&list);
+    assert!(names.contains(&"run_js".to_string()), "native run_js missing: {:?}", names);
+    assert!(
+        !names.iter().any(|n| n.starts_with("runjs__wasm__")),
+        "wasm stubs should be hidden when --wasm-stubs false: {:?}",
+        names,
+    );
+
+    // Calling the stub-shaped name now falls through to the normal dispatcher,
+    // which does not return stub instructions.
+    let resp = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "runjs__wasm__math",
+                "arguments": {}
+            }
+        }))
+        .await?;
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        !text.contains("Execute it from"),
+        "should not return wasm stub instructions when disabled: {}",
+        text,
+    );
+
+    server.stop().await;
+    common::cleanup_heap_dir(&heap);
+    Ok(())
+}

--- a/server/tests/wasm_stub_e2e.rs
+++ b/server/tests/wasm_stub_e2e.rs
@@ -191,6 +191,47 @@ async fn calling_wasm_stub_returns_run_js_instructions() -> Result<(), Box<dyn s
 }
 
 #[tokio::test]
+async fn wasm_stub_description_flag_sets_tool_description() -> Result<(), Box<dyn std::error::Error>> {
+    let heap = common::create_temp_heap_dir() + "-wasm-stub-desc";
+    std::fs::create_dir_all(&heap).ok();
+
+    let mut server = WasmServer::start_with_args(
+        &heap,
+        &["--wasm-stub-description", "math=Adds two integers together."],
+    )
+    .await?;
+    server.initialize().await?;
+
+    let list = server
+        .send(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }))
+        .await?;
+
+    let stub = list["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("runjs__wasm__math"))
+        .expect("stub present");
+    let desc = stub["description"].as_str().unwrap_or_default();
+    assert!(
+        desc.contains("Adds two integers together."),
+        "custom description should appear: {}",
+        desc,
+    );
+    // Auto-generated usage hint still present.
+    assert!(desc.contains("__wasm_math"), "description: {}", desc);
+
+    server.stop().await;
+    common::cleanup_heap_dir(&heap);
+    Ok(())
+}
+
+#[tokio::test]
 async fn wasm_stub_prefix_flag_overrides_default() -> Result<(), Box<dyn std::error::Error>> {
     let heap = common::create_temp_heap_dir() + "-wasm-stub3";
     std::fs::create_dir_all(&heap).ok();

--- a/site-docs/how-to/use-sqlite-wasm.md
+++ b/site-docs/how-to/use-sqlite-wasm.md
@@ -114,6 +114,19 @@ Control this behaviour with:
 
 - `--wasm-stubs false` to hide the stubs
 - `--wasm-stub-prefix <prefix>` to change the `runjs__` prefix
+- `--wasm-stub-description <name>=<text>` to add a human description to a
+  module's stub (shown to agents alongside the auto-generated usage hint)
+
+The description can also be set inline in `--wasm-config`:
+
+```json
+{
+  "sqlite": {
+    "path": "examples/sqlite-wasm/sqlite3.wasm",
+    "description": "In-memory SQLite database (exec/query SQL)."
+  }
+}
+```
 
 This mirrors the [MCP server tool stubs](../concepts/mcp-pass-through.md).
 

--- a/site-docs/how-to/use-sqlite-wasm.md
+++ b/site-docs/how-to/use-sqlite-wasm.md
@@ -98,6 +98,25 @@ db.close();
 JSON.stringify(result.rows);
 ```
 
+## Discover loaded modules via stub tools
+
+By default, every module loaded with `--wasm-module` / `--wasm-config` is
+also advertised on the MCPJS MCP surface as a stub tool named
+`runjs__wasm__<name>` (so the SQLite module above appears as
+`runjs__wasm__sqlite`). A downstream MCP client can discover the module via
+`tools/list` or tool search without reading server configuration.
+
+The stub is not an executable proxy: calling it returns instructions telling
+the agent to use the module from JavaScript via `run_js` (the compiled module
+is available as the `__wasm_<name>` global, exactly as described above).
+
+Control this behaviour with:
+
+- `--wasm-stubs false` to hide the stubs
+- `--wasm-stub-prefix <prefix>` to change the `runjs__` prefix
+
+This mirrors the [MCP server tool stubs](../concepts/mcp-pass-through.md).
+
 ## Limits to keep in mind
 
 - the example is built for in-memory databases only

--- a/site-docs/reference/cli-flags.md
+++ b/site-docs/reference/cli-flags.md
@@ -225,3 +225,16 @@ Default max native memory for WASM modules without a per-module limit. Supports 
 
 - Default: `16m`
 - Value: `WASM_DEFAULT_MAX_MEMORY`
+
+### `--wasm-stubs`
+
+Expose pre-loaded WASM modules on the MCPJS server itself as `<prefix>wasm__<name>` stubs. When `true` (the default whenever at least one WASM module is loaded), an external client of MCPJS can discover the module via tools/list and tool search; calling a stub returns instructional text telling the caller to use the module from JavaScript via run_js (the module is available as the `__wasm_<name>` global). Pass `--wasm-stubs false` to disable
+
+- Default: `true`
+
+### `--wasm-stub-prefix`
+
+Prefix applied to WASM stub tool names. Defaults to `runjs__` so it is obvious to a calling agent that these modules execute through the JS runtime rather than dispatching directly. Has no effect when --wasm-stubs is false
+
+- Default: `runjs__`
+- Value: `WASM_STUB_PREFIX`

--- a/site-docs/reference/cli-flags.md
+++ b/site-docs/reference/cli-flags.md
@@ -215,7 +215,7 @@ Pre-load a WASM module as a global. Format: name=/path/to/module.wasm[:max_memor
 
 ### `--wasm-config`
 
-Path to a JSON config file mapping global names to .wasm file paths or objects. String value: {"name": "/path/to/module.wasm"} Object value: {"name": {"path": "/path/to/module.wasm", "max_memory_bytes": 16777216}}
+Path to a JSON config file mapping global names to .wasm file paths or objects. String value: {"name": "/path/to/module.wasm"} Object value: {"name": {"path": "/path/to/module.wasm", "max_memory_bytes": 16777216, "description": "what the module does"}} The optional "description" sets the MCP stub tool's description
 
 - Value: `PATH`
 
@@ -238,3 +238,10 @@ Prefix applied to WASM stub tool names. Defaults to `runjs__` so it is obvious t
 
 - Default: `runjs__`
 - Value: `WASM_STUB_PREFIX`
+
+### `--wasm-stub-description`
+
+Set the MCP stub tool description for a loaded WASM module. Format: name=description text. The text is shown to downstream agents alongside the auto-generated usage hint (globals, exports, instantiation), helping them decide when to use the module. Can be specified multiple times. Overrides a "description" set inline via --wasm-config. The named module must be loaded with --wasm-module or --wasm-config
+
+- Value: `NAME=TEXT`
+- Repeatable: yes


### PR DESCRIPTION
## Summary

Adds **WASM module stubs**, mirroring the existing upstream **MCP server tool stubs** (`mcp_client.rs` / `runjs__<server>__<tool>`).

Pre-loaded WASM modules (`--wasm-module` / `--wasm-config`) are injected into the JS runtime as `__wasm_<name>` globals, but until now they were invisible to a downstream MCP client — the agent had no way to know a module was available without reading server config. This change advertises each loaded module on the MCPJS MCP surface as a `runjs__wasm__<name>` stub tool:

- it appears in `tools/list` / tool search,
- its description explains the `__wasm_<name>` global, the module's exports, and whether it needs an imports object,
- calling it returns instructional text telling the agent to drive the module from JavaScript via `run_js` (WASM exports have no MCP-level schema, so the stub is intentionally **not** an executable proxy).

## Changes

- **`engine::wasm_stub`** (new): stub-name round-tripping (`runjs__wasm__<name>`), module surface introspection (imports + export names via `wasmparser`), stub `Tool` and instructional `CallToolResult` construction. 13 unit tests.
- **`Engine`**: new `wasm_stub_config` plus `wasm_stub_tools()` / `wasm_stub_call_response()`, with a `with_wasm_stub_config()` builder.
- **`McpService`** and **`StatelessMcpService`**: advertise WASM stubs in `list_tools` and short-circuit them in `call_tool`.
- **CLI**: `--wasm-stubs` (default `true` whenever a module is loaded) and `--wasm-stub-prefix` (default `runjs__`), wired in `main.rs`; regenerated `cli-flags.md`.
- **Tests**: `wasm_stub_e2e.rs` (discovery, stub call, custom prefix, disabled).
- **Docs**: stub-discovery section in `use-sqlite-wasm.md`.

## Testing

- `cargo test -p server --lib wasm_stub` → 13 passed
- `cargo test -p server --test wasm_stub_e2e` → 4 passed
- `cargo test -p server --test wasm --test mcp_stub_e2e` → 4 + 14 passed (no regressions)

https://claude.ai/code/session_011QGbw5jjxYu9NWDcGM7tmA

---
_Generated by [Claude Code](https://claude.ai/code/session_011QGbw5jjxYu9NWDcGM7tmA)_