### PR TITLE
Add CLI flags to override MCP server instructions and run_js description

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ println!("execution_id: {}", resp.into_inner().execution_id);
 
 - `--session-db-path <path>`: Path to the sled database used for session logging (default: `/tmp/mcp-v8-sessions`). Only applies in stateful mode. (Conflicts with `--stateless`)
 
+### Prompt / Tool Description Options
+
+These options let you override the text the server presents to MCP clients. Each flag accepts either **inline text** or, when the value begins with `@`, a **path to a file** whose contents are used. Use `@@` to pass a literal value that starts with `@`.
+
+- `--instructions <TEXT_OR_@FILE>`: Override the MCP server `instructions` (the "system prompt" reported during `initialize`). Applies to both stateful and stateless modes.
+- `--run-js-description <TEXT_OR_@FILE>`: Override the description advertised for the `run_js` tool in `tools/list`. Other tools are unaffected.
+
+**Examples:**
+```bash
+# Inline text
+mcp-v8 --stateless --instructions "Execute JavaScript on the user's behalf."
+
+# Read from files
+mcp-v8 --stateless \
+  --instructions @./prompts/system.md \
+  --run-js-description @./prompts/run_js.md
+```
+
 ### Cluster Options
 
 These options enable Raft-based clustering for distributed coordination and replicated session logging.

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -70,6 +70,23 @@ pub struct Cli {
     #[arg(long, default_value = "/tmp/mcp-v8-sessions", help_heading = "Core")]
     pub session_db_path: String,
 
+    /// Override the MCP server `instructions` (the "system prompt" the server
+    /// reports to clients during `initialize`). The value is used verbatim as
+    /// inline text, unless it begins with `@`, in which case the remainder is
+    /// treated as a path to a file whose contents are used (`@-` is not special;
+    /// use `@@` for a literal leading `@`).
+    /// Examples: --instructions "Run JS for me"  --instructions @./prompt.txt
+    #[arg(long, value_name = "TEXT_OR_@FILE", help_heading = "Prompt")]
+    pub instructions: Option<String>,
+
+    /// Override the description advertised for the `run_js` tool in `tools/list`.
+    /// The value is used verbatim as inline text, unless it begins with `@`, in
+    /// which case the remainder is treated as a path to a file whose contents are
+    /// used (use `@@` for a literal leading `@`).
+    /// Examples: --run-js-description "Execute JS"  --run-js-description @./run_js.md
+    #[arg(long = "run-js-description", value_name = "TEXT_OR_@FILE", help_heading = "Prompt")]
+    pub run_js_description: Option<String>,
+
     /// Port for the Raft cluster HTTP server. Enables cluster mode when set.
     #[arg(long, help_heading = "Cluster")]
     pub cluster_port: Option<u16>,

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -1167,6 +1167,13 @@ pub struct Engine {
     mcp_tools_policy_chain: Option<Arc<opa::PolicyChain>>,
     /// Policy-gated subprocess configuration. When Some, subprocess execution is injected into the JS runtime.
     subprocess_config: Option<Arc<subprocess::SubprocessConfig>>,
+    /// Optional override for the MCP server `instructions` field (the "system
+    /// prompt" returned during `initialize`). When `None`, the built-in default
+    /// is used.
+    instructions_override: Option<Arc<str>>,
+    /// Optional override for the `run_js` tool description advertised in
+    /// `tools/list`. When `None`, the compiled-in description is used.
+    run_js_description_override: Option<Arc<str>>,
 }
 
 /// Builder for `Engine::run_js()`. Only `code` is required; everything else
@@ -1263,6 +1270,8 @@ impl Engine {
             mcp_client_manager: None,
             mcp_tools_policy_chain: None,
             subprocess_config: None,
+            instructions_override: None,
+            run_js_description_override: None,
         }
     }
 
@@ -1294,6 +1303,8 @@ impl Engine {
             mcp_client_manager: None,
             mcp_tools_policy_chain: None,
             subprocess_config: None,
+            instructions_override: None,
+            run_js_description_override: None,
         }
     }
 
@@ -1356,6 +1367,29 @@ impl Engine {
     pub fn with_subprocess_config(mut self, config: subprocess::SubprocessConfig) -> Self {
         self.subprocess_config = Some(Arc::new(config));
         self
+    }
+
+    /// Override the MCP server `instructions` (the "system prompt" returned
+    /// during `initialize`).
+    pub fn with_instructions_override(mut self, text: String) -> Self {
+        self.instructions_override = Some(Arc::from(text));
+        self
+    }
+
+    /// Get the MCP server `instructions` override, if one was configured.
+    pub fn instructions_override(&self) -> Option<Arc<str>> {
+        self.instructions_override.clone()
+    }
+
+    /// Override the `run_js` tool description advertised in `tools/list`.
+    pub fn with_run_js_description_override(mut self, text: String) -> Self {
+        self.run_js_description_override = Some(Arc::from(text));
+        self
+    }
+
+    /// Get the `run_js` tool description override, if one was configured.
+    pub fn run_js_description_override(&self) -> Option<Arc<str>> {
+        self.run_js_description_override.clone()
     }
 
     /// Create a builder for submitting JavaScript code for execution.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -363,6 +363,23 @@ async fn main() -> Result<()> {
         engine
     };
 
+    // ── Prompt / tool description overrides ──────────────────────────────
+    // Both flags accept inline text or, with a leading `@`, a path to a file.
+    let engine = if let Some(ref value) = cli.instructions {
+        let text = resolve_text_or_file(value, "--instructions")?;
+        tracing::info!("Overriding MCP server instructions ({} chars)", text.len());
+        engine.with_instructions_override(text)
+    } else {
+        engine
+    };
+    let engine = if let Some(ref value) = cli.run_js_description {
+        let text = resolve_text_or_file(value, "--run-js-description")?;
+        tracing::info!("Overriding run_js tool description ({} chars)", text.len());
+        engine.with_run_js_description_override(text)
+    } else {
+        engine
+    };
+
     // ── Build session verifier (if --jwks-url) ─────────────────────────
     let session_verifier: Option<Arc<SessionVerifier>> = if let Some(ref jwks_url) = cli.jwks_url {
         tracing::info!("Fetching JWKS keys from {}", jwks_url);
@@ -632,6 +649,18 @@ fn load_wasm_modules(
     }
 
     Ok(modules)
+}
+
+/// Resolve a CLI value that may be either inline text or a `@path` file
+/// reference. A leading `@` means "read the rest as a file path"; `@@` escapes
+/// to a literal value beginning with `@`. Any other value is returned verbatim.
+fn resolve_text_or_file(value: &str, flag: &str) -> Result<String> {
+    match value.strip_prefix('@') {
+        Some(rest) if rest.starts_with('@') => Ok(rest.to_string()),
+        Some(path) => std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("Failed to read {} file '{}': {}", flag, path, e)),
+        None => Ok(value.to_string()),
+    }
 }
 
 /// Parse a human-readable memory size string into bytes.
@@ -961,7 +990,40 @@ fn load_mcp_server_configs(
 
 #[cfg(test)]
 mod tests {
-    use super::{load_fetch_header_rules, parse_fetch_header_cli};
+    use super::{load_fetch_header_rules, parse_fetch_header_cli, resolve_text_or_file};
+
+    #[test]
+    fn resolve_text_or_file_returns_inline_text_verbatim() {
+        let resolved = resolve_text_or_file("just some text", "--instructions")
+            .expect("inline text should resolve");
+        assert_eq!(resolved, "just some text");
+    }
+
+    #[test]
+    fn resolve_text_or_file_reads_file_for_at_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let path = dir.path().join("prompt.txt");
+        std::fs::write(&path, "from a file\n").expect("file should be written");
+
+        let arg = format!("@{}", path.display());
+        let resolved = resolve_text_or_file(&arg, "--instructions")
+            .expect("file value should resolve");
+        assert_eq!(resolved, "from a file\n");
+    }
+
+    #[test]
+    fn resolve_text_or_file_escapes_double_at_to_literal() {
+        let resolved = resolve_text_or_file("@@literal", "--instructions")
+            .expect("escaped value should resolve");
+        assert_eq!(resolved, "@literal");
+    }
+
+    #[test]
+    fn resolve_text_or_file_errors_on_missing_file() {
+        let err = resolve_text_or_file("@/no/such/file/here.txt", "--run-js-description")
+            .expect_err("missing file should error");
+        assert!(err.to_string().contains("Failed to read --run-js-description file"));
+    }
 
     #[test]
     fn parse_fetch_header_cli_supports_static_rules() {

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -293,6 +293,19 @@ impl IntoContents for QueryHeapTagsResponse {
     }
 }
 
+/// Replace the `run_js` tool's description with an operator-provided override,
+/// if one was configured via `--run-js-description`. Other tools are left
+/// untouched.
+fn apply_run_js_description_override(tools: &mut [Tool], override_desc: Option<Arc<str>>) {
+    if let Some(desc) = override_desc {
+        for tool in tools.iter_mut() {
+            if tool.name.as_ref() == "run_js" {
+                tool.description = Some(desc.to_string().into());
+            }
+        }
+    }
+}
+
 // ── McpService ──────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -549,13 +562,16 @@ impl McpService {
 
 impl ServerHandler for McpService {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
+        let instructions = self.engine.instructions_override()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
                 "JavaScript execution service (stateful mode - with heap persistence). \
                  Use resources/list and resources/read to explore docs://readme, \
                  docs://llms-txt, docs://openapi, and docs://tools before calling tools."
                 .to_string()
-            ),
+            });
+        ServerInfo {
+            instructions: Some(instructions),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
@@ -593,6 +609,7 @@ impl ServerHandler for McpService {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let mut tools = Self::tool_box().list();
+        apply_run_js_description_override(&mut tools, self.engine.run_js_description_override());
         if let Some(client) = &self.mcp_client {
             tools.extend(client.stub_tools());
         }
@@ -785,13 +802,16 @@ impl StatelessMcpService {
 
 impl ServerHandler for StatelessMcpService {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
+        let instructions = self.engine.instructions_override()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
                 "JavaScript execution service (stateless mode — no heap persistence). \
                  Use resources/list and resources/read to explore docs://readme, \
                  docs://llms-txt, docs://openapi, and docs://tools before calling tools."
                 .to_string()
-            ),
+            });
+        ServerInfo {
+            instructions: Some(instructions),
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
@@ -829,6 +849,7 @@ impl ServerHandler for StatelessMcpService {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let mut tools = Self::tool_box().list();
+        apply_run_js_description_override(&mut tools, self.engine.run_js_description_override());
         if let Some(client) = &self.mcp_client {
             tools.extend(client.stub_tools());
         }
@@ -898,5 +919,38 @@ impl ServerHandler for StatelessMcpService {
             }
         }
         Ok(self.get_info())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_run_js_description_override;
+    use rmcp::model::Tool;
+    use std::sync::Arc;
+
+    fn tool(name: &'static str, desc: &'static str) -> Tool {
+        Tool {
+            name: name.into(),
+            description: Some(desc.into()),
+            input_schema: Arc::new(serde_json::Map::new()),
+            annotations: None,
+        }
+    }
+
+    #[test]
+    fn override_replaces_only_run_js_description() {
+        let mut tools = vec![tool("run_js", "original"), tool("get_execution", "other")];
+        apply_run_js_description_override(&mut tools, Some(Arc::from("custom description")));
+
+        assert_eq!(tools[0].description.as_deref(), Some("custom description"));
+        // Non-run_js tools are untouched.
+        assert_eq!(tools[1].description.as_deref(), Some("other"));
+    }
+
+    #[test]
+    fn no_override_leaves_descriptions_unchanged() {
+        let mut tools = vec![tool("run_js", "original")];
+        apply_run_js_description_override(&mut tools, None);
+        assert_eq!(tools[0].description.as_deref(), Some("original"));
     }
 }


### PR DESCRIPTION
## Summary
This PR adds two new CLI flags (`--instructions` and `--run-js-description`) that allow operators to customize the text the MCP server presents to clients. Both flags support inline text or file-based input via `@path` syntax.

## Key Changes

- **New CLI flags** (`cli.rs`):
  - `--instructions`: Override the MCP server's system prompt (returned during `initialize`)
  - `--run-js-description`: Override the `run_js` tool's description in `tools/list`
  - Both support inline text or `@file` references; use `@@` to escape a literal `@` prefix

- **Engine configuration** (`engine/mod.rs`):
  - Added `instructions_override` and `run_js_description_override` fields to `Engine`
  - Added builder methods `with_instructions_override()` and `with_run_js_description_override()`
  - Added getter methods to retrieve configured overrides

- **MCP server integration** (`mcp.rs`):
  - New `apply_run_js_description_override()` function to selectively replace the `run_js` tool description while leaving other tools untouched
  - Updated `McpService::get_info()` and `StatelessMcpService::get_info()` to use the instructions override when available
  - Updated `list_tools()` in both services to apply the run_js description override
  - Added comprehensive unit tests for the override logic

- **Main initialization** (`main.rs`):
  - New `resolve_text_or_file()` helper function to parse CLI values (inline text vs. file paths)
  - Integrated override configuration into the engine setup pipeline
  - Added unit tests covering inline text, file reading, escaping, and error cases

- **Documentation** (`README.md`):
  - Added "Prompt / Tool Description Options" section with usage examples and syntax explanation

## Implementation Details

- The `@file` syntax is flexible: `@/path/to/file` reads the file, `@@text` produces literal `@text`
- Overrides are applied at the MCP protocol level (during `initialize` and `tools/list` responses)
- The `run_js` tool override is selective—other tools remain unaffected
- Both stateful and stateless modes support these overrides

https://claude.ai/code/session_01C3T7K7kKjAyJ5wzTEknUgY