### PR TITLE
Add Blob, File, and FormData support to fetch API

### DIFF
--- a/server/src/engine/console.rs
+++ b/server/src/engine/console.rs
@@ -300,13 +300,19 @@ const BASE64_JS: &str = r#"
 (function() {
     var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
+    function InvalidCharacterError(message) {
+        this.name = 'InvalidCharacterError';
+        this.message = message;
+    }
+    InvalidCharacterError.prototype = Object.create(Error.prototype);
+    InvalidCharacterError.prototype.constructor = InvalidCharacterError;
+
     globalThis.btoa = function btoa(input) {
         var str = String(input);
         for (var i = 0; i < str.length; i++) {
             if (str.charCodeAt(i) > 255) {
-                throw new DOMException(
-                    "The string to be encoded contains characters outside of the Latin1 range.",
-                    "InvalidCharacterError"
+                throw new InvalidCharacterError(
+                    "The string to be encoded contains characters outside of the Latin1 range."
                 );
             }
         }
@@ -326,9 +332,8 @@ const BASE64_JS: &str = r#"
     globalThis.atob = function atob(input) {
         var str = String(input).replace(/[\t\n\f\r ]/g, '');
         if (str.length % 4 === 1) {
-            throw new DOMException(
-                "The string to be decoded is not correctly encoded.",
-                "InvalidCharacterError"
+            throw new InvalidCharacterError(
+                "The string to be decoded is not correctly encoded."
             );
         }
         var out = '';
@@ -337,9 +342,8 @@ const BASE64_JS: &str = r#"
             if (str[i] === '=') break;
             var idx = chars.indexOf(str[i]);
             if (idx === -1) {
-                throw new DOMException(
-                    "The string to be decoded contains invalid characters.",
-                    "InvalidCharacterError"
+                throw new InvalidCharacterError(
+                    "The string to be decoded contains invalid characters."
                 );
             }
             buf = (buf << 6) | idx;
@@ -350,6 +354,125 @@ const BASE64_JS: &str = r#"
             }
         }
         return out;
+    };
+})();
+"#;
+
+// ── Blob / File / FormData globals ──────────────────────────────────────
+
+pub fn inject_web_apis(runtime: &mut JsRuntime) -> Result<(), String> {
+    runtime
+        .execute_script("<web-apis-setup>", WEB_APIS_JS.to_string())
+        .map_err(|e| format!("Failed to install Blob/File/FormData: {}", e))?;
+    Ok(())
+}
+
+pub fn inject_web_apis_snapshot(runtime: &mut deno_core::JsRuntimeForSnapshot) -> Result<(), String> {
+    runtime
+        .execute_script("<web-apis-setup>", WEB_APIS_JS.to_string())
+        .map_err(|e| format!("Failed to install Blob/File/FormData: {}", e))?;
+    Ok(())
+}
+
+const WEB_APIS_JS: &str = r#"
+(function() {
+    globalThis.Blob = function Blob(parts, options) {
+        const opt = options || {};
+        this.type = opt.type || '';
+        const chunks = [];
+        for (const part of (parts || [])) {
+            if (part instanceof Blob) {
+                chunks.push(part._data);
+            } else if (typeof part === 'string') {
+                chunks.push(part);
+            } else {
+                chunks.push(String(part));
+            }
+        }
+        this._data = chunks.join('');
+        this.size = this._data.length;
+    };
+    Blob.prototype.text = function() { return Promise.resolve(this._data); };
+    Blob.prototype.slice = function(start, end, contentType) {
+        const s = this._data.slice(start, end);
+        return new Blob([s], { type: contentType || this.type });
+    };
+    Blob.prototype.arrayBuffer = function() {
+        const buf = new ArrayBuffer(this._data.length);
+        const view = new Uint8Array(buf);
+        for (let i = 0; i < this._data.length; i++) view[i] = this._data.charCodeAt(i) & 0xff;
+        return Promise.resolve(buf);
+    };
+
+    globalThis.File = function File(parts, name, options) {
+        Blob.call(this, parts, options);
+        this.name = name;
+        this.lastModified = (options && options.lastModified) || Date.now();
+    };
+    File.prototype = Object.create(Blob.prototype);
+    File.prototype.constructor = File;
+
+    globalThis.FormData = function FormData() {
+        this._entries = [];
+    };
+    FormData.prototype.append = function(name, value, filename) {
+        this._entries.push({ name: String(name), value: value, filename: filename });
+    };
+    FormData.prototype.set = function(name, value, filename) {
+        const n = String(name);
+        this._entries = this._entries.filter(function(e) { return e.name !== n; });
+        this._entries.push({ name: n, value: value, filename: filename });
+    };
+    FormData.prototype.get = function(name) {
+        const n = String(name);
+        for (const e of this._entries) { if (e.name === n) return e.value; }
+        return null;
+    };
+    FormData.prototype.getAll = function(name) {
+        const n = String(name);
+        return this._entries.filter(function(e) { return e.name === n; }).map(function(e) { return e.value; });
+    };
+    FormData.prototype.has = function(name) {
+        const n = String(name);
+        return this._entries.some(function(e) { return e.name === n; });
+    };
+    FormData.prototype.delete = function(name) {
+        const n = String(name);
+        this._entries = this._entries.filter(function(e) { return e.name !== n; });
+    };
+    FormData.prototype.entries = function() { return this._entries.map(function(e) { return [e.name, e.value]; }); };
+    FormData.prototype.keys = function() { return this._entries.map(function(e) { return e.name; }); };
+    FormData.prototype.values = function() { return this._entries.map(function(e) { return e.value; }); };
+    FormData.prototype.forEach = function(cb) {
+        for (const e of this._entries) { cb(e.value, e.name, this); }
+    };
+    FormData.prototype._serialize = function() {
+        const boundary = '----FormData' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        const parts = [];
+        for (const entry of this._entries) {
+            let disposition = 'form-data; name="' + entry.name + '"';
+            let contentType = null;
+            let body;
+            if (entry.value instanceof File) {
+                const fn = entry.filename || entry.value.name || 'blob';
+                disposition += '; filename="' + fn + '"';
+                contentType = entry.value.type || 'application/octet-stream';
+                body = entry.value._data;
+            } else if (entry.value instanceof Blob) {
+                const fn = entry.filename || 'blob';
+                disposition += '; filename="' + fn + '"';
+                contentType = entry.value.type || 'application/octet-stream';
+                body = entry.value._data;
+            } else {
+                body = String(entry.value);
+            }
+            let part = '--' + boundary + '\r\nContent-Disposition: ' + disposition + '\r\n';
+            if (contentType) part += 'Content-Type: ' + contentType + '\r\n';
+            part += '\r\n' + body + '\r\n';
+            parts.push(part);
+        }
+        parts.push('--' + boundary + '--\r\n');
+        return { boundary: boundary, body: parts.join('') };
     };
 })();
 "#;

--- a/server/src/engine/console.rs
+++ b/server/src/engine/console.rs
@@ -280,6 +280,80 @@ const HARDENING_JS: &str = r#"
 })();
 "#;
 
+// ── Base64 globals (atob / btoa) ────────────────────────────────────────
+
+pub fn inject_base64(runtime: &mut JsRuntime) -> Result<(), String> {
+    runtime
+        .execute_script("<base64-setup>", BASE64_JS.to_string())
+        .map_err(|e| format!("Failed to install atob/btoa: {}", e))?;
+    Ok(())
+}
+
+pub fn inject_base64_snapshot(runtime: &mut deno_core::JsRuntimeForSnapshot) -> Result<(), String> {
+    runtime
+        .execute_script("<base64-setup>", BASE64_JS.to_string())
+        .map_err(|e| format!("Failed to install atob/btoa: {}", e))?;
+    Ok(())
+}
+
+const BASE64_JS: &str = r#"
+(function() {
+    var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+    globalThis.btoa = function btoa(input) {
+        var str = String(input);
+        for (var i = 0; i < str.length; i++) {
+            if (str.charCodeAt(i) > 255) {
+                throw new DOMException(
+                    "The string to be encoded contains characters outside of the Latin1 range.",
+                    "InvalidCharacterError"
+                );
+            }
+        }
+        var out = '';
+        for (var i = 0; i < str.length; i += 3) {
+            var a = str.charCodeAt(i);
+            var b = i + 1 < str.length ? str.charCodeAt(i + 1) : 0;
+            var c = i + 2 < str.length ? str.charCodeAt(i + 2) : 0;
+            out += chars[a >> 2];
+            out += chars[((a & 3) << 4) | (b >> 4)];
+            out += i + 1 < str.length ? chars[((b & 15) << 2) | (c >> 6)] : '=';
+            out += i + 2 < str.length ? chars[c & 63] : '=';
+        }
+        return out;
+    };
+
+    globalThis.atob = function atob(input) {
+        var str = String(input).replace(/[\t\n\f\r ]/g, '');
+        if (str.length % 4 === 1) {
+            throw new DOMException(
+                "The string to be decoded is not correctly encoded.",
+                "InvalidCharacterError"
+            );
+        }
+        var out = '';
+        var buf = 0, bits = 0;
+        for (var i = 0; i < str.length; i++) {
+            if (str[i] === '=') break;
+            var idx = chars.indexOf(str[i]);
+            if (idx === -1) {
+                throw new DOMException(
+                    "The string to be decoded contains invalid characters.",
+                    "InvalidCharacterError"
+                );
+            }
+            buf = (buf << 6) | idx;
+            bits += 6;
+            if (bits >= 8) {
+                bits -= 8;
+                out += String.fromCharCode((buf >> bits) & 0xff);
+            }
+        }
+        return out;
+    };
+})();
+"#;
+
 // ── Flush helper ─────────────────────────────────────────────────────────
 
 /// Flush any remaining console output from the runtime's OpState.

--- a/server/src/engine/fetch.rs
+++ b/server/src/engine/fetch.rs
@@ -436,6 +436,20 @@ const FETCH_JS_WRAPPER: &str = r#"
     Headers.prototype.has = function(name) {
         return name.toLowerCase() in this._map;
     };
+    Headers.prototype.set = function(name, value) {
+        this._map[name.toLowerCase()] = String(value);
+    };
+    Headers.prototype.append = function(name, value) {
+        const key = name.toLowerCase();
+        if (key in this._map) {
+            this._map[key] += ', ' + String(value);
+        } else {
+            this._map[key] = String(value);
+        }
+    };
+    Headers.prototype.delete = function(name) {
+        delete this._map[name.toLowerCase()];
+    };
     Headers.prototype.entries = function() {
         return Object.entries(this._map);
     };
@@ -451,6 +465,108 @@ const FETCH_JS_WRAPPER: &str = r#"
         }
     };
 
+    // ── Blob ────────────────────────────────────────────────────────────
+    globalThis.Blob = function Blob(parts, options) {
+        const opt = options || {};
+        this.type = opt.type || '';
+        const chunks = [];
+        for (const part of (parts || [])) {
+            if (part instanceof Blob) {
+                chunks.push(part._data);
+            } else if (typeof part === 'string') {
+                chunks.push(part);
+            } else {
+                chunks.push(String(part));
+            }
+        }
+        this._data = chunks.join('');
+        this.size = this._data.length;
+    };
+    Blob.prototype.text = function() { return Promise.resolve(this._data); };
+    Blob.prototype.slice = function(start, end, contentType) {
+        const s = this._data.slice(start, end);
+        return new Blob([s], { type: contentType || this.type });
+    };
+    Blob.prototype.arrayBuffer = function() {
+        const buf = new ArrayBuffer(this._data.length);
+        const view = new Uint8Array(buf);
+        for (let i = 0; i < this._data.length; i++) view[i] = this._data.charCodeAt(i) & 0xff;
+        return Promise.resolve(buf);
+    };
+
+    // ── File (extends Blob) ─────────────────────────────────────────────
+    globalThis.File = function File(parts, name, options) {
+        Blob.call(this, parts, options);
+        this.name = name;
+        this.lastModified = (options && options.lastModified) || Date.now();
+    };
+    File.prototype = Object.create(Blob.prototype);
+    File.prototype.constructor = File;
+
+    // ── FormData ────────────────────────────────────────────────────────
+    globalThis.FormData = function FormData() {
+        this._entries = [];
+    };
+    FormData.prototype.append = function(name, value, filename) {
+        this._entries.push({ name: String(name), value: value, filename: filename });
+    };
+    FormData.prototype.set = function(name, value, filename) {
+        const n = String(name);
+        this._entries = this._entries.filter(function(e) { return e.name !== n; });
+        this._entries.push({ name: n, value: value, filename: filename });
+    };
+    FormData.prototype.get = function(name) {
+        const n = String(name);
+        for (const e of this._entries) { if (e.name === n) return e.value; }
+        return null;
+    };
+    FormData.prototype.getAll = function(name) {
+        const n = String(name);
+        return this._entries.filter(function(e) { return e.name === n; }).map(function(e) { return e.value; });
+    };
+    FormData.prototype.has = function(name) {
+        const n = String(name);
+        return this._entries.some(function(e) { return e.name === n; });
+    };
+    FormData.prototype.delete = function(name) {
+        const n = String(name);
+        this._entries = this._entries.filter(function(e) { return e.name !== n; });
+    };
+    FormData.prototype.entries = function() { return this._entries.map(function(e) { return [e.name, e.value]; }); };
+    FormData.prototype.keys = function() { return this._entries.map(function(e) { return e.name; }); };
+    FormData.prototype.values = function() { return this._entries.map(function(e) { return e.value; }); };
+    FormData.prototype.forEach = function(cb) {
+        for (const e of this._entries) { cb(e.value, e.name, this); }
+    };
+    FormData.prototype._serialize = function() {
+        const boundary = '----FormData' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+        const parts = [];
+        for (const entry of this._entries) {
+            let disposition = 'form-data; name="' + entry.name + '"';
+            let contentType = null;
+            let body;
+            if (entry.value instanceof File) {
+                const fn = entry.filename || entry.value.name || 'blob';
+                disposition += '; filename="' + fn + '"';
+                contentType = entry.value.type || 'application/octet-stream';
+                body = entry.value._data;
+            } else if (entry.value instanceof Blob) {
+                const fn = entry.filename || 'blob';
+                disposition += '; filename="' + fn + '"';
+                contentType = entry.value.type || 'application/octet-stream';
+                body = entry.value._data;
+            } else {
+                body = String(entry.value);
+            }
+            let part = '--' + boundary + '\r\nContent-Disposition: ' + disposition + '\r\n';
+            if (contentType) part += 'Content-Type: ' + contentType + '\r\n';
+            part += '\r\n' + body + '\r\n';
+            parts.push(part);
+        }
+        parts.push('--' + boundary + '--\r\n');
+        return { boundary: boundary, body: parts.join('') };
+    };
+
     globalThis.fetch = async function fetch(resource, init) {
         if (typeof resource !== 'string') {
             throw new TypeError('fetch: first argument must be a URL string');
@@ -459,14 +575,30 @@ const FETCH_JS_WRAPPER: &str = r#"
         const opts = init || {};
         const method = (opts.method || 'GET').toUpperCase();
         const headers = opts.headers || {};
-        const body = opts.body !== undefined ? String(opts.body) : "";
 
         // Normalize headers to plain object with lowercase keys
         const normalizedHeaders = {};
         if (headers && typeof headers === 'object') {
-            for (const key of Object.keys(headers)) {
-                normalizedHeaders[key.toLowerCase()] = String(headers[key]);
+            if (typeof headers.entries === 'function' && headers instanceof Headers) {
+                for (const [k, v] of headers.entries()) {
+                    normalizedHeaders[k] = v;
+                }
+            } else {
+                for (const key of Object.keys(headers)) {
+                    normalizedHeaders[key.toLowerCase()] = String(headers[key]);
+                }
             }
+        }
+
+        let body;
+        if (opts.body instanceof FormData) {
+            const serialized = opts.body._serialize();
+            body = serialized.body;
+            if (!('content-type' in normalizedHeaders)) {
+                normalizedHeaders['content-type'] = 'multipart/form-data; boundary=' + serialized.boundary;
+            }
+        } else {
+            body = opts.body !== undefined ? String(opts.body) : "";
         }
 
         const headersJson = JSON.stringify(normalizedHeaders);
@@ -489,6 +621,7 @@ const FETCH_JS_WRAPPER: &str = r#"
             bodyUsed: false,
             text: function() { return Promise.resolve(responseBody); },
             json: function() { return Promise.resolve(JSON.parse(responseBody)); },
+            blob: function() { return Promise.resolve(new Blob([responseBody], { type: responseHeaders.get('content-type') || '' })); },
             clone: function() {
                 return {
                     ok: this.ok,
@@ -501,6 +634,7 @@ const FETCH_JS_WRAPPER: &str = r#"
                     bodyUsed: false,
                     text: function() { return Promise.resolve(responseBody); },
                     json: function() { return Promise.resolve(JSON.parse(responseBody)); },
+                    blob: function() { return Promise.resolve(new Blob([responseBody], { type: responseHeaders.get('content-type') || '' })); },
                 };
             }
         };
@@ -1232,5 +1366,70 @@ allow if {{
             !err.contains("server-refresh-token"),
             "refresh token leaked in error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_do_fetch_sends_multipart_body() {
+        #[derive(Clone)]
+        struct MultipartState {
+            requests: Arc<tokio::sync::Mutex<Vec<(String, String)>>>,
+        }
+
+        async fn multipart_handler(
+            State(state): State<MultipartState>,
+            headers: HeaderMap,
+            body: axum::body::Bytes,
+        ) -> impl IntoResponse {
+            let ct = headers
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("")
+                .to_string();
+            let body_str = String::from_utf8_lossy(&body).to_string();
+            state.requests.lock().await.push((ct, body_str));
+            (StatusCode::OK, Json(json!({"received": true})))
+        }
+
+        let state = MultipartState {
+            requests: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        };
+
+        let app = Router::new()
+            .route("/upload", post(multipart_handler))
+            .with_state(state.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let url = format!("http://{}/upload", addr);
+        let boundary = "----TestBoundary123";
+        let body = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"f\"; filename=\"test.txt\"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n--{boundary}--\r\n"
+        );
+        let ct = format!("multipart/form-data; boundary={boundary}");
+        let headers_json = serde_json::json!({"content-type": ct}).to_string();
+
+        let resp = do_fetch(
+            url,
+            "POST".to_string(),
+            headers_json,
+            Some(body.clone()),
+            Arc::new(PolicyChain::new(vec![], EvalMode::All)),
+            reqwest::Client::new(),
+            vec![],
+        )
+        .await
+        .expect("multipart fetch should succeed");
+
+        let parsed: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(parsed["status"], 200);
+
+        let reqs = state.requests.lock().await;
+        assert_eq!(reqs.len(), 1);
+        assert!(reqs[0].0.starts_with("multipart/form-data; boundary="));
+        assert!(reqs[0].1.contains("hello world"));
+        assert!(reqs[0].1.contains("name=\"f\""));
+        assert!(reqs[0].1.contains("filename=\"test.txt\""));
     }
 }

--- a/server/src/engine/fetch.rs
+++ b/server/src/engine/fetch.rs
@@ -465,108 +465,6 @@ const FETCH_JS_WRAPPER: &str = r#"
         }
     };
 
-    // ── Blob ────────────────────────────────────────────────────────────
-    globalThis.Blob = function Blob(parts, options) {
-        const opt = options || {};
-        this.type = opt.type || '';
-        const chunks = [];
-        for (const part of (parts || [])) {
-            if (part instanceof Blob) {
-                chunks.push(part._data);
-            } else if (typeof part === 'string') {
-                chunks.push(part);
-            } else {
-                chunks.push(String(part));
-            }
-        }
-        this._data = chunks.join('');
-        this.size = this._data.length;
-    };
-    Blob.prototype.text = function() { return Promise.resolve(this._data); };
-    Blob.prototype.slice = function(start, end, contentType) {
-        const s = this._data.slice(start, end);
-        return new Blob([s], { type: contentType || this.type });
-    };
-    Blob.prototype.arrayBuffer = function() {
-        const buf = new ArrayBuffer(this._data.length);
-        const view = new Uint8Array(buf);
-        for (let i = 0; i < this._data.length; i++) view[i] = this._data.charCodeAt(i) & 0xff;
-        return Promise.resolve(buf);
-    };
-
-    // ── File (extends Blob) ─────────────────────────────────────────────
-    globalThis.File = function File(parts, name, options) {
-        Blob.call(this, parts, options);
-        this.name = name;
-        this.lastModified = (options && options.lastModified) || Date.now();
-    };
-    File.prototype = Object.create(Blob.prototype);
-    File.prototype.constructor = File;
-
-    // ── FormData ────────────────────────────────────────────────────────
-    globalThis.FormData = function FormData() {
-        this._entries = [];
-    };
-    FormData.prototype.append = function(name, value, filename) {
-        this._entries.push({ name: String(name), value: value, filename: filename });
-    };
-    FormData.prototype.set = function(name, value, filename) {
-        const n = String(name);
-        this._entries = this._entries.filter(function(e) { return e.name !== n; });
-        this._entries.push({ name: n, value: value, filename: filename });
-    };
-    FormData.prototype.get = function(name) {
-        const n = String(name);
-        for (const e of this._entries) { if (e.name === n) return e.value; }
-        return null;
-    };
-    FormData.prototype.getAll = function(name) {
-        const n = String(name);
-        return this._entries.filter(function(e) { return e.name === n; }).map(function(e) { return e.value; });
-    };
-    FormData.prototype.has = function(name) {
-        const n = String(name);
-        return this._entries.some(function(e) { return e.name === n; });
-    };
-    FormData.prototype.delete = function(name) {
-        const n = String(name);
-        this._entries = this._entries.filter(function(e) { return e.name !== n; });
-    };
-    FormData.prototype.entries = function() { return this._entries.map(function(e) { return [e.name, e.value]; }); };
-    FormData.prototype.keys = function() { return this._entries.map(function(e) { return e.name; }); };
-    FormData.prototype.values = function() { return this._entries.map(function(e) { return e.value; }); };
-    FormData.prototype.forEach = function(cb) {
-        for (const e of this._entries) { cb(e.value, e.name, this); }
-    };
-    FormData.prototype._serialize = function() {
-        const boundary = '----FormData' + Math.random().toString(36).slice(2) + Date.now().toString(36);
-        const parts = [];
-        for (const entry of this._entries) {
-            let disposition = 'form-data; name="' + entry.name + '"';
-            let contentType = null;
-            let body;
-            if (entry.value instanceof File) {
-                const fn = entry.filename || entry.value.name || 'blob';
-                disposition += '; filename="' + fn + '"';
-                contentType = entry.value.type || 'application/octet-stream';
-                body = entry.value._data;
-            } else if (entry.value instanceof Blob) {
-                const fn = entry.filename || 'blob';
-                disposition += '; filename="' + fn + '"';
-                contentType = entry.value.type || 'application/octet-stream';
-                body = entry.value._data;
-            } else {
-                body = String(entry.value);
-            }
-            let part = '--' + boundary + '\r\nContent-Disposition: ' + disposition + '\r\n';
-            if (contentType) part += 'Content-Type: ' + contentType + '\r\n';
-            part += '\r\n' + body + '\r\n';
-            parts.push(part);
-        }
-        parts.push('--' + boundary + '--\r\n');
-        return { boundary: boundary, body: parts.join('') };
-    };
-
     globalThis.fetch = async function fetch(resource, init) {
         if (typeof resource !== 'string') {
             throw new TypeError('fetch: first argument must be a URL string');
@@ -591,7 +489,7 @@ const FETCH_JS_WRAPPER: &str = r#"
         }
 
         let body;
-        if (opts.body instanceof FormData) {
+        if (typeof FormData !== 'undefined' && opts.body instanceof FormData) {
             const serialized = opts.body._serialize();
             body = serialized.body;
             if (!('content-type' in normalizedHeaders)) {

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -863,6 +863,10 @@ pub fn execute_stateless(
                 if let Err(e) = console::inject_base64(&mut runtime) {
                     return Err(e);
                 }
+                // Inject Blob/File/FormData (always available).
+                if let Err(e) = console::inject_web_apis(&mut runtime) {
+                    return Err(e);
+                }
                 // Inject fetch() JS wrapper if OPA is configured.
                 if fetch_config.is_some() {
                     if let Err(e) = fetch::inject_fetch(&mut runtime) {
@@ -1056,6 +1060,10 @@ pub fn execute_stateful(
                     }
                     // Inject atob/btoa (always available).
                     if let Err(e) = console::inject_base64_snapshot(&mut runtime) {
+                        return Err(e);
+                    }
+                    // Inject Blob/File/FormData (always available).
+                    if let Err(e) = console::inject_web_apis_snapshot(&mut runtime) {
                         return Err(e);
                     }
                     // Inject fetch() JS wrapper if OPA is configured.

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -859,6 +859,10 @@ pub fn execute_stateless(
                 if let Err(e) = console::neutralize_dangerous_ops(&mut runtime) {
                     return Err(e);
                 }
+                // Inject atob/btoa (always available).
+                if let Err(e) = console::inject_base64(&mut runtime) {
+                    return Err(e);
+                }
                 // Inject fetch() JS wrapper if OPA is configured.
                 if fetch_config.is_some() {
                     if let Err(e) = fetch::inject_fetch(&mut runtime) {
@@ -1048,6 +1052,10 @@ pub fn execute_stateful(
                     }
                     // Neutralize dangerous built-in ops (op_panic, print).
                     if let Err(e) = console::neutralize_dangerous_ops(&mut runtime) {
+                        return Err(e);
+                    }
+                    // Inject atob/btoa (always available).
+                    if let Err(e) = console::inject_base64_snapshot(&mut runtime) {
                         return Err(e);
                     }
                     // Inject fetch() JS wrapper if OPA is configured.

--- a/server/tests/base64_and_formdata.rs
+++ b/server/tests/base64_and_formdata.rs
@@ -1,0 +1,319 @@
+/// Tests for atob/btoa base64 globals and FormData/Blob/File polyfills.
+
+use std::sync::{Arc, Once};
+use server::engine::{initialize_v8, Engine};
+use server::engine::execution::ExecutionRegistry;
+use server::mcp::StatelessMcpService;
+
+static INIT: Once = Once::new();
+
+fn ensure_v8() {
+    INIT.call_once(|| {
+        initialize_v8();
+    });
+}
+
+fn rand_id() -> u64 {
+    use std::time::SystemTime;
+    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos() as u64
+}
+
+fn create_test_engine() -> Engine {
+    let tmp = std::env::temp_dir().join(format!("mcp-base64-test-{}-{}", std::process::id(), rand_id()));
+    let registry = ExecutionRegistry::new(tmp.to_str().unwrap()).expect("Failed to create test registry");
+    Engine::new_stateless(8 * 1024 * 1024, 30, 4)
+        .with_execution_registry(Arc::new(registry))
+}
+
+use server::mcp::StatelessRunJsResponse;
+
+fn parse_response(resp: StatelessRunJsResponse) -> serde_json::Value {
+    resp.value
+}
+
+fn assert_output_contains(value: &serde_json::Value, expected: &str) {
+    assert!(value["error"].is_null(), "Should not have error: {:?}", value);
+    let output = value["output"].as_str().expect("Should have output field");
+    assert!(output.contains(expected), "Expected output to contain '{}', got: {}", expected, output);
+}
+
+// ── btoa tests ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_btoa_basic() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js("console.log(btoa('hello'))".to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "aGVsbG8=");
+}
+
+#[tokio::test]
+async fn test_btoa_empty() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js("console.log(btoa(''))".to_string(), None, None).await;
+    let value = parse_response(resp);
+    let output = value["output"].as_str().unwrap();
+    assert!(output.trim().is_empty() || output.contains(""), "btoa('') should return empty string");
+}
+
+#[tokio::test]
+async fn test_btoa_binary_chars() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    // Test with bytes 0-255 (Latin1 range)
+    let resp = service.run_js(r#"console.log(btoa('\x00\x01\xff'))"#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "AAH/");
+}
+
+#[tokio::test]
+async fn test_btoa_rejects_non_latin1() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        try { btoa('Ā'); console.log('NO ERROR'); }
+        catch(e) { console.log('CAUGHT: ' + e.name + ': ' + e.message); }
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "CAUGHT:");
+    assert_output_contains(&value, "Latin1");
+}
+
+// ── atob tests ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_atob_basic() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js("console.log(atob('aGVsbG8='))".to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "hello");
+}
+
+#[tokio::test]
+async fn test_atob_no_padding() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js("console.log(atob('aGVsbG8'))".to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "hello");
+}
+
+#[tokio::test]
+async fn test_atob_rejects_invalid() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        try { atob('!!!!'); console.log('NO ERROR'); }
+        catch(e) { console.log('CAUGHT: ' + e.message); }
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "CAUGHT:");
+}
+
+#[tokio::test]
+async fn test_btoa_atob_roundtrip() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var original = 'The quick brown fox jumps over the lazy dog';
+        var encoded = btoa(original);
+        var decoded = atob(encoded);
+        console.log(decoded === original ? 'ROUNDTRIP_OK' : 'MISMATCH');
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "ROUNDTRIP_OK");
+}
+
+// ── Blob tests ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_blob_basic() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var b = new Blob(['hello ', 'world'], { type: 'text/plain' });
+        console.log(b.size + '|' + b.type);
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "11|text/plain");
+}
+
+#[tokio::test]
+async fn test_blob_text() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        (async () => {
+            var b = new Blob(['abc', 'def']);
+            console.log(await b.text());
+        })();
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "abcdef");
+}
+
+#[tokio::test]
+async fn test_blob_slice() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        (async () => {
+            var b = new Blob(['hello world']);
+            var sliced = b.slice(0, 5);
+            console.log(await sliced.text());
+        })();
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "hello");
+}
+
+// ── File tests ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_file_basic() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var f = new File(['content'], 'test.txt', { type: 'text/plain' });
+        console.log(f.name + '|' + f.size + '|' + f.type + '|' + (f instanceof Blob));
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "test.txt|7|text/plain|true");
+}
+
+// ── FormData tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_formdata_append_get() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var fd = new FormData();
+        fd.append('name', 'alice');
+        fd.append('name', 'bob');
+        console.log(fd.get('name') + '|' + fd.getAll('name').join(','));
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "alice|alice,bob");
+}
+
+#[tokio::test]
+async fn test_formdata_set_replaces() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var fd = new FormData();
+        fd.append('x', '1');
+        fd.append('x', '2');
+        fd.set('x', '3');
+        console.log(fd.getAll('x').join(','));
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "3");
+}
+
+#[tokio::test]
+async fn test_formdata_has_delete() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var fd = new FormData();
+        fd.append('key', 'val');
+        var before = fd.has('key');
+        fd.delete('key');
+        var after = fd.has('key');
+        console.log(before + '|' + after);
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "true|false");
+}
+
+#[tokio::test]
+async fn test_formdata_serialize_text() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var fd = new FormData();
+        fd.append('field', 'value');
+        var s = fd._serialize();
+        var ok = s.body.includes('Content-Disposition: form-data; name="field"')
+              && s.body.includes('value')
+              && s.body.includes('--' + s.boundary + '--');
+        console.log(ok ? 'SERIALIZE_OK' : 'FAIL: ' + s.body);
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "SERIALIZE_OK");
+}
+
+#[tokio::test]
+async fn test_formdata_serialize_blob_with_filename() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var fd = new FormData();
+        fd.append('f', new Blob(['file data'], { type: 'text/plain' }), 'upload.txt');
+        var s = fd._serialize();
+        var ok = s.body.includes('filename="upload.txt"')
+              && s.body.includes('Content-Type: text/plain')
+              && s.body.includes('file data');
+        console.log(ok ? 'BLOB_OK' : 'FAIL: ' + s.body);
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "BLOB_OK");
+}
+
+#[tokio::test]
+async fn test_formdata_serialize_file() {
+    ensure_v8();
+    let engine = create_test_engine();
+    let service = StatelessMcpService::new(engine, None);
+
+    let resp = service.run_js(r#"
+        var fd = new FormData();
+        fd.append('doc', new File(['csv,data'], 'data.csv', { type: 'text/csv' }));
+        var s = fd._serialize();
+        var ok = s.body.includes('filename="data.csv"')
+              && s.body.includes('Content-Type: text/csv')
+              && s.body.includes('csv,data');
+        console.log(ok ? 'FILE_OK' : 'FAIL: ' + s.body);
+    "#.to_string(), None, None).await;
+    let value = parse_response(resp);
+    assert_output_contains(&value, "FILE_OK");
+}

--- a/site-docs/reference/fetch.md
+++ b/site-docs/reference/fetch.md
@@ -22,7 +22,7 @@ fetch(url: string, init?: FetchInit): Promise<Response>
 |---|---|---|---|
 | `method` | string | `"GET"` | HTTP method. Normalised to upper-case. |
 | `headers` | object | `{}` | Request headers as plain key/value object. Keys are lower-cased before sending. |
-| `body` | string | `""` | Request body. Any non-string value is coerced with `String()`. An empty string sends no body. |
+| `body` | string \| FormData | `""` | Request body. A `FormData` instance is serialized as `multipart/form-data` with an auto-generated boundary; the `Content-Type` header is set automatically. Any other non-string value is coerced with `String()`. An empty string sends no body. |
 
 ### Response
 
@@ -38,6 +38,7 @@ fetch(url: string, init?: FetchInit): Promise<Response>
 | `bodyUsed` | boolean | Always `false`. |
 | `text()` | `() => Promise<string>` | Resolves with the response body as a string. |
 | `json()` | `() => Promise<any>` | Resolves with `JSON.parse(body)`. |
+| `blob()` | `() => Promise<Blob>` | Resolves with the response body as a `Blob`. |
 | `clone()` | `() => Response` | Returns a shallow clone of the response. |
 
 ### Headers
@@ -48,12 +49,76 @@ The `response.headers` object exposes the following methods:
 |---|---|---|
 | `get` | `(name: string) => string \| null` | Returns the header value, or `null` if absent. Name is case-insensitive. |
 | `has` | `(name: string) => boolean` | Returns `true` if the header is present. |
+| `set` | `(name: string, value: string) => void` | Sets the header value, replacing any existing value. |
+| `append` | `(name: string, value: string) => void` | Appends to the header value (comma-separated) or sets it if absent. |
+| `delete` | `(name: string) => void` | Removes the header. |
 | `entries` | `() => [string, string][]` | Returns all header `[name, value]` pairs. |
 | `keys` | `() => string[]` | Returns all header names. |
 | `values` | `() => string[]` | Returns all header values. |
 | `forEach` | `(cb: (value, name, headers) => void) => void` | Iterates over all headers. |
 
 Header names are stored and returned in lower-case.
+
+### Blob
+
+`globalThis.Blob` is available for constructing binary-like payloads from
+strings. This is a text-only polyfill — all parts are stored as strings.
+
+```js
+const blob = new Blob(["hello ", "world"], { type: "text/plain" });
+blob.size;          // 11
+blob.type;          // "text/plain"
+await blob.text();  // "hello world"
+```
+
+| Property / Method | Type | Description |
+|---|---|---|
+| `size` | number | Length of the content in characters. |
+| `type` | string | MIME type. |
+| `text()` | `() => Promise<string>` | Content as a string. |
+| `slice(start?, end?, contentType?)` | `(...) => Blob` | Returns a new Blob with a substring of the content. |
+| `arrayBuffer()` | `() => Promise<ArrayBuffer>` | Content as an ArrayBuffer (one byte per char, low byte only). |
+
+### File
+
+`globalThis.File` extends `Blob` with a `name` and `lastModified` timestamp.
+
+```js
+const file = new File(["col1,col2\na,b\n"], "data.csv", { type: "text/csv" });
+file.name;          // "data.csv"
+file.lastModified;  // number (epoch ms)
+```
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | string | Filename. |
+| `lastModified` | number | Epoch milliseconds. Defaults to `Date.now()`. |
+
+### FormData
+
+`globalThis.FormData` builds `multipart/form-data` request bodies. When passed
+as the `body` of a `fetch()` call, it is serialized automatically and the
+`Content-Type` header is set.
+
+```js
+const fd = new FormData();
+fd.append("field", "value");
+fd.append("file", new Blob(["content"]), "upload.txt");
+const resp = await fetch(url, { method: "POST", body: fd });
+```
+
+| Method | Signature | Description |
+|---|---|---|
+| `append` | `(name, value, filename?) => void` | Adds a new entry. For `Blob`/`File` values, `filename` sets the `filename` parameter in the `Content-Disposition` header. |
+| `set` | `(name, value, filename?) => void` | Replaces all entries with the given name. |
+| `get` | `(name) => value \| null` | Returns the first value for the name, or `null`. |
+| `getAll` | `(name) => value[]` | Returns all values for the name. |
+| `has` | `(name) => boolean` | Returns `true` if any entry has the name. |
+| `delete` | `(name) => void` | Removes all entries with the name. |
+| `entries` | `() => [name, value][]` | All entries as `[name, value]` pairs. |
+| `keys` | `() => string[]` | All entry names. |
+| `values` | `() => value[]` | All entry values. |
+| `forEach` | `(cb: (value, name, fd) => void) => void` | Iterates over all entries. |
 
 ### Example
 
@@ -70,6 +135,20 @@ if (!response.ok) {
 
 const data = await response.json();
 console.log(data);
+```
+
+### Multipart upload example
+
+```js
+const fd = new FormData();
+fd.append("f", new Blob(["file content here"]), "notes.txt");
+
+const resp = await fetch("https://example.com/upload", {
+  method: "POST",
+  body: fd,
+});
+const text = await resp.text();
+console.log(text);
 ```
 
 ## --fetch-header CLI flag


### PR DESCRIPTION
## Summary

This PR extends the fetch API polyfill with support for `Blob`, `File`, and `FormData` objects, enabling multipart form data uploads and binary-like payload handling in policy scripts.

## Key Changes

- **Headers API enhancements**: Added `set()`, `append()`, and `delete()` methods to the Headers prototype for more complete header manipulation
- **Blob implementation**: Added a text-based `Blob` polyfill with `text()`, `slice()`, and `arrayBuffer()` methods
- **File implementation**: Extended `Blob` with `name` and `lastModified` properties for file metadata
- **FormData implementation**: Complete `FormData` API with `append()`, `set()`, `get()`, `getAll()`, `has()`, `delete()`, `entries()`, `keys()`, `values()`, and `forEach()` methods
- **Multipart serialization**: Added `_serialize()` method to FormData that generates proper `multipart/form-data` bodies with auto-generated boundaries
- **Fetch integration**: Updated fetch to detect and handle FormData bodies, automatically setting the `Content-Type` header with the correct boundary
- **Response enhancements**: Added `blob()` method to Response objects
- **Headers normalization**: Improved header handling to work with Headers instances in addition to plain objects
- **Documentation**: Updated reference docs with complete API documentation and usage examples for all new types

## Implementation Details

- FormData serialization follows the multipart/form-data format with proper Content-Disposition and Content-Type headers
- Blob and File are text-only polyfills (all content stored as strings) suitable for policy script use cases
- Headers methods properly handle case-insensitive header names
- FormData automatically detects File/Blob values and includes filename parameters in the serialized output
- Added comprehensive test coverage for multipart form data uploads

https://claude.ai/code/session_01EYvzxjbXVg4opw5dk6n89m