### PR TITLE
feat(cluster): non-voting learner nodes

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -105,6 +105,12 @@ pub struct Cli {
     #[arg(long, help_heading = "Cluster")]
     pub join: Option<String>,
 
+    /// Join as a non-voting learner: the node replicates the log but is
+    /// excluded from election and commit quorums and never starts elections.
+    /// Use for ephemeral nodes whose churn must not affect availability.
+    #[arg(long, help_heading = "Cluster")]
+    pub join_as_learner: bool,
+
     /// Advertise address for this node (host:port). Used for peer discovery
     /// and write forwarding. Defaults to <node-id>:<cluster-port>.
     #[arg(long, help_heading = "Cluster")]

--- a/server/src/cluster.rs
+++ b/server/src/cluster.rs
@@ -48,6 +48,10 @@ pub struct AppendEntriesRequest {
     /// changes. Absent (None) for backwards compatibility with older nodes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub peer_addrs: Option<HashMap<String, String>>,
+    /// Addresses of non-voting learner members, so followers compute the same
+    /// voting set the leader does. Absent (None) for older nodes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub learner_addrs: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -81,6 +85,12 @@ pub struct ClusterStatus {
     pub log_length: u64,
     pub peers: Vec<String>,
     pub peer_addrs: HashMap<String, String>,
+    /// Addresses of peers that are non-voting learners.
+    #[serde(default)]
+    pub learners: Vec<String>,
+    /// Whether this node itself is a non-voting learner.
+    #[serde(default)]
+    pub is_learner: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -99,6 +109,9 @@ pub struct GetResponse {
 pub struct JoinRequest {
     pub node_id: String,
     pub addr: String,
+    /// Join as a non-voting learner instead of a full voting member.
+    #[serde(default)]
+    pub as_learner: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -125,6 +138,11 @@ pub struct ClusterConfig {
     pub heartbeat_interval: Duration,
     pub election_timeout_min: Duration,
     pub election_timeout_max: Duration,
+    /// When true this node runs as a non-voting learner: it replicates the log
+    /// but never starts elections, never grants votes, and is excluded from
+    /// election and commit quorums. Intended for ephemeral nodes whose churn
+    /// must not affect cluster availability.
+    pub learner: bool,
 }
 
 impl ClusterConfig {
@@ -158,6 +176,7 @@ impl Default for ClusterConfig {
             heartbeat_interval: Duration::from_millis(100),
             election_timeout_min: Duration::from_millis(300),
             election_timeout_max: Duration::from_millis(500),
+            learner: false,
         }
     }
 }
@@ -184,6 +203,9 @@ pub struct RaftState {
     // node_id → address mapping for write forwarding and peer resolution.
     // Includes this node itself so followers can resolve any node id.
     pub peer_addrs: HashMap<String, String>,
+    // Addresses (subset of `peers`) that are non-voting learners. They receive
+    // replicated entries but are excluded from election and commit quorums.
+    pub learners: std::collections::HashSet<String>,
 }
 
 impl RaftState {
@@ -201,6 +223,7 @@ impl RaftState {
             last_heartbeat: Instant::now(),
             peers: Vec::new(),
             peer_addrs: HashMap::new(),
+            learners: std::collections::HashSet::new(),
         }
     }
 
@@ -210,6 +233,15 @@ impl RaftState {
 
     pub fn last_log_term(&self) -> u64 {
         self.log.last().map(|e| e.term).unwrap_or(0)
+    }
+
+    /// Peer addresses that are voting members (excludes learners).
+    pub fn voter_peers(&self) -> Vec<String> {
+        self.peers
+            .iter()
+            .filter(|p| !self.learners.contains(*p))
+            .cloned()
+            .collect()
     }
 }
 
@@ -280,6 +312,13 @@ impl ClusterNode {
             }
         }
 
+        // Restore persisted learner addresses.
+        if let Ok(Some(data)) = db.get("raft_learners") {
+            if let Ok(persisted) = serde_json::from_slice::<Vec<String>>(&data) {
+                raft_state.learners = persisted.into_iter().collect();
+            }
+        }
+
         let http_client = reqwest::Client::builder()
             .timeout(Duration::from_millis(500))
             .connect_timeout(Duration::from_millis(200))
@@ -331,6 +370,13 @@ impl ClusterNode {
             "raft_peers",
             serde_json::to_vec(&state.peer_addrs).unwrap().as_slice(),
         );
+        // Learner classification is persisted alongside the peer set so a
+        // restarting leader does not mistakenly treat a learner as a voter.
+        let learners: Vec<String> = state.learners.iter().cloned().collect();
+        let _ = self.db.insert(
+            "raft_learners",
+            serde_json::to_vec(&learners).unwrap().as_slice(),
+        );
     }
 
     fn persist_meta(&self, state: &RaftState) {
@@ -376,6 +422,10 @@ impl ClusterNode {
 
             tokio::select! {
                 _ = sleep(timeout) => {
+                    // Learners never start elections; they only follow.
+                    if self.config.learner {
+                        continue;
+                    }
                     let state = self.state.read().await;
                     if state.role == Role::Leader {
                         continue;
@@ -397,7 +447,7 @@ impl ClusterNode {
     }
 
     async fn start_election(self: &Arc<Self>) {
-        let (term, last_log_index, last_log_term, peers) = {
+        let (term, last_log_index, last_log_term, peers, voter_count) = {
             let mut state = self.state.write().await;
             state.current_term += 1;
             state.role = Role::Candidate;
@@ -409,10 +459,9 @@ impl ClusterNode {
                 state.last_log_index(),
                 state.last_log_term(),
                 state.peers.clone(),
+                state.voter_peers().len(),
             )
         };
-
-        let peer_count = peers.len();
 
         tracing::info!(
             "[{}] Starting election for term {}",
@@ -420,7 +469,9 @@ impl ClusterNode {
             term
         );
 
-        let majority = (peer_count + 1) / 2 + 1;
+        // Only voting members count toward the election quorum. Learners are
+        // sent RequestVote (harmless) but refuse, so they cannot inflate votes.
+        let majority = (voter_count + 1) / 2 + 1;
         let mut votes: usize = 1; // vote for self
 
         // Send RequestVote RPCs to all peers in parallel
@@ -473,11 +524,11 @@ impl ClusterNode {
                 }
                 self.persist_meta(&state);
                 tracing::info!(
-                    "[{}] Won election for term {} ({}/{} votes)",
+                    "[{}] Won election for term {} ({}/{} voter votes)",
                     self.config.node_id,
                     term,
                     votes,
-                    peer_count + 1
+                    voter_count + 1
                 );
             }
         }
@@ -527,7 +578,16 @@ impl ClusterNode {
     }
 
     async fn send_append_entries_to_peer(self: &Arc<Self>, peer: &str) {
-        let (term, leader_id, prev_log_index, prev_log_term, entries, leader_commit, current_peer_addrs) = {
+        let (
+            term,
+            leader_id,
+            prev_log_index,
+            prev_log_term,
+            entries,
+            leader_commit,
+            current_peer_addrs,
+            current_learners,
+        ) = {
             let state = self.state.read().await;
             if state.role != Role::Leader {
                 return;
@@ -558,6 +618,7 @@ impl ClusterNode {
                 entries,
                 state.commit_index,
                 state.peer_addrs.clone(),
+                state.learners.iter().cloned().collect::<Vec<String>>(),
             )
         };
 
@@ -569,6 +630,7 @@ impl ClusterNode {
             entries: entries.clone(),
             leader_commit,
             peer_addrs: Some(current_peer_addrs),
+            learner_addrs: Some(current_learners),
         };
 
         let url = format!("http://{}/raft/append-entries", peer);
@@ -612,15 +674,18 @@ impl ClusterNode {
             return;
         }
 
-        let peer_count = state.peers.len();
-        let majority = (peer_count + 1) / 2 + 1;
+        // Only voting members count toward the commit quorum. Learners are
+        // still replicated to (they remain in `peers`), but a write commits as
+        // soon as a majority of voters — including the leader — has it.
+        let voter_peers = state.voter_peers();
+        let majority = (voter_peers.len() + 1) / 2 + 1;
 
         // Find the highest N such that a majority of match_index[i] >= N
         // and log[N].term == currentTerm
         let last_idx = state.last_log_index();
         for n in (state.commit_index + 1..=last_idx).rev() {
             let mut replication_count: usize = 1; // count self
-            for peer in &state.peers.clone() {
+            for peer in &voter_peers {
                 if state.match_index.get(peer).copied().unwrap_or(0) >= n {
                     replication_count += 1;
                 }
@@ -708,6 +773,17 @@ impl ClusterNode {
             }
         }
 
+        // Adopt the leader's learner set so this node computes the same voting
+        // membership (matters if it ever becomes a candidate/leader).
+        if let Some(leader_learners) = &req.learner_addrs {
+            let incoming: std::collections::HashSet<String> =
+                leader_learners.iter().cloned().collect();
+            if incoming != state.learners {
+                state.learners = incoming;
+                self.persist_peers(&state);
+            }
+        }
+
         // Log consistency check
         if req.prev_log_index > 0 {
             match state.log.get((req.prev_log_index - 1) as usize) {
@@ -773,6 +849,21 @@ impl ClusterNode {
 
     pub async fn handle_request_vote(&self, req: RequestVoteRequest) -> RequestVoteResponse {
         let mut state = self.state.write().await;
+
+        // Learners are non-voting: they never grant votes, so a candidate that
+        // (incorrectly) counted a learner's vote could not reach quorum from it.
+        if self.config.learner {
+            // Still adopt a higher term so we stay a passive follower.
+            if req.term > state.current_term {
+                state.current_term = req.term;
+                state.voted_for = None;
+                self.persist_meta(&state);
+            }
+            return RequestVoteResponse {
+                term: state.current_term,
+                vote_granted: false,
+            };
+        }
 
         if req.term < state.current_term {
             return RequestVoteResponse {
@@ -904,7 +995,14 @@ impl ClusterNode {
 
     /// Add a peer to the cluster.  Must be called on the leader.
     /// The peer is immediately added to the active peer set and persisted.
-    pub async fn add_peer(&self, node_id: String, addr: String) -> Result<(), String> {
+    /// When `as_learner` is true the peer is replicated to but excluded from
+    /// election and commit quorums.
+    pub async fn add_peer(
+        &self,
+        node_id: String,
+        addr: String,
+        as_learner: bool,
+    ) -> Result<(), String> {
         let mut state = self.state.write().await;
         if state.role != Role::Leader {
             return Err(format!(
@@ -920,6 +1018,9 @@ impl ClusterNode {
 
         state.peers.push(addr.clone());
         state.peer_addrs.insert(node_id.clone(), addr.clone());
+        if as_learner {
+            state.learners.insert(addr.clone());
+        }
 
         // Initialize replication state for the new peer
         let last_index = state.last_log_index();
@@ -927,7 +1028,13 @@ impl ClusterNode {
         state.match_index.insert(addr.clone(), 0);
 
         self.persist_peers(&state);
-        tracing::info!("[{}] Added peer {}@{}", self.config.node_id, node_id, addr);
+        tracing::info!(
+            "[{}] Added {} {}@{}",
+            self.config.node_id,
+            if as_learner { "learner" } else { "peer" },
+            node_id,
+            addr
+        );
         Ok(())
     }
 
@@ -943,6 +1050,7 @@ impl ClusterNode {
 
         if let Some(addr) = state.peer_addrs.remove(&node_id) {
             state.peers.retain(|p| p != &addr);
+            state.learners.remove(&addr);
             state.next_index.remove(&addr);
             state.match_index.remove(&addr);
             self.persist_peers(&state);
@@ -965,7 +1073,7 @@ impl ClusterNode {
             let state = self.state.read().await;
             if state.role == Role::Leader {
                 drop(state);
-                return self.add_peer(req.node_id, req.addr).await;
+                return self.add_peer(req.node_id, req.addr, req.as_learner).await;
             }
         }
 
@@ -995,7 +1103,10 @@ impl ClusterNode {
                     let mut state = self.state.write().await;
                     if !state.peer_addrs.contains_key(&req.node_id) {
                         state.peers.push(req.addr.clone());
-                        state.peer_addrs.insert(req.node_id, req.addr);
+                        state.peer_addrs.insert(req.node_id, req.addr.clone());
+                        if req.as_learner {
+                            state.learners.insert(req.addr);
+                        }
                         self.persist_peers(&state);
                     }
                     Ok(())
@@ -1093,6 +1204,8 @@ impl ClusterNode {
             log_length: state.log.len() as u64,
             peers: state.peers.clone(),
             peer_addrs: state.peer_addrs.clone(),
+            learners: state.learners.iter().cloned().collect(),
+            is_learner: self.config.learner,
         }
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -78,6 +78,7 @@ async fn main() -> Result<()> {
             heartbeat_interval: std::time::Duration::from_millis(cli.heartbeat_interval),
             election_timeout_min: std::time::Duration::from_millis(cli.election_timeout_min),
             election_timeout_max: std::time::Duration::from_millis(cli.election_timeout_max),
+            learner: cli.join_as_learner,
         };
 
         let cluster_db_path = format!("{}/cluster-{}", cli.session_db_path, cli.node_id);
@@ -95,6 +96,7 @@ async fn main() -> Result<()> {
             let join_req = cluster::JoinRequest {
                 node_id: cli.node_id.clone(),
                 addr: my_addr,
+                as_learner: cli.join_as_learner,
             };
             let client = reqwest::Client::new();
             let url = format!("http://{}/raft/join", seed_addr);

--- a/server/tests/cluster_learner.rs
+++ b/server/tests/cluster_learner.rs
@@ -1,0 +1,129 @@
+//! Learner (non-voting member) tests.
+//!
+//! A learner replicates the log but is excluded from election and commit
+//! quorums. This is what makes ephemeral nodes safe: a learner joining or
+//! dying must never affect the cluster's ability to elect a leader or commit
+//! writes. The decisive test here is that killing a learner does not block
+//! the leader's writes — which it would if the learner were a voter.
+
+use server::cluster::{ClusterConfig, ClusterNode, Role};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+
+fn temp_sled(label: &str) -> sled::Db {
+    let dir = std::env::temp_dir().join(format!(
+        "mcp-cluster-learner-{}-{}-{}",
+        label,
+        std::process::id(),
+        rand::random::<u32>()
+    ));
+    sled::Config::new()
+        .path(dir)
+        .temporary(true)
+        .open()
+        .unwrap()
+}
+
+fn base_config(node_id: &str, cluster_port: u16) -> ClusterConfig {
+    ClusterConfig {
+        node_id: node_id.to_string(),
+        peers: Vec::new(),
+        peer_addrs: HashMap::new(),
+        cluster_port,
+        advertise_addr: Some(format!("127.0.0.1:{}", cluster_port)),
+        heartbeat_interval: Duration::from_millis(80),
+        election_timeout_min: Duration::from_millis(250),
+        election_timeout_max: Duration::from_millis(500),
+        learner: false,
+    }
+}
+
+async fn wait_for_leader(node: &Arc<ClusterNode>, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if node.status().await.role == Role::Leader {
+            return true;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    false
+}
+
+#[tokio::test]
+async fn learner_replicates_but_does_not_break_quorum() {
+    let p1 = 47011;
+    let p2 = 47012;
+    let addr2 = format!("127.0.0.1:{}", p2);
+
+    // node1: the sole voter. Starts with no peers, so it elects itself (a
+    // one-voter majority) and becomes the stable leader / "main writer".
+    let node1 = ClusterNode::new(base_config("node1", p1), temp_sled("voter"));
+
+    // node2: a learner that knows the leader and runs in learner mode.
+    let mut cfg2 = base_config("node2", p2);
+    cfg2.peers = vec![format!("127.0.0.1:{}", p1)];
+    cfg2.peer_addrs
+        .insert("node1".to_string(), format!("127.0.0.1:{}", p1));
+    cfg2.learner = true;
+    let node2 = ClusterNode::new(cfg2, temp_sled("learner"));
+
+    node1.start().await;
+    node2.start().await;
+
+    assert!(
+        wait_for_leader(&node1, Duration::from_secs(10)).await,
+        "the sole voter should become leader"
+    );
+
+    // Register the learner with the leader.
+    node1
+        .add_peer("node2".to_string(), addr2.clone(), true)
+        .await
+        .expect("leader adds learner");
+
+    // A write commits via the voter quorum (just the leader) and replicates
+    // to the learner.
+    node1
+        .put("k1".to_string(), "v1".to_string())
+        .await
+        .expect("write commits with a single voter");
+
+    // The learner should receive the replicated entry within a few heartbeats.
+    let mut replicated = false;
+    for _ in 0..40 {
+        if node2.get("k1").await.unwrap().as_deref() == Some("v1") {
+            replicated = true;
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    assert!(replicated, "learner should replicate committed entries");
+
+    // The learner must never win leadership.
+    let st2 = node2.status().await;
+    assert_eq!(st2.role, Role::Follower, "a learner stays a follower");
+    assert!(st2.is_learner, "node2 reports itself as a learner");
+
+    // The decisive check: kill the learner, then write again. With the learner
+    // excluded from the commit quorum, the leader still commits. (If the
+    // learner were a voter, losing it would break the 2-node majority and this
+    // write would time out.)
+    node2.shutdown();
+    sleep(Duration::from_millis(200)).await;
+
+    node1
+        .put("k2".to_string(), "v2".to_string())
+        .await
+        .expect("write still commits after the learner dies");
+
+    assert_eq!(node1.get("k2").await.unwrap().as_deref(), Some("v2"));
+    assert_eq!(
+        node1.status().await.role,
+        Role::Leader,
+        "leader is retained"
+    );
+
+    node1.shutdown();
+}

--- a/server/tests/cluster_simulation.rs
+++ b/server/tests/cluster_simulation.rs
@@ -44,6 +44,7 @@ fn make_config(idx: usize, ports: &[u16; 5]) -> ClusterConfig {
         heartbeat_interval: Duration::from_millis(80),
         election_timeout_min: Duration::from_millis(250),
         election_timeout_max: Duration::from_millis(500),
+        learner: false,
     }
 }
 

--- a/server/tests/cluster_write_forwarding.rs
+++ b/server/tests/cluster_write_forwarding.rs
@@ -42,6 +42,7 @@ fn make_config_3(idx: usize, ports: &[u16; 3]) -> ClusterConfig {
         heartbeat_interval: Duration::from_millis(80),
         election_timeout_min: Duration::from_millis(250),
         election_timeout_max: Duration::from_millis(500),
+        learner: false,
     }
 }
 
@@ -440,6 +441,7 @@ async fn test_dynamic_peer_join() {
             heartbeat_interval: Duration::from_millis(80),
             election_timeout_min: Duration::from_millis(250),
             election_timeout_max: Duration::from_millis(500),
+            learner: false,
         }
     };
     let config2 = {
@@ -454,6 +456,7 @@ async fn test_dynamic_peer_join() {
             heartbeat_interval: Duration::from_millis(80),
             election_timeout_min: Duration::from_millis(250),
             election_timeout_max: Duration::from_millis(500),
+            learner: false,
         }
     };
 
@@ -491,6 +494,7 @@ async fn test_dynamic_peer_join() {
         heartbeat_interval: Duration::from_millis(80),
         election_timeout_min: Duration::from_millis(250),
         election_timeout_max: Duration::from_millis(500),
+        learner: false,
     };
     let db3 = temp_sled("dyn-join-node3");
     let node3 = ClusterNode::new(config3, db3);
@@ -501,6 +505,7 @@ async fn test_dynamic_peer_join() {
         .handle_join(JoinRequest {
             node_id: "node3".to_string(),
             addr: format!("127.0.0.1:{}", ports[2]),
+            as_learner: false,
         })
         .await
         .expect("Join should succeed on leader");

--- a/site-docs/concepts/clustering.md
+++ b/site-docs/concepts/clustering.md
@@ -86,6 +86,17 @@ Initial peer addresses are supplied via `--peers` using the format `id@host:port
 
 Peer information is persisted to the local sled database under the key `raft_peers`, so a restarting node recovers its peer list without reconfiguration.
 
+## Non-voting learners
+
+A node can join as a **non-voting learner** with `--join-as-learner`. A learner participates in replication exactly like a voter — the leader sends it `AppendEntries` and it applies committed entries — but it is excluded from both quorums:
+
+- It never starts an election and never grants a vote, so it cannot become leader or split a vote.
+- The leader does **not** count it toward the commit majority, and candidates do not count it toward the election majority.
+
+This matters for **ephemeral nodes**. With ordinary voters, the majority grows with the cluster (`⌊N/2⌋ + 1`), so a node that joins and then disappears can stall writes until it is removed — a real hazard when nodes are spawned and torn down frequently (for example, one worker per session). Learners sidestep this: a cluster of one voter plus any number of learners still commits as soon as the voter has the entry, and a learner crashing or leaving never affects availability.
+
+The leader tracks which members are learners and propagates that set to followers (alongside `peer_addrs`) so every node computes the same voting membership; the classification is persisted under `raft_learners`. A learner is promoted or removed through the same dynamic-membership path as any other peer (`POST /raft/leave`, or `remove_peer` on the leader).
+
 ## See also
 
 - [How-to: Clustering & replication (Raft)](../how-to/clustering.md)

--- a/site-docs/reference/cli-flags.md
+++ b/site-docs/reference/cli-flags.md
@@ -46,6 +46,10 @@ Join an existing cluster by contacting this seed address (host:port). The node w
 
 - Value: `JOIN`
 
+### `--join-as-learner`
+
+Join as a non-voting learner: the node replicates the log but is excluded from election and commit quorums and never starts elections. Use for ephemeral nodes whose churn must not affect availability
+
 ### `--advertise-addr`
 
 Advertise address for this node (host:port). Used for peer discovery and write forwarding. Defaults to <node-id>:<cluster-port>


### PR DESCRIPTION
## Summary

Adds a **non-voting learner** mode to the Raft cluster. A node started with `--join-as-learner` joins and replicates the log like any member, but is **excluded from the election and commit quorums**, never starts an election, and never grants a vote.

## Why

With ordinary voters the write/election majority grows with the cluster (`⌊N/2⌋ + 1`). That means a node which joins and then disappears can **stall writes** until it is explicitly removed. This is a real hazard when nodes are spawned and torn down frequently — e.g. running **one mcp-v8 worker per session** and pointing them at a shared store for heap continuity. Today each such ephemeral worker would have to become a voter, and its churn would threaten cluster liveness.

With learners, a cluster of **one voter (the "main writer") + any number of learners** keeps committing as soon as the voter has the entry, and a learner crashing or leaving never affects availability — while learners still receive full replication of the session log and heap-tag store.

## What changed

- `ClusterConfig.learner` + `--join-as-learner` CLI flag; `JoinRequest.as_learner`.
- The leader tracks learner addresses and excludes them from both the **election** majority (`start_election`) and the **commit** majority (`update_commit_index`). Learners still receive `AppendEntries`, so they stay caught up.
- Learners **never start elections** (election timer is a no-op) and **never grant votes** (`handle_request_vote` short-circuits), so they cannot inflate a candidate's vote count.
- The leader propagates the learner set to followers via `AppendEntries` (`learner_addrs`), so every node computes the same voting membership. Classification is **persisted** under `raft_learners` and cleared on `remove_peer`.
- `ClusterStatus` now exposes `learners` and `is_learner` for observability.
- Wire/serde changes are backwards-compatible (`learner_addrs` and `as_learner` default to absent/false), so mixed-version nodes degrade safely to voter behavior.

## Tests

- New `server/tests/cluster_learner.rs`: a learner replicates committed entries, reports itself as a follower/learner, never wins leadership, and — the decisive check — **the leader keeps committing writes after the learner is killed** (a voter's death would break a 2-node majority and time out).
- Existing `cluster_simulation` (3) and `cluster_write_forwarding` (6) tests pass unchanged.

```
running 1 test
test learner_replicates_but_does_not_break_quorum ... ok
```

## Docs

- Regenerated `site-docs/reference/cli-flags.md` (adds `--join-as-learner`).
- Added a "Non-voting learners" section to `site-docs/concepts/clustering.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)