### PR TITLE
fix(fs): cross-worker snapshot loading for session fork

### DIFF
--- a/server/src/engine/fs_mount.rs
+++ b/server/src/engine/fs_mount.rs
@@ -58,6 +58,17 @@ impl SessionMount {
         self.base_id
     }
 
+    /// Warm the node-local blob cache with this mount's entire base tree. Must
+    /// be called on the runtime that owns the blob backend's remote I/O (the
+    /// server's main runtime), before the isolate runs — see
+    /// [`FsStore::prefetch`]. No-op for an empty (fresh) mount.
+    pub async fn warm(&self) -> anyhow::Result<()> {
+        if let Some(id) = self.base_id {
+            self.store.prefetch(*id.as_bytes()).await?;
+        }
+        Ok(())
+    }
+
     fn base_root(&self) -> Option<[u8; 32]> {
         self.base_id.map(|h| *h.as_bytes())
     }

--- a/server/src/engine/fs_store.rs
+++ b/server/src/engine/fs_store.rs
@@ -167,6 +167,39 @@ impl FsStore {
         }
     }
 
+    /// Warm the node-local blob cache with every tree node and file chunk
+    /// reachable from `root`. Intended to run on the runtime that owns the blob
+    /// backend's remote I/O (the server's main runtime), BEFORE the isolate
+    /// executes: deno_core ops run on the isolate's own current-thread runtime
+    /// and cannot await remote I/O from another runtime, so a lazy in-op fetch
+    /// from S3 would deadlock. Pre-staging every reachable blob locally makes
+    /// the in-op reads pure local-cache hits. Already-local blobs are skipped
+    /// cheaply via `HeapStorage::contains`.
+    pub async fn prefetch(&self, root: [u8; 32]) -> anyhow::Result<()> {
+        let mut stack = vec![root];
+        while let Some(id) = stack.pop() {
+            // Fetching the node populates the cache (write-through) and lets us
+            // walk its children.
+            let node = self.get_node(&id).await?;
+            for child in node.children.values() {
+                if let Some(entry) = &child.file {
+                    if let Content::Chunks(hashes) = &entry.content {
+                        for h in hashes {
+                            self.blobs
+                                .warm(&chunk_key(h))
+                                .await
+                                .map_err(|e| anyhow::anyhow!("warm chunk: {e}"))?;
+                        }
+                    }
+                }
+                if let Some(d) = child.dir {
+                    stack.push(d);
+                }
+            }
+        }
+        Ok(())
+    }
+
     // ── Tree nodes ─────────────────────────────────────────────────────────
 
     /// Fetch and decode a tree node, consulting the shared node cache first.

--- a/server/src/engine/heap_storage.rs
+++ b/server/src/engine/heap_storage.rs
@@ -22,6 +22,23 @@ pub trait HeapStorage: Send + Sync + 'static {
     async fn delete(&self, _name: &str) -> Result<(), String> {
         Err("delete is not supported by this storage backend".to_string())
     }
+
+    /// Whether a blob is present in this backend's *local* layer. Cheap by
+    /// default only where it can be (a local file/memory store); the generic
+    /// fallback actually fetches. Used by `warm` to skip already-local blobs.
+    async fn contains(&self, name: &str) -> Result<bool, String> {
+        Ok(self.get(name).await.is_ok())
+    }
+
+    /// Ensure a blob is materialized in this backend's local layer so a later
+    /// `get` does not have to cross to a remote backend (or another tokio
+    /// runtime). On a write-through cache this populates the local cache from
+    /// the primary; on a purely-local backend it is a no-op. Pre-staging fs
+    /// blobs via `warm` on the main runtime is what lets the isolate's
+    /// current-thread ops read them without awaiting remote I/O.
+    async fn warm(&self, name: &str) -> Result<(), String> {
+        self.get(name).await.map(|_| ())
+    }
 }
 
 /// In-memory blob backend. Primarily for tests and the `FsStore::in_memory`
@@ -61,6 +78,12 @@ impl HeapStorage for MemoryHeapStorage {
     async fn delete(&self, name: &str) -> Result<(), String> {
         self.map.lock().unwrap().remove(name);
         Ok(())
+    }
+    async fn contains(&self, name: &str) -> Result<bool, String> {
+        Ok(self.map.lock().unwrap().contains_key(name))
+    }
+    async fn warm(&self, _name: &str) -> Result<(), String> {
+        Ok(()) // already local
     }
 }
 
@@ -114,12 +137,24 @@ impl HeapStorage for FileHeapStorage {
             Err(e) => Err(e.to_string()),
         }
     }
+    async fn contains(&self, name: &str) -> Result<bool, String> {
+        Ok(self.dir.join(name).exists())
+    }
+    async fn warm(&self, _name: &str) -> Result<(), String> {
+        Ok(()) // this backend IS the local layer
+    }
 }
 
 #[derive(Clone)]
 pub struct S3HeapStorage {
     bucket: String,
     client: Arc<S3Client>,
+    // The runtime the S3 client (and its hyper connection pool / IO reactor)
+    // was created on. S3 calls are dispatched here even when invoked from
+    // another runtime — e.g. the isolate's current-thread runtime during an
+    // fs-snapshot blob fetch. Awaiting the aws future directly on a different
+    // runtime hangs because the connection's IO reactor lives on this one.
+    runtime: tokio::runtime::Handle,
 }
 
 impl S3HeapStorage {
@@ -152,6 +187,7 @@ impl S3HeapStorage {
         Self {
             bucket: bucket.into(),
             client: Arc::new(client),
+            runtime: tokio::runtime::Handle::current(),
         }
     }
 
@@ -160,30 +196,42 @@ impl S3HeapStorage {
         let bucket = self.bucket.clone();
         let name = name.to_string();
         let data = data.to_vec();
-        client
-            .put_object()
-            .bucket(bucket)
-            .key(name)
-            .body(ByteStream::from(data))
-            .send()
+        // Run on the S3 client's own runtime (see `runtime` field), awaiting the
+        // JoinHandle — which is safe to poll from any runtime.
+        self.runtime
+            .spawn(async move {
+                client
+                    .put_object()
+                    .bucket(bucket)
+                    .key(name)
+                    .body(ByteStream::from(data))
+                    .send()
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            })
             .await
-            .map(|_| ())
-            .map_err(|e| e.to_string())
+            .map_err(|e| format!("s3 put task join error: {e}"))?
     }
 
     async fn get_blocking(&self, name: &str) -> Result<Vec<u8>, String> {
         let client = self.client.clone();
         let bucket = self.bucket.clone();
         let name = name.to_string();
-        let output = client
-            .get_object()
-            .bucket(bucket)
-            .key(name)
-            .send()
+        self.runtime
+            .spawn(async move {
+                let output = client
+                    .get_object()
+                    .bucket(bucket)
+                    .key(name)
+                    .send()
+                    .await
+                    .map_err(|e| e.to_string())?;
+                let data = output.body.collect().await.map_err(|e| e.to_string())?;
+                Ok::<Vec<u8>, String>(data.into_bytes().to_vec())
+            })
             .await
-            .map_err(|e| e.to_string())?;
-        let data = output.body.collect().await.map_err(|e| e.to_string())?;
-        Ok(data.into_bytes().to_vec())
+            .map_err(|e| format!("s3 get task join error: {e}"))?
     }
 }
 
@@ -322,6 +370,24 @@ impl<P: HeapStorage + Clone> HeapStorage for WriteThroughCacheHeapStorage<P> {
         self.bound.lock().unwrap().forget(name);
         let _ = self.cache.delete(name).await;
         self.primary.delete(name).await
+    }
+    async fn contains(&self, name: &str) -> Result<bool, String> {
+        self.cache.contains(name).await
+    }
+    async fn warm(&self, name: &str) -> Result<(), String> {
+        // Already cached locally — nothing to fetch.
+        if self.cache.contains(name).await.unwrap_or(false) {
+            return Ok(());
+        }
+        // Pull from the primary (e.g. S3) and populate the local cache, so a
+        // later get() served from the cache never crosses to a remote backend.
+        let data = self.primary.get(name).await?;
+        if let Err(e) = self.cache.put(name, &data).await {
+            tracing::warn!("Failed to warm FS cache for {}: {}", name, e);
+        } else {
+            self.note_cached(name, data.len() as u64).await;
+        }
+        Ok(())
     }
 }
 

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -744,19 +744,27 @@ fn execute_module(runtime: &mut JsRuntime, code: &str) -> Result<(), String> {
     let main_url = ModuleSpecifier::parse(&format!("file:///main_{}.js", id))
         .map_err(|e| format!("internal specifier error: {}", e))?;
 
-    // The isolate event loop MUST run on a current-thread tokio runtime, never
-    // the ambient multi-thread server runtime. deno_core's op driver schedules
-    // every pending async op via `deno_unsync::spawn`, which asserts a
-    // current-thread runtime flavor; on a multi-thread runtime any op that
-    // stays pending (e.g. an fs-snapshot blob fetched from S3 on a cold cache)
-    // hits that assertion and aborts the process. We are always invoked from a
-    // blocking context (spawn_blocking), so building and blocking on a
-    // dedicated current-thread runtime here is safe.
-    let owned_rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
-    let handle = owned_rt.handle().clone();
+    // Use the current tokio runtime handle if available, otherwise create a
+    // temporary one. Direct callers (tests, fuzz targets) may not have a
+    // tokio runtime on the current thread.
+    //
+    // NOTE: the isolate runs on the ambient (multi-thread) server runtime on
+    // purpose. Async ops that await resources bound to that runtime — the child
+    // MCP clients (mcp.callTool) and the S3 client — only make progress there.
+    // Cross-worker fs-snapshot blobs are pre-staged into the local cache by
+    // `build_fs_mount` (on this runtime) before the isolate runs, so in-op fs
+    // reads are local and never await remote I/O from inside the isolate.
+    let owned_rt;
+    let handle = match tokio::runtime::Handle::try_current() {
+        Ok(h) => h,
+        Err(_) => {
+            owned_rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
+            owned_rt.handle().clone()
+        }
+    };
 
     let _guard = handle.enter();
 

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -744,20 +744,19 @@ fn execute_module(runtime: &mut JsRuntime, code: &str) -> Result<(), String> {
     let main_url = ModuleSpecifier::parse(&format!("file:///main_{}.js", id))
         .map_err(|e| format!("internal specifier error: {}", e))?;
 
-    // Use the current tokio runtime handle if available, otherwise create a
-    // temporary one. Direct callers (tests, fuzz targets) may not have a
-    // tokio runtime on the current thread.
-    let owned_rt;
-    let handle = match tokio::runtime::Handle::try_current() {
-        Ok(h) => h,
-        Err(_) => {
-            owned_rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
-            owned_rt.handle().clone()
-        }
-    };
+    // The isolate event loop MUST run on a current-thread tokio runtime, never
+    // the ambient multi-thread server runtime. deno_core's op driver schedules
+    // every pending async op via `deno_unsync::spawn`, which asserts a
+    // current-thread runtime flavor; on a multi-thread runtime any op that
+    // stays pending (e.g. an fs-snapshot blob fetched from S3 on a cold cache)
+    // hits that assertion and aborts the process. We are always invoked from a
+    // blocking context (spawn_blocking), so building and blocking on a
+    // dedicated current-thread runtime here is safe.
+    let owned_rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
+    let handle = owned_rt.handle().clone();
 
     let _guard = handle.enter();
 
@@ -1736,6 +1735,17 @@ impl Engine {
                 None => fs_mount::SessionMount::empty((**store).clone()),
             }
         };
+
+        // Pre-stage the mounted tree's blobs into the node-local cache now, on
+        // this (main) runtime. The isolate runs on its own current-thread
+        // runtime and its fs ops cannot await the blob backend's remote I/O, so
+        // a lazy in-op fetch from S3 would deadlock; warming here makes those
+        // reads pure local-cache hits.
+        mount
+            .warm()
+            .await
+            .map_err(|e| format!("fs mount: warm {handle}: {e}"))?;
+
         Ok(Some(fs::FsMountHandle::new(mount)))
     }
 

--- a/site-docs/how-to/storage-backends.md
+++ b/site-docs/how-to/storage-backends.md
@@ -30,6 +30,25 @@ The server initialises the S3 client from the environment at startup using the s
 
 S3 storage lets multiple nodes share the same heap store, which is required for a horizontally-scaled or clustered deployment.
 
+## Use an S3-compatible store (MinIO, LocalStack)
+
+Point the S3 client at a non-AWS endpoint with `AWS_ENDPOINT_URL`, and enable
+path-style addressing with `AWS_S3_FORCE_PATH_STYLE` (most S3-compatible stores
+serve `host/bucket/key` rather than `bucket.host/key`):
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:9000
+export AWS_S3_FORCE_PATH_STYLE=true
+export AWS_ACCESS_KEY_ID=minioadmin
+export AWS_SECRET_ACCESS_KEY=minioadmin
+export AWS_DEFAULT_REGION=us-east-1
+
+mcp-v8 --http-port=8080 --s3-bucket=my-mcp-heaps
+```
+
+The bucket must already exist (create it with `mc mb` or the store's console).
+Leave `AWS_ENDPOINT_URL` / `AWS_S3_FORCE_PATH_STYLE` unset for real AWS S3.
+
 ## Add a local FS write-through cache in front of S3
 
 Use `--cache-dir` together with `--s3-bucket` to keep a local disk cache:

--- a/site-docs/reference/storage-backends.md
+++ b/site-docs/reference/storage-backends.md
@@ -41,7 +41,7 @@ The session DB is separate from the heap store. Losing the session DB does not d
 
 ## S3 credential expectations
 
-The S3 client is initialised at server startup via `aws_config::load_from_env()`, which walks the standard AWS SDK credential chain in order:
+The S3 client is initialised at server startup from the environment (the default AWS SDK config with the latest behavior version), which walks the standard AWS SDK credential chain in order:
 
 1. **Environment variables**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_SESSION_TOKEN`.
 2. **Shared credentials file**: `~/.aws/credentials` (profile selected by `AWS_PROFILE`, default `default`).
@@ -53,6 +53,7 @@ Additional environment variables that influence S3 behaviour:
 |---|---|
 | `AWS_DEFAULT_REGION` | AWS region for the bucket (required if not in `~/.aws/config`) |
 | `AWS_ENDPOINT_URL` | Override the S3 endpoint URL (use for S3-compatible stores such as MinIO or LocalStack) |
+| `AWS_S3_FORCE_PATH_STYLE` | Set to `true` to use path-style addressing (`host/bucket/key`). Required by most S3-compatible stores (MinIO, etc.); leave unset for real AWS S3, which uses virtual-hosted style |
 | `AWS_SESSION_TOKEN` | Temporary session token for STS-issued credentials |
 
 The server does not accept S3 credentials via CLI flags. All credential configuration must be done through the AWS SDK credential chain before the process starts.


### PR DESCRIPTION
Loading a heap + filesystem snapshot created by a **different** worker — the session-fork case (read a source session's snapshots, seed a fresh worker from them) — failed three ways. This makes it work: a worker can restore another worker's heap and fs from the shared S3 blob store.

## Fixes

1. **Isolate runtime.** `execute_module` drove the V8 event loop on the ambient multi-thread runtime. deno_core's op driver schedules every pending async op via `deno_unsync::spawn`, which asserts a **current-thread** runtime; any op that stayed pending (e.g. an fs blob fetched from S3 on a cold cache) aborted the process. The isolate now always runs on a dedicated current-thread runtime.

2. **S3 client runtime affinity.** The S3 client's connection pool / IO reactor lives on the runtime it was built on (the server's main runtime). Calls issued from the isolate's current-thread runtime never progressed. `S3HeapStorage` now captures that handle and dispatches every call onto it.

3. **Lazy in-op fs fetch.** fs reads pull chunks on demand from inside the op, on the isolate runtime, which cannot await the blob backend's remote I/O. Added `HeapStorage::warm`/`contains` and `FsStore::prefetch`; `build_fs_mount` warms the mounted tree's blobs into the node-local cache on the **main** runtime before the isolate runs, so in-op reads are pure local-cache hits. `warm()` skips already-local blobs cheaply, so same-worker sessions are unaffected.

## Verification

Coordinator + 2 learners + MinIO. A learner restores another learner's heap and fs from S3; a fork accumulates its own changes across runs (`VAR=heap-7+mod FILE=fs-7+more` on re-run) while the source is unchanged (`VAR=heap-7 FILE=fs-7`) — copy-on-write isolation. 99 lib tests pass.

## Note on debug builds

A debug-only assertion in the deno_core fork's `serialize_for_snapshotting` (`by_name.len() == handles.len()`) fires when re-snapshotting a cross-loaded isolate. It is compiled out in release, and the resulting snapshot is valid (verified end-to-end on a release build), so production is unaffected. Run a release binary for local fork testing, or relax that assertion in the fork for debug builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)