### PR TITLE
feat: decouple heap & filesystem persistence + fix isolate runtime (v0.16.0)

### DIFF
--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Run bash CLI E2E tests
         run: |
-          # Start the server in HTTP stateless mode
-          ./server-bin --stateless --http-port 3000 &
+          # Start the server in HTTP stateless mode (the default: no heap/fs)
+          ./server-bin --http-port 3000 &
           SERVER_PID=$!
 
           cleanup() { kill $SERVER_PID 2>/dev/null || true; }

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -81,9 +81,9 @@ jobs:
           if [ "${{ matrix.topology }}" = "single" ]; then
             # ── Single node ─────────────────────────────────
             if [ "${{ matrix.mode }}" = "stateful" ]; then
-              ARGS="--http-port=3001 --directory-path=/tmp/loadtest/node1/heaps --session-db-path=/tmp/loadtest/node1/sessions"
+              ARGS="--http-port=3001 --heap-store=dir --heap-dir=/tmp/loadtest/node1/heaps --session-db-path=/tmp/loadtest/node1/sessions"
             else
-              ARGS="--http-port=3001 --stateless --session-db-path=/tmp/loadtest/node1/sessions"
+              ARGS="--http-port=3001 --session-db-path=/tmp/loadtest/node1/sessions"
             fi
 
             echo "Starting single node on port 3001..."
@@ -110,9 +110,9 @@ jobs:
               done
 
               if [ "${{ matrix.mode }}" = "stateful" ]; then
-                MODE_ARGS="--directory-path=/tmp/loadtest/${NODE_ID}/heaps --session-db-path=/tmp/loadtest/${NODE_ID}/sessions"
+                MODE_ARGS="--heap-store=dir --heap-dir=/tmp/loadtest/${NODE_ID}/heaps --session-db-path=/tmp/loadtest/${NODE_ID}/sessions"
               else
-                MODE_ARGS="--stateless --session-db-path=/tmp/loadtest/${NODE_ID}/sessions"
+                MODE_ARGS="--session-db-path=/tmp/loadtest/${NODE_ID}/sessions"
               fi
 
               echo "Starting ${NODE_ID} on HTTP ${HTTP_PORT}, cluster ${CLUSTER_PORT}..."

--- a/.github/workflows/mcp-e2e.yml
+++ b/.github/workflows/mcp-e2e.yml
@@ -34,9 +34,10 @@ jobs:
 
           # Start the HTTP server with an MCP server connection.
           # The MCP server is another mcp-js instance running in stateless
-          # stdio MCP mode, providing the "run_js" tool.
-          $SERVER_BIN --stateless --http-port 8080 \
-            --mcp-server "tools=stdio:${SERVER_BIN}:--stateless" &
+          # stdio MCP mode (the default: no heap/fs persistence), providing
+          # the "run_js" tool.
+          $SERVER_BIN --http-port 8080 \
+            --mcp-server "tools=stdio:${SERVER_BIN}" &
           SERVER_PID=$!
 
           cleanup() { kill $SERVER_PID 2>/dev/null || true; }

--- a/.github/workflows/sqlite-wasm-e2e.yml
+++ b/.github/workflows/sqlite-wasm-e2e.yml
@@ -38,8 +38,9 @@ jobs:
           echo "WASM: $WASM_PATH"
           echo "Server: $SERVER_BIN"
 
-          # Start server in HTTP mode with the SQLite WASM module
-          $SERVER_BIN --stateless --http-port 8080 \
+          # Start server in HTTP mode with the SQLite WASM module (stateless is
+          # the default; WASM is incompatible with heap persistence anyway)
+          $SERVER_BIN --http-port 8080 \
             --wasm-module sqlite="$WASM_PATH" \
             --heap-memory-max 64 &
           SERVER_PID=$!

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,10 @@ EXPOSE 8080
 
 # Use ENTRYPOINT for the binary so CMD provides default arguments.
 # This allows Docker MCP Registry and other orchestrators to override
-# just the arguments (e.g. --stateless for stdio) without repeating the binary name.
+# just the arguments without repeating the binary name.
 ENTRYPOINT ["mcp-v8"]
 
-# Default: run SSE server on port 8080 in stateless mode.
-# Override with: docker run <image> --stateless (stdio), --http-port 8080 --stateless, etc.
-CMD ["--sse-port", "8080", "--stateless"]
+# Default: run SSE server on port 8080, stateless (no heap/fs persistence).
+# Override args, e.g.: docker run <image> --http-port 8080 --fs-store dir --fs-dir /data/fs
+CMD ["--sse-port", "8080"]
 

--- a/docker-compose.cluster-stateless.yml
+++ b/docker-compose.cluster-stateless.yml
@@ -26,7 +26,6 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --stateless
       - --cluster-port=4000
       - --node-id=node1
       - --peers=node2@node2:4000,node3@node3:4000
@@ -41,7 +40,6 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --stateless
       - --cluster-port=4000
       - --node-id=node2
       - --peers=node1@node1:4000,node3@node3:4000
@@ -56,7 +54,6 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --stateless
       - --cluster-port=4000
       - --node-id=node3
       - --peers=node1@node1:4000,node2@node2:4000

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -25,7 +25,8 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
       - --cluster-port=4000
       - --node-id=node1
@@ -43,7 +44,8 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
       - --cluster-port=4000
       - --node-id=node2
@@ -61,7 +63,8 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
       - --cluster-port=4000
       - --node-id=node3

--- a/docker-compose.module-policy.yml
+++ b/docker-compose.module-policy.yml
@@ -18,7 +18,8 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
     tmpfs:
       - /data:uid=1000,gid=1000
@@ -29,7 +30,8 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
       - --allow-external-modules
       - --policies-json={"modules":{"policies":[{"url":"http://opa:8181","policy_path":"mcp/modules"}]}}

--- a/docker-compose.secure-sessions.yml
+++ b/docker-compose.secure-sessions.yml
@@ -28,7 +28,8 @@ services:
       - JWKS_URL=http://keycloak:8080/realms/mcp/protocol/openid-connect/certs
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
       - --policies-json={"fetch":{"policies":[{"url":"http://opa:8181"}]},"filesystem":{"policies":[{"url":"http://opa:8181"}]}}
       - --fetch-header=host=host.docker.internal,header=Authorization,token_url=http://keycloak:8080/realms/mcp/protocol/openid-connect/token,client_id=mcp-client,client_secret=mcp-client-secret

--- a/docker-compose.single-node-stateful.yml
+++ b/docker-compose.single-node-stateful.yml
@@ -24,7 +24,8 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
     volumes:
       - node1-data:/data

--- a/docker-compose.single-node.yml
+++ b/docker-compose.single-node.yml
@@ -24,6 +24,5 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --stateless
     expose:
       - "3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
     build: .
     command:
       - --http-port=3000
-      - --directory-path=/data/heaps
+      - --heap-store=dir
+      - --heap-dir=/data/heaps
       - --session-db-path=/data/sessions
       - --policies-json={"fetch":{"policies":[{"url":"http://opa:8181"}]}}
       - --fetch-header=host=api.github.com,header=Authorization,value=Bearer ${GITHUB_TOKEN}

--- a/mcp-v8-client/tests/cli_e2e.rs
+++ b/mcp-v8-client/tests/cli_e2e.rs
@@ -85,7 +85,7 @@ impl TestServer {
         let bin = server_bin();
 
         let child = Command::new(&bin)
-            .args(["--stateless", "--http-port", &port.to_string()])
+            .args(["--http-port", &port.to_string()])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/server/README.md
+++ b/server/README.md
@@ -166,12 +166,35 @@ println!("execution_id: {}", resp.into_inner().execution_id);
 
 ### Storage Options
 
-- `--s3-bucket <bucket>`: Use AWS S3 for heap snapshots. Specify the S3 bucket name. (Conflicts with `--stateless`)
-- `--cache-dir <path>`: Local filesystem cache directory for S3 write-through caching. Reduces latency by caching snapshots locally. (Requires `--s3-bucket`)
-- `--directory-path <path>`: Use a local directory for heap snapshots. Specify the directory path. (Conflicts with `--stateless`)
-- `--stateless`: Run in stateless mode - no heap snapshots are saved or loaded. Each JavaScript execution starts with a fresh V8 isolate. (Conflicts with `--s3-bucket` and `--directory-path`)
+Heap persistence (V8 heap snapshots) and filesystem persistence (the
+content-addressed `/work` filesystem) are **two independent, opt-in axes**. Each
+is selected with a `*-store` flag (`none` | `dir` | `s3`); both default to
+`none`. Any combination is valid: neither, heap-only, fs-only, or both.
 
-**Note:** For heap storage, if neither `--s3-bucket`, `--directory-path`, nor `--stateless` is provided, the server defaults to using `/tmp/mcp-v8-heaps` as the local directory.
+- `--heap-store <none|dir|s3>`: V8 heap-snapshot backend (default `none`). `dir`
+  uses `--heap-dir` (default `/tmp/mcp-v8-heaps`); `s3` uses the shared
+  `--s3-bucket`. Heap snapshots run in a V8 SnapshotCreator isolate that
+  **disables WebAssembly**, so `--heap-store` (other than `none`) is mutually
+  exclusive with `--wasm-module`/`--wasm-config` (rejected at startup).
+- `--heap-dir <path>`: directory for `--heap-store dir`.
+- `--fs-store <none|dir|s3>`: `/work` filesystem backend (default `none`). `dir`
+  uses `--fs-dir` (default `<session-db>/fs-blobs`); `s3` uses `--s3-bucket`.
+  Works with any isolate (compatible with WASM). When on, the `fs` parameter of
+  `run_js` and the `fs_*` tools / `/api/fs/...` endpoints become functional.
+- `--fs-dir <path>`: directory for `--fs-store dir`.
+- `--fs-labels-db <path>`: fs label/reflog sled db (default `<session-db>/fs-labels`).
+- `--s3-bucket <bucket>`: shared S3 bucket backing whichever axes use `s3`.
+- `--cache-dir <path>`: local write-through cache for the S3 backend. (Requires `--s3-bucket`)
+
+Every flag is also settable via an `MCP_V8_*` environment variable (precedence:
+CLI flag > env var > default), e.g. `MCP_V8_FS_STORE=dir`, `MCP_V8_S3_BUCKET=...`.
+
+> **Migration from ≤ v0.15:** `--stateless` is removed — the default is now
+> `--heap-store none` (no heap). `--directory-path X` → `--heap-store dir
+> --heap-dir X`. `--s3-bucket B` (for heaps) → `--heap-store s3 --s3-bucket B`.
+> `--enable-fs-snapshots` (+ `--fs-store-dir X`) → `--fs-store dir` (+ `--fs-dir
+> X`) or `--fs-store s3`. New capability: `--fs-store dir --wasm-module …` with
+> no heap (fs + WASM, previously impossible).
 
 ### Transport Options
 
@@ -186,7 +209,7 @@ println!("execution_id: {}", resp.into_inner().execution_id);
 
 ### Session Logging
 
-- `--session-db-path <path>`: Path to the sled database used for session logging (default: `/tmp/mcp-v8-sessions`). Only applies in stateful mode. (Conflicts with `--stateless`)
+- `--session-db-path <path>`: Path to the sled database used for the session log (per-session heap+fs history) and execution registry (default: `/tmp/mcp-v8-sessions`). Used whenever heap or fs persistence is enabled.
 
 ### Cluster Options
 

--- a/server/src/bin/generate-mcp-tools-markdown.rs
+++ b/server/src/bin/generate-mcp-tools-markdown.rs
@@ -214,8 +214,10 @@ fn render_mode(catalog: ToolCatalog) -> Vec<String> {
 }
 
 fn main() {
-    let stateful = built_in_tool_catalog(true);
-    let stateless = built_in_tool_catalog(false);
+    // "stateful" doc = the full session-capable surface (heap + fs); "stateless"
+    // doc = the no-state surface.
+    let stateful = built_in_tool_catalog(true, true);
+    let stateless = built_in_tool_catalog(false, false);
 
     let mut lines = vec![
         "# MCP Tools".to_string(),

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -6,7 +6,35 @@ fn default_max_concurrent() -> usize {
     std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4)
 }
 
-/// Command line arguments for configuring heap storage
+/// Backend selection for an independent state axis (heap or filesystem).
+///
+/// `none` disables that axis entirely; `dir` uses a node-local directory; `s3`
+/// uses the shared `--s3-bucket` (optionally fronted by `--cache-dir`). Heap and
+/// filesystem persistence are independent: any combination of the two is valid
+/// (neither / heap-only / fs-only / both).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum StoreKind {
+    None,
+    Dir,
+    S3,
+}
+
+impl std::fmt::Display for StoreKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            StoreKind::None => "none",
+            StoreKind::Dir => "dir",
+            StoreKind::S3 => "s3",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Command line arguments. Heap snapshots and the content-addressed filesystem
+/// are two independent, opt-in axes of per-session state (see `StoreKind`).
+///
+/// Every flag is also bindable from an `MCP_V8_*` environment variable
+/// (precedence: explicit CLI flag > env var > default).
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
@@ -15,38 +43,29 @@ pub struct Cli {
     #[arg(long, help_heading = "Core")]
     pub print_openapi: bool,
 
-    /// S3 bucket name (required if --use-s3)
-    #[arg(long, conflicts_with_all = ["directory_path", "stateless"], help_heading = "Core")]
-    pub s3_bucket: Option<String>,
-
-    /// Local filesystem cache directory for S3 write-through caching (only used with --s3-bucket)
-    #[arg(long, requires = "s3_bucket", help_heading = "Core")]
-    pub cache_dir: Option<String>,
-
-    /// Directory path for filesystem storage (required if --use-filesystem)
-    #[arg(long, conflicts_with_all = ["s3_bucket", "stateless"], help_heading = "Core")]
-    pub directory_path: Option<String>,
-
-    /// Run in stateless mode - no heap snapshots are saved or loaded
-    #[arg(long, conflicts_with_all = ["s3_bucket", "directory_path"], help_heading = "Core")]
-    pub stateless: bool,
-
     /// JWKS endpoint URL for fetching public keys (e.g., Keycloak OIDC certs URL).
     /// Enables JWT verification of Authorization: Bearer tokens during initialize.
     #[arg(long, env = "JWKS_URL", help_heading = "Core")]
     pub jwks_url: Option<String>,
 
     /// HTTP port using Streamable HTTP transport (MCP 2025-03-26+, load-balanceable)
-    #[arg(long, conflicts_with = "sse_port", help_heading = "Core")]
+    #[arg(long, env = "MCP_V8_HTTP_PORT", conflicts_with = "sse_port", help_heading = "Core")]
     pub http_port: Option<u16>,
 
     /// SSE port using the older HTTP+SSE transport
-    #[arg(long, conflicts_with = "http_port", help_heading = "Core")]
+    #[arg(long, env = "MCP_V8_SSE_PORT", conflicts_with = "http_port", help_heading = "Core")]
     pub sse_port: Option<u16>,
+
+    /// Host/address the HTTP and SSE transports bind to. Defaults to all IPv4
+    /// interfaces (0.0.0.0). Set to "::" for a dual-stack IPv6 listener, which is
+    /// required to be reachable over IPv6-resolving private networks (e.g. Railway).
+    #[arg(long, env = "MCP_V8_BIND_HOST", default_value = "0.0.0.0", help_heading = "Core")]
+    pub bind_host: String,
 
     /// Maximum V8 heap memory per isolate in megabytes (default: 8)
     #[arg(
         long,
+        env = "MCP_V8_HEAP_MEMORY_MAX",
         default_value = "8",
         value_parser = clap::value_parser!(u64).range(1..),
         help_heading = "Core"
@@ -56,6 +75,7 @@ pub struct Cli {
     /// Maximum execution timeout in seconds (default: 30, max: 300)
     #[arg(
         long,
+        env = "MCP_V8_EXECUTION_TIMEOUT",
         default_value_t = DEFAULT_EXECUTION_TIMEOUT_SECS,
         value_parser = clap::value_parser!(u64).range(1..=300),
         help_heading = "Core"
@@ -63,12 +83,65 @@ pub struct Cli {
     pub execution_timeout: u64,
 
     /// Maximum concurrent V8 executions (default: CPU core count)
-    #[arg(long, default_value_t = default_max_concurrent(), help_heading = "Core")]
+    #[arg(long, env = "MCP_V8_MAX_CONCURRENT_EXECUTIONS", default_value_t = default_max_concurrent(), help_heading = "Core")]
     pub max_concurrent_executions: usize,
 
-    /// Path to the sled database for session logging (default: /tmp/mcp-v8-sessions)
-    #[arg(long, default_value = "/tmp/mcp-v8-sessions", help_heading = "Core")]
+    /// Path to the sled database for the session log (per-session heap+fs
+    /// history) and the execution registry. Also the default parent for the
+    /// heap-tag store, fs blob store, and fs label db. Default: /tmp/mcp-v8-sessions.
+    #[arg(long, env = "MCP_V8_SESSION_DB_PATH", default_value = "/tmp/mcp-v8-sessions", help_heading = "Core")]
     pub session_db_path: String,
+
+    // ── Heap persistence (independent axis) ──────────────────────────────────
+    /// V8 heap-snapshot backend. `none` (default) = no heap persistence; JS
+    /// globals do NOT survive between runs. `dir` = node-local directory
+    /// (`--heap-dir`). `s3` = shared `--s3-bucket` (optionally `--cache-dir`).
+    ///
+    /// Heap snapshots require a V8 SnapshotCreator isolate, which disables
+    /// WebAssembly — so heap persistence is mutually exclusive with
+    /// `--wasm-module`/`--wasm-config` (rejected at startup).
+    #[arg(long, env = "MCP_V8_HEAP_STORE", value_enum, default_value_t = StoreKind::None, help_heading = "Heap")]
+    pub heap_store: StoreKind,
+
+    /// Directory for the heap-snapshot store when `--heap-store dir`.
+    /// Defaults to /tmp/mcp-v8-heaps.
+    #[arg(long, env = "MCP_V8_HEAP_DIR", value_name = "DIR", help_heading = "Heap")]
+    pub heap_dir: Option<String>,
+
+    // ── Filesystem persistence (independent axis) ────────────────────────────
+    /// Content-addressed `/work` filesystem backend. `none` (default) = no fs
+    /// persistence. `dir` = node-local blob store (`--fs-dir`). `s3` = shared
+    /// `--s3-bucket`. When enabled, the `fs` parameter of run_js can mount a
+    /// snapshot (by label or CA id) and the `fs_*` tools / `/api/fs/...`
+    /// endpoints become functional. Works with any isolate (compatible with
+    /// `--wasm-module`).
+    ///
+    /// In cluster mode labels replicate cluster-wide, but blobs/manifests are
+    /// only shared when stored on shared storage — so `--fs-store s3` is required
+    /// when running fs persistence in a cluster.
+    #[arg(long, env = "MCP_V8_FS_STORE", value_enum, default_value_t = StoreKind::None, help_heading = "Filesystem")]
+    pub fs_store: StoreKind,
+
+    /// Directory for the fs snapshot blob store (chunks + manifests) when
+    /// `--fs-store dir`. Defaults to `<session-db-path>/fs-blobs`.
+    #[arg(long = "fs-dir", env = "MCP_V8_FS_DIR", value_name = "DIR", help_heading = "Filesystem")]
+    pub fs_dir: Option<String>,
+
+    /// Path for the fs label/reflog database (sled). Defaults to
+    /// `<session-db-path>/fs-labels`.
+    #[arg(long = "fs-labels-db", env = "MCP_V8_FS_LABELS_DB", value_name = "PATH", help_heading = "Filesystem")]
+    pub fs_labels_db: Option<String>,
+
+    // ── Shared S3 backend (used by heap-store=s3 and/or fs-store=s3) ──────────
+    /// S3 bucket backing whichever axes select `s3`. Required when
+    /// `--heap-store s3` or `--fs-store s3` is set.
+    #[arg(long, env = "MCP_V8_S3_BUCKET", help_heading = "Storage (S3)")]
+    pub s3_bucket: Option<String>,
+
+    /// Local filesystem cache directory for S3 write-through caching (only used
+    /// with `--s3-bucket`).
+    #[arg(long, env = "MCP_V8_CACHE_DIR", requires = "s3_bucket", help_heading = "Storage (S3)")]
+    pub cache_dir: Option<String>,
 
     /// Override the MCP server `instructions` (the "system prompt" the server
     /// reports to clients during `initialize`). The value is used verbatim as
@@ -76,7 +149,7 @@ pub struct Cli {
     /// treated as a path to a file whose contents are used (`@-` is not special;
     /// use `@@` for a literal leading `@`).
     /// Examples: --instructions "Run JS for me"  --instructions @./prompt.txt
-    #[arg(long, value_name = "TEXT_OR_@FILE", help_heading = "Prompt")]
+    #[arg(long, env = "MCP_V8_INSTRUCTIONS", value_name = "TEXT_OR_@FILE", help_heading = "Prompt")]
     pub instructions: Option<String>,
 
     /// Override the description advertised for the `run_js` tool in `tools/list`.
@@ -84,48 +157,48 @@ pub struct Cli {
     /// which case the remainder is treated as a path to a file whose contents are
     /// used (use `@@` for a literal leading `@`).
     /// Examples: --run-js-description "Execute JS"  --run-js-description @./run_js.md
-    #[arg(long = "run-js-description", value_name = "TEXT_OR_@FILE", help_heading = "Prompt")]
+    #[arg(long = "run-js-description", env = "MCP_V8_RUN_JS_DESCRIPTION", value_name = "TEXT_OR_@FILE", help_heading = "Prompt")]
     pub run_js_description: Option<String>,
 
     /// Port for the Raft cluster HTTP server. Enables cluster mode when set.
-    #[arg(long, help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_CLUSTER_PORT", help_heading = "Cluster")]
     pub cluster_port: Option<u16>,
 
     /// Unique node identifier within the cluster
-    #[arg(long, default_value = "node1", help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_NODE_ID", default_value = "node1", help_heading = "Cluster")]
     pub node_id: String,
 
     /// Comma-separated list of seed peer addresses. Format: id@host:port or host:port.
     /// Peers can also join dynamically via POST /raft/join.
-    #[arg(long, value_delimiter = ',', help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_PEERS", value_delimiter = ',', help_heading = "Cluster")]
     pub peers: Vec<String>,
 
     /// Join an existing cluster by contacting this seed address (host:port).
     /// The node will register itself with the cluster leader via /raft/join.
-    #[arg(long, help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_JOIN", help_heading = "Cluster")]
     pub join: Option<String>,
 
     /// Join as a non-voting learner: the node replicates the log but is
     /// excluded from election and commit quorums and never starts elections.
     /// Use for ephemeral nodes whose churn must not affect availability.
-    #[arg(long, help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_JOIN_AS_LEARNER", help_heading = "Cluster")]
     pub join_as_learner: bool,
 
     /// Advertise address for this node (host:port). Used for peer discovery
     /// and write forwarding. Defaults to <node-id>:<cluster-port>.
-    #[arg(long, help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_ADVERTISE_ADDR", help_heading = "Cluster")]
     pub advertise_addr: Option<String>,
 
     /// Heartbeat interval in milliseconds
-    #[arg(long, default_value = "100", help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_HEARTBEAT_INTERVAL", default_value = "100", help_heading = "Cluster")]
     pub heartbeat_interval: u64,
 
     /// Minimum election timeout in milliseconds
-    #[arg(long, default_value = "300", help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_ELECTION_TIMEOUT_MIN", default_value = "300", help_heading = "Cluster")]
     pub election_timeout_min: u64,
 
     /// Maximum election timeout in milliseconds
-    #[arg(long, default_value = "500", help_heading = "Cluster")]
+    #[arg(long, env = "MCP_V8_ELECTION_TIMEOUT_MAX", default_value = "500", help_heading = "Cluster")]
     pub election_timeout_max: u64,
 
     /// Pre-load a WASM module as a global. Format: name=/path/to/module.wasm[:max_memory]
@@ -134,6 +207,7 @@ pub struct Cli {
     /// Supported suffixes: raw bytes, k/K (KiB), m/M (MiB), g/G (GiB).
     /// Examples: math=/path.wasm  math=/path.wasm:16m  math=/path.wasm:1048576
     /// Can be specified multiple times for multiple modules.
+    /// NOTE: incompatible with heap persistence (`--heap-store` other than none).
     #[arg(long = "wasm-module", value_name = "NAME=PATH[:LIMIT]", help_heading = "WASM")]
     pub wasm_modules: Vec<String>,
 
@@ -141,14 +215,15 @@ pub struct Cli {
     /// String value: {"name": "/path/to/module.wasm"}
     /// Object value: {"name": {"path": "/path/to/module.wasm", "max_memory_bytes": 16777216, "description": "what the module does"}}
     /// The optional "description" sets the MCP stub tool's description.
-    #[arg(long = "wasm-config", value_name = "PATH", help_heading = "WASM")]
+    /// NOTE: incompatible with heap persistence (`--heap-store` other than none).
+    #[arg(long = "wasm-config", env = "MCP_V8_WASM_CONFIG", value_name = "PATH", help_heading = "WASM")]
     pub wasm_config: Option<String>,
 
     /// Default max native memory for WASM modules without a per-module limit.
     /// Supports suffixes: k/K (KiB), m/M (MiB), g/G (GiB), or raw bytes.
     /// This is separate from --heap-memory-max (JS heap); WASM linear memory
     /// is allocated as native memory outside the V8 heap.
-    #[arg(long = "wasm-default-max-memory", default_value = "16m", help_heading = "WASM")]
+    #[arg(long = "wasm-default-max-memory", env = "MCP_V8_WASM_DEFAULT_MAX_MEMORY", default_value = "16m", help_heading = "WASM")]
     pub wasm_default_max_memory: String,
 
     /// Expose pre-loaded WASM modules on the MCPJS server itself as
@@ -158,7 +233,7 @@ pub struct Cli {
     /// returns instructional text telling the caller to use the module from
     /// JavaScript via run_js (the module is available as the `__wasm_<name>`
     /// global). Pass `--wasm-stubs false` to disable.
-    #[arg(long = "wasm-stubs", default_value = "true", num_args = 1, help_heading = "WASM")]
+    #[arg(long = "wasm-stubs", env = "MCP_V8_WASM_STUBS", default_value = "true", num_args = 1, help_heading = "WASM")]
     pub wasm_stubs: bool,
 
     /// Prefix applied to WASM stub tool names. Defaults to `runjs__` so it is
@@ -167,6 +242,7 @@ pub struct Cli {
     /// --wasm-stubs is false.
     #[arg(
         long = "wasm-stub-prefix",
+        env = "MCP_V8_WASM_STUB_PREFIX",
         default_value = crate::engine::wasm_stub::DEFAULT_WASM_STUB_PREFIX,
         help_heading = "WASM"
     )]
@@ -189,13 +265,13 @@ pub struct Cli {
 
     /// Path to a JSON file with header injection rules.
     /// Format: [{"host": "api.github.com", "methods": ["GET","POST"], "headers": {"Authorization": "Bearer ..."}}]
-    #[arg(long = "fetch-header-config", value_name = "PATH", help_heading = "Fetch")]
+    #[arg(long = "fetch-header-config", env = "MCP_V8_FETCH_HEADER_CONFIG", value_name = "PATH", help_heading = "Fetch")]
     pub fetch_header_config: Option<String>,
 
     /// Allow external module imports (npm:, jsr:, and URL imports).
     /// When disabled (the default), code using import declarations for external
     /// packages will be rejected. Enable with --allow-external-modules.
-    #[arg(long = "allow-external-modules", default_value = "false", help_heading = "Module Import")]
+    #[arg(long = "allow-external-modules", env = "MCP_V8_ALLOW_EXTERNAL_MODULES", default_value = "false", help_heading = "Module Import")]
     pub allow_external_modules: bool,
 
     /// Allow the `run_js` tool to read its code from a file on the server's own
@@ -205,33 +281,8 @@ pub struct Cli {
     /// --policies-json instead (a Rego/OPA chain decides which paths are allowed);
     /// the policy input is `{ "operation": "read", "path": "<canonical path>" }`.
     /// This flag takes precedence over a configured run_js_file policy.
-    #[arg(long = "allow-run-js-file", default_value = "false", help_heading = "Run JS File")]
+    #[arg(long = "allow-run-js-file", env = "MCP_V8_ALLOW_RUN_JS_FILE", default_value = "false", help_heading = "Run JS File")]
     pub allow_run_js_file: bool,
-
-    /// Enable the content-addressed, snapshottable filesystem. When set, the
-    /// `fs` parameter of run_js can mount a snapshot (by label or CA id) and the
-    /// `fs_*` tools / `/api/fs/...` endpoints become functional.
-    ///
-    /// In cluster mode labels replicate cluster-wide, but blobs/manifests are
-    /// only shared when stored on shared storage. Node-local file blobs are
-    /// single-node only; enabling fs snapshots in a cluster therefore requires
-    /// `--s3-bucket` (optionally `--cache-dir` for a write-through cache),
-    /// otherwise startup is refused.
-    #[arg(long = "enable-fs-snapshots", default_value = "false", help_heading = "FS Snapshots")]
-    pub enable_fs_snapshots: bool,
-
-    /// Directory for the fs snapshot blob store (chunks + manifests). Defaults
-    /// to `<session-db-path>/fs-blobs`. Node-local and single-node only; in a
-    /// cluster, configure `--s3-bucket` instead so blobs are shared across
-    /// nodes (this directory is then used only as the write-through cache when
-    /// `--cache-dir` is set).
-    #[arg(long = "fs-store-dir", value_name = "DIR", help_heading = "FS Snapshots")]
-    pub fs_store_dir: Option<String>,
-
-    /// Path for the fs label/reflog database (sled). Defaults to
-    /// `<session-db-path>/fs-labels`.
-    #[arg(long = "fs-labels-db", value_name = "PATH", help_heading = "FS Snapshots")]
-    pub fs_labels_db: Option<String>,
 
     /// JSON policy configuration (inline JSON or path to a JSON file).
     /// Enables fetch() and/or module policy gating via local Rego files
@@ -240,7 +291,7 @@ pub struct Cli {
     /// Example: --policies-json '{"fetch":{"policies":[{"url":"file:///path/to/fetch.rego"}]}}'
     ///
     /// Schema: { "fetch": { "mode": "all"|"any", "policies": [{"url": "...", "policy_path": "...", "rule": "..."}] }, "modules": { ... } }
-    #[arg(long = "policies-json", value_name = "JSON_OR_PATH", help_heading = "Policy")]
+    #[arg(long = "policies-json", env = "MCP_V8_POLICIES_JSON", value_name = "JSON_OR_PATH", help_heading = "Policy")]
     pub policies_json: Option<String>,
 
     /// Connect to an external MCP server as a module. JS code can call its tools
@@ -254,7 +305,7 @@ pub struct Cli {
     /// Path to a JSON config file for MCP server modules.
     /// Format: [{"name": "srv", "transport": "stdio", "command": "cmd", "args": ["a"]},
     ///          {"name": "srv2", "transport": "sse", "url": "http://..."}]
-    #[arg(long = "mcp-config", value_name = "PATH", help_heading = "MCP Server Module")]
+    #[arg(long = "mcp-config", env = "MCP_V8_MCP_CONFIG", value_name = "PATH", help_heading = "MCP Server Module")]
     pub mcp_config: Option<String>,
 
     /// Expose upstream MCP server tools on the MCPJS server itself as
@@ -264,7 +315,7 @@ pub struct Cli {
     /// calling a stub returns instructional text telling the caller to
     /// invoke the tool from JavaScript via run_js + mcp.callTool(...).
     /// Pass `--mcp-stubs false` to disable.
-    #[arg(long = "mcp-stubs", default_value = "true", num_args = 1, help_heading = "MCP Server Module")]
+    #[arg(long = "mcp-stubs", env = "MCP_V8_MCP_STUBS", default_value = "true", num_args = 1, help_heading = "MCP Server Module")]
     pub mcp_stubs: bool,
 
     /// Prefix applied to stub tool names. Defaults to `runjs__` so it is
@@ -273,8 +324,21 @@ pub struct Cli {
     /// --mcp-stubs is false.
     #[arg(
         long = "mcp-stub-prefix",
+        env = "MCP_V8_MCP_STUB_PREFIX",
         default_value = crate::engine::mcp_client::DEFAULT_STUB_PREFIX,
         help_heading = "MCP Server Module"
     )]
     pub mcp_stub_prefix: String,
+}
+
+impl Cli {
+    /// True when heap persistence is configured (`--heap-store` != none).
+    pub fn heap_enabled(&self) -> bool {
+        self.heap_store != StoreKind::None
+    }
+
+    /// True when filesystem persistence is configured (`--fs-store` != none).
+    pub fn fs_enabled(&self) -> bool {
+        self.fs_store != StoreKind::None
+    }
 }

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -739,48 +739,58 @@ static MODULE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 /// Execute code as an ES module. All code is always executed as a module,
 /// which supports `import` declarations, `export`, and top-level `await`.
-fn execute_module(runtime: &mut JsRuntime, code: &str) -> Result<(), String> {
+// Build the dedicated current-thread runtime each isolate runs on.
+//
+// V8/deno_core is single-threaded and deno_core's async op driver dispatches ops
+// through `deno_unsync`, which requires a `RuntimeFlavor::CurrentThread` runtime
+// (on a multi-thread runtime it panics in debug and deadlocks fs ops in
+// release). We are called from `spawn_blocking` (a blocking task), so building
+// and driving a fresh current-thread runtime here is allowed — no dedicated OS
+// thread needed.
+//
+// Ops that need the server's multi-thread runtime don't run their I/O here: the
+// S3 client (heap + fs blobs) captures that runtime's Handle at construction and
+// bridges via `handle.spawn(...).await`, and cross-worker fs blobs are pre-staged
+// into the local cache by `build_fs_mount` before the isolate runs.
+fn isolate_runtime() -> Result<tokio::runtime::Runtime, String> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("Failed to create current-thread runtime: {}", e))
+}
+
+fn execute_module(
+    rt: &tokio::runtime::Runtime,
+    runtime: &mut JsRuntime,
+    code: &str,
+) -> Result<(), String> {
     let id = MODULE_COUNTER.fetch_add(1, Ordering::Relaxed);
     let main_url = ModuleSpecifier::parse(&format!("file:///main_{}.js", id))
         .map_err(|e| format!("internal specifier error: {}", e))?;
 
-    // Use the current tokio runtime handle if available, otherwise create a
-    // temporary one. Direct callers (tests, fuzz targets) may not have a
-    // tokio runtime on the current thread.
-    //
-    // NOTE: the isolate runs on the ambient (multi-thread) server runtime on
-    // purpose. Async ops that await resources bound to that runtime — the child
-    // MCP clients (mcp.callTool) and the S3 client — only make progress there.
-    // Cross-worker fs-snapshot blobs are pre-staged into the local cache by
-    // `build_fs_mount` (on this runtime) before the isolate runs, so in-op fs
-    // reads are local and never await remote I/O from inside the isolate.
-    let owned_rt;
-    let handle = match tokio::runtime::Handle::try_current() {
-        Ok(h) => h,
-        Err(_) => {
-            owned_rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
-            owned_rt.handle().clone()
-        }
-    };
+    // CRITICAL: run the load, module evaluation, AND event loop inside ONE
+    // `block_on`. `mod_evaluate` runs the module's top-level synchronous code
+    // immediately (up to the first await), which submits async ops — so it must
+    // execute under this current-thread runtime's context too, not between
+    // `block_on` calls (where the ambient multi-thread runtime is current and
+    // deno_unsync's op spawn would panic/deadlock).
+    rt.block_on(async move {
+        let mod_id = runtime
+            .load_side_es_module_from_code(&main_url, code.to_string())
+            .await
+            .map_err(|e| format!("{}", e))?;
 
-    let _guard = handle.enter();
+        let eval_future = runtime.mod_evaluate(mod_id);
 
-    let mod_id = handle
-        .block_on(runtime.load_side_es_module_from_code(&main_url, code.to_string()))
-        .map_err(|e| format!("{}", e))?;
+        runtime
+            .run_event_loop(Default::default())
+            .await
+            .map_err(|e| format!("{}", e))?;
 
-    let eval_future = runtime.mod_evaluate(mod_id);
+        eval_future.await.map_err(|e| format!("{}", e))?;
 
-    handle
-        .block_on(runtime.run_event_loop(Default::default()))
-        .map_err(|e| format!("{}", e))?;
-
-    handle.block_on(eval_future).map_err(|e| format!("{}", e))?;
-
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Configuration bundle for `execute_stateless` / `execute_stateful`.
@@ -941,6 +951,10 @@ pub fn execute_stateless(
             ..Default::default()
         });
 
+        // Current-thread runtime that drives this isolate's async ops (see
+        // `execute_module` / `isolate_runtime`).
+        let rt = isolate_runtime()?;
+
         // Put console log state in OpState.
         if let Some(tree) = console_tree {
             runtime.op_state().borrow_mut().put(ConsoleLogState::new(tree));
@@ -1036,7 +1050,7 @@ pub fn execute_stateless(
                 if let Err(e) = console::harden_runtime(&mut runtime) {
                     return Err(e);
                 }
-                execute_module(&mut runtime, code)
+                execute_module(&rt, &mut runtime, code)
             }
         };
 
@@ -1137,6 +1151,10 @@ pub fn execute_stateful(
             ..Default::default()
         });
 
+        // Current-thread runtime that drives this isolate's async ops (see
+        // `execute_module` / `isolate_runtime`).
+        let rt = isolate_runtime()?;
+
         // Put console log state in OpState.
         if let Some(tree) = console_tree {
             runtime.op_state().borrow_mut().put(ConsoleLogState::new(tree));
@@ -1186,7 +1204,7 @@ pub fn execute_stateful(
         let has_snapshot = leaked_snapshot.is_some();
 
         let output_result = if has_snapshot {
-            execute_module(&mut runtime, code)
+            execute_module(&rt, &mut runtime, code)
         } else {
             // Inject WASM modules as globals via V8 native API.
             // Do NOT early-return here — snapshot() must be called below.
@@ -1242,7 +1260,7 @@ pub fn execute_stateful(
                     if let Err(e) = console::harden_runtime(&mut runtime) {
                         return Err(e);
                     }
-                    execute_module(&mut runtime, code)
+                    execute_module(&rt, &mut runtime, code)
                 }
             }
         };

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -1464,6 +1464,38 @@ impl Engine {
         self.heap_storage.is_some()
     }
 
+    /// Heap persistence (V8 heap snapshots) is configured. Alias of
+    /// `is_stateful`, kept for readability now that heap and fs are independent.
+    pub fn heap_enabled(&self) -> bool {
+        self.heap_storage.is_some()
+    }
+
+    /// Filesystem persistence (content-addressed `/work` snapshots) is configured.
+    pub fn fs_enabled(&self) -> bool {
+        self.fs_store.is_some()
+    }
+
+    /// True when the engine carries any per-session state (heap and/or fs), and
+    /// therefore needs the session-capable MCP surface and a session log.
+    pub fn session_capable(&self) -> bool {
+        self.heap_enabled() || self.fs_enabled()
+    }
+
+    /// Attach a session log to an existing engine. Required for per-session
+    /// state resolution on either axis (heap or fs); the stateful constructor
+    /// passes one inline, but a stateless (heap-off) engine with fs persistence
+    /// needs one too.
+    pub fn with_session_log(mut self, log: SessionLog) -> Self {
+        self.session_log = Some(log);
+        self
+    }
+
+    /// Attach a heap-tag store to an existing engine (heap persistence only).
+    pub fn with_heap_tag_store(mut self, store: HeapTagStore) -> Self {
+        self.heap_tag_store = Some(store);
+        self
+    }
+
     pub fn new_stateless(heap_memory_max_bytes: usize, execution_timeout_secs: u64, max_concurrent: usize) -> Self {
         Self {
             heap_storage: None,
@@ -2267,6 +2299,9 @@ impl Engine {
                 let mlc = self.module_loader_config.clone();
                 let mc = self.mcp_client_manager.as_ref().map(|m| mcp_client::McpConfig { client_manager: (**m).clone(), policy_chain: self.mcp_tools_policy_chain.clone() });
                 let fm = fs_mount.clone();
+                // Cloned for the post-run session-log entry, since `code` is
+                // moved into the spawn_blocking closure below.
+                let code_for_log = code.clone();
                 let mut join_handle = tokio::task::spawn_blocking(move || {
                     execute_stateless(&code, ExecutionConfig::new(max_bytes)
                         .isolate_handle(ih)
@@ -2323,7 +2358,25 @@ impl Engine {
                         // fails the run rather than reporting lost fs changes.
                         match self.push_mount(&fs_mount).await {
                             Ok(output_fs) => {
-                                registry.set_fs(&id, output_fs);
+                                registry.set_fs(&id, output_fs.clone());
+                                // Record the resulting fs snapshot per session so a
+                                // later run in the same session resumes it. This is
+                                // what gives fs-only (heap-off) engines per-session
+                                // filesystem persistence; no heap fields are set.
+                                if let (Some(session_name), Some(log)) =
+                                    (&session, &self.session_log)
+                                {
+                                    let entry = SessionLogEntry {
+                                        input_heap: None,
+                                        output_heap: String::new(),
+                                        output_fs: output_fs.clone(),
+                                        code: code_for_log,
+                                        timestamp: chrono::Utc::now().to_rfc3339(),
+                                    };
+                                    if let Err(e) = log.append(session_name, entry).await {
+                                        tracing::warn!("Failed to log session entry: {}", e);
+                                    }
+                                }
                                 registry.complete(&id, js_result.output, None);
                             }
                             Err(e) => registry.fail(&id, e),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,7 +16,7 @@ mod api;
 mod cluster;
 mod cli;
 mod session;
-use cli::Cli;
+use cli::{Cli, StoreKind};
 use engine::{initialize_v8, Engine, WasmModule};
 use engine::fetch::FetchConfig;
 use engine::fs::FsConfig;
@@ -133,33 +133,70 @@ async fn main() -> Result<()> {
             wasm_modules.iter().map(|m| m.name.as_str()).collect::<Vec<_>>().join(", "));
     }
 
+    let heap_enabled = cli.heap_enabled();
+    let fs_enabled = cli.fs_enabled();
+
+    // Heap snapshots run in a V8 SnapshotCreator isolate, which disables
+    // WebAssembly. Reject heap + WASM at startup rather than failing at the
+    // first execution with "WebAssembly is not an object".
+    if heap_enabled && !wasm_modules.is_empty() {
+        use clap::CommandFactory;
+        Cli::command()
+            .error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "--wasm-module/--wasm-config is incompatible with heap persistence \
+                 (--heap-store other than 'none'). V8 heap snapshots require a \
+                 SnapshotCreator isolate that disables WebAssembly. Use filesystem \
+                 persistence (--fs-store) instead, or drop the WASM modules.",
+            )
+            .exit();
+    }
+
     // Captured before the engine build consumes them, so fs snapshots can reuse
-    // the same shared storage backend (see the fs-snapshots block below).
+    // the same shared S3 backend (see the fs-snapshots block below).
     let fs_s3_bucket = cli.s3_bucket.clone();
     let fs_cache_dir = cli.cache_dir.clone();
 
     // ── Build Engine ────────────────────────────────────────────────────
-    let engine = if cli.stateless {
-        tracing::info!("Creating stateless engine");
-        Engine::new_stateless(heap_memory_max_bytes, execution_timeout_secs, cli.max_concurrent_executions)
-    } else {
-        let heap_storage = if let Some(bucket) = cli.s3_bucket {
-            if let Some(cache_dir) = cli.cache_dir {
-                tracing::info!("Using S3 storage with FS write-through cache at {}", cache_dir);
-                AnyHeapStorage::S3WithFsCache(WriteThroughCacheHeapStorage::new(
-                    S3HeapStorage::new(bucket).await,
-                    cache_dir,
-                ))
-            } else {
-                AnyHeapStorage::S3(S3HeapStorage::new(bucket).await)
+    // Heap and filesystem persistence are independent axes (see cli::StoreKind).
+    // The base engine carries the heap axis; the session log + fs are attached
+    // by builders so any combination (neither/heap-only/fs-only/both) is valid.
+    let engine = if heap_enabled {
+        let heap_storage = match cli.heap_store {
+            StoreKind::S3 => {
+                let bucket = cli
+                    .s3_bucket
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("--heap-store s3 requires --s3-bucket"))?;
+                if let Some(cache_dir) = cli.cache_dir.clone() {
+                    tracing::info!("Heap: S3 bucket '{}' with write-through cache at {}", bucket, cache_dir);
+                    AnyHeapStorage::S3WithFsCache(WriteThroughCacheHeapStorage::new(
+                        S3HeapStorage::new(bucket).await,
+                        cache_dir,
+                    ))
+                } else {
+                    tracing::info!("Heap: S3 bucket '{}'", bucket);
+                    AnyHeapStorage::S3(S3HeapStorage::new(bucket).await)
+                }
             }
-        } else if let Some(dir) = cli.directory_path {
-            AnyHeapStorage::File(FileHeapStorage::new(dir))
-        } else {
-            AnyHeapStorage::File(FileHeapStorage::new("/tmp/mcp-v8-heaps"))
+            StoreKind::Dir => {
+                let dir = cli.heap_dir.clone().unwrap_or_else(|| "/tmp/mcp-v8-heaps".to_string());
+                tracing::info!("Heap: directory store at {}", dir);
+                AnyHeapStorage::File(FileHeapStorage::new(dir))
+            }
+            StoreKind::None => unreachable!("heap_enabled implies heap_store != none"),
         };
+        tracing::info!("Heap persistence: ENABLED");
+        Engine::new_stateful(heap_storage, None, None, heap_memory_max_bytes, execution_timeout_secs, cli.max_concurrent_executions)
+    } else {
+        tracing::info!("Heap persistence: disabled");
+        Engine::new_stateless(heap_memory_max_bytes, execution_timeout_secs, cli.max_concurrent_executions)
+    };
 
-        let session_log = match SessionLog::new(&cli.session_db_path) {
+    // Session log: keys per-session state for EITHER axis (heap resume and/or
+    // fs resume), so create it whenever heap or fs persistence is enabled.
+    let engine = if heap_enabled || fs_enabled {
+        match SessionLog::new(&cli.session_db_path) {
             Ok(log) => {
                 tracing::info!("Session log opened at {}", cli.session_db_path);
                 let log = if let Some(ref cn) = cluster_node {
@@ -168,16 +205,21 @@ async fn main() -> Result<()> {
                 } else {
                     log
                 };
-                Some(log)
+                engine.with_session_log(log)
             }
             Err(e) => {
                 tracing::warn!("Failed to open session log at {}: {}. Session logging disabled.", cli.session_db_path, e);
-                None
+                engine
             }
-        };
+        }
+    } else {
+        engine
+    };
 
+    // Heap-tag store: heap axis only.
+    let engine = if heap_enabled {
         let heap_tag_db_path = format!("{}/heap-tags", cli.session_db_path);
-        let heap_tag_store = match HeapTagStore::new(&heap_tag_db_path) {
+        match HeapTagStore::new(&heap_tag_db_path) {
             Ok(store) => {
                 tracing::info!("Heap tag store opened at {}", heap_tag_db_path);
                 let store = if let Some(ref cn) = cluster_node {
@@ -185,16 +227,15 @@ async fn main() -> Result<()> {
                 } else {
                     store
                 };
-                Some(store)
+                engine.with_heap_tag_store(store)
             }
             Err(e) => {
                 tracing::warn!("Failed to open heap tag store at {}: {}. Heap tagging disabled.", heap_tag_db_path, e);
-                None
+                engine
             }
-        };
-
-        tracing::info!("Creating stateful engine");
-        Engine::new_stateful(heap_storage, session_log, heap_tag_store, heap_memory_max_bytes, execution_timeout_secs, cli.max_concurrent_executions)
+        }
+    } else {
+        engine
     };
 
     let engine = engine.with_wasm_default_max_bytes(wasm_default_max_bytes);
@@ -343,16 +384,16 @@ async fn main() -> Result<()> {
     // no fs policy was supplied, default to an allow-all policy chain.
     let engine = if let Some(chain) = fs_policy_chain {
         engine.with_fs_config(FsConfig::new(chain))
-    } else if cli.enable_fs_snapshots {
+    } else if fs_enabled {
         engine.with_fs_config(FsConfig::new(Arc::new(PolicyChain::new(vec![], EvalMode::All))))
     } else {
         engine
     };
 
     // ── Filesystem snapshots (content-addressed store + label/reflog) ─────
-    let engine = if cli.enable_fs_snapshots {
+    let engine = if fs_enabled {
         let store_dir = cli
-            .fs_store_dir
+            .fs_dir
             .clone()
             .unwrap_or_else(|| format!("{}/fs-blobs", cli.session_db_path));
         let labels_db = cli
@@ -360,26 +401,37 @@ async fn main() -> Result<()> {
             .clone()
             .unwrap_or_else(|| format!("{}/fs-labels", cli.session_db_path));
 
+        let fs_on_s3 = cli.fs_store == StoreKind::S3;
+
         // Labels replicate cluster-wide, but blobs/manifests are only shared if
         // they sit on shared storage. Node-local file blobs are single-node
         // only: in a cluster a label advanced on one node would resolve on
         // another to a manifest that node is missing. Refuse that combination up
         // front rather than failing later after a rebalance.
-        if cluster_node.is_some() && fs_s3_bucket.is_none() {
+        if cluster_node.is_some() && !fs_on_s3 {
             Cli::command()
                 .error(
                     clap::error::ErrorKind::ArgumentConflict,
-                    "--enable-fs-snapshots in cluster mode requires shared blob storage: \
-                     pass --s3-bucket (optionally with --cache-dir for a write-through \
-                     cache). Node-local fs snapshot blobs are single-node only.",
+                    "--fs-store s3 (with --s3-bucket) is required in cluster mode: \
+                     fs snapshot blobs must live on shared storage. Node-local \
+                     (--fs-store dir) blobs are single-node only.",
                 )
                 .exit();
         }
 
-        // Back the blob store with shared S3 (matching the heap backend) when a
-        // bucket is configured, so mounts resolve on any node; otherwise use
-        // node-local files (single-node).
-        let backend: Arc<dyn HeapStorage> = if let Some(bucket) = &fs_s3_bucket {
+        // Back the blob store with shared S3 when --fs-store s3, so mounts
+        // resolve on any node; otherwise use node-local files (single-node).
+        let backend: Arc<dyn HeapStorage> = if fs_on_s3 {
+            let bucket = fs_s3_bucket
+                .clone()
+                .unwrap_or_else(|| {
+                    Cli::command()
+                        .error(
+                            clap::error::ErrorKind::MissingRequiredArgument,
+                            "--fs-store s3 requires --s3-bucket.",
+                        )
+                        .exit()
+                });
             if let Some(cache_dir) = &fs_cache_dir {
                 tracing::info!(
                     "FS snapshots: shared S3 blob storage (bucket {}) with write-through cache at {}",
@@ -544,27 +596,30 @@ async fn main() -> Result<()> {
     };
 
     // ── Start transport ─────────────────────────────────────────────────
+    // McpService (session-capable) is used whenever any per-session state axis
+    // is on (heap and/or fs); StatelessMcpService only when neither is.
+    let bind_host = cli.bind_host.clone();
     if let Some(port) = cli.http_port {
         tracing::info!("Starting Streamable HTTP transport on port {}", port);
-        if engine.is_stateful() {
+        if engine.session_capable() {
             let verifier = session_verifier.clone();
-            start_streamable_http(engine, port, move |e| McpService::new(e, verifier.clone())).await?;
+            start_streamable_http(engine, bind_host, port, move |e| McpService::new(e, verifier.clone())).await?;
         } else {
             let verifier = session_verifier.clone();
-            start_streamable_http(engine, port, move |e| StatelessMcpService::new(e, verifier.clone())).await?;
+            start_streamable_http(engine, bind_host, port, move |e| StatelessMcpService::new(e, verifier.clone())).await?;
         }
     } else if let Some(port) = cli.sse_port {
         tracing::info!("Starting SSE transport on port {}", port);
-        if engine.is_stateful() {
+        if engine.session_capable() {
             let verifier = session_verifier.clone();
-            start_sse_server(engine, port, move |e| McpService::new(e, verifier.clone())).await?;
+            start_sse_server(engine, bind_host, port, move |e| McpService::new(e, verifier.clone())).await?;
         } else {
             let verifier = session_verifier.clone();
-            start_sse_server(engine, port, move |e| StatelessMcpService::new(e, verifier.clone())).await?;
+            start_sse_server(engine, bind_host, port, move |e| StatelessMcpService::new(e, verifier.clone())).await?;
         }
     } else {
         tracing::info!("Starting stdio transport");
-        if engine.is_stateful() {
+        if engine.session_capable() {
             let service = McpService::new(engine, None)
                 .serve(stdio())
                 .await
@@ -586,27 +641,25 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-// Resolve the listen address for the HTTP transports. Defaults to all IPv4
-// interfaces (0.0.0.0) so existing deployments are unchanged, but honours
-// MCP_V8_BIND_HOST so an operator can bind a dual-stack IPv6 address ("::"),
-// which is required to be reachable over private networks (e.g. Railway) that
-// resolve service hostnames to IPv6.
-fn resolve_bind_addr(port: u16) -> Result<std::net::SocketAddr> {
-    let host = std::env::var("MCP_V8_BIND_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+// Resolve the listen address for the HTTP transports from `--bind-host`
+// (env MCP_V8_BIND_HOST). Defaults to all IPv4 interfaces (0.0.0.0); set "::"
+// for a dual-stack IPv6 listener, required to be reachable over private
+// networks (e.g. Railway) that resolve service hostnames to IPv6.
+fn resolve_bind_addr(host: &str, port: u16) -> Result<std::net::SocketAddr> {
     let ip: std::net::IpAddr = host
         .parse()
-        .map_err(|e| anyhow::anyhow!("invalid MCP_V8_BIND_HOST '{host}': {e}"))?;
+        .map_err(|e| anyhow::anyhow!("invalid --bind-host '{host}': {e}"))?;
     Ok(std::net::SocketAddr::new(ip, port))
 }
 
 // ── Streamable HTTP transport (--http-port) ─────────────────────────────
 
-async fn start_streamable_http<S, F>(engine: Engine, port: u16, make_service: F) -> Result<()>
+async fn start_streamable_http<S, F>(engine: Engine, host: String, port: u16, make_service: F) -> Result<()>
 where
     S: ServerHandler + Send + Sync + 'static,
     F: Fn(Engine) -> S + Send + Sync + Clone + 'static,
 {
-    let bind: std::net::SocketAddr = resolve_bind_addr(port)?;
+    let bind: std::net::SocketAddr = resolve_bind_addr(&host, port)?;
     let ct = CancellationToken::new();
 
     let config = StreamableHttpServerConfig {
@@ -662,12 +715,12 @@ where
 
 // ── SSE transport (--sse-port) ──────────────────────────────────────────
 
-async fn start_sse_server<S, F>(engine: Engine, port: u16, make_service: F) -> Result<()>
+async fn start_sse_server<S, F>(engine: Engine, host: String, port: u16, make_service: F) -> Result<()>
 where
     S: ServerHandler + Send + Sync + 'static,
     F: Fn(Engine) -> S + Send + Sync + Clone + 'static,
 {
-    let addr = resolve_bind_addr(port)?;
+    let addr = resolve_bind_addr(&host, port)?;
 
     let config = SseServerConfig {
         bind: addr,

--- a/server/src/mcp.rs
+++ b/server/src/mcp.rs
@@ -44,18 +44,25 @@ pub struct ToolCatalog {
     pub tools: Vec<ToolDoc>,
 }
 
-fn built_in_tools(stateful: bool) -> Vec<Tool> {
-    if stateful {
-        McpService::tool_box().list()
+fn built_in_tools(heap: bool, fs: bool) -> Vec<Tool> {
+    if heap || fs {
+        let mut tools = McpService::tool_box().list();
+        filter_tools_by_capability(&mut tools, heap, fs);
+        tools
     } else {
         StatelessMcpService::tool_box().list()
     }
 }
 
-pub fn built_in_tool_catalog(stateful: bool) -> ToolCatalog {
+pub fn built_in_tool_catalog(heap: bool, fs: bool) -> ToolCatalog {
     ToolCatalog {
-        mode: if stateful { "stateful" } else { "stateless" },
-        tools: built_in_tools(stateful)
+        mode: match (heap, fs) {
+            (true, true) => "heap+fs",
+            (true, false) => "heap",
+            (false, true) => "fs",
+            (false, false) => "stateless",
+        },
+        tools: built_in_tools(heap, fs)
             .into_iter()
             .map(ToolDoc::from_tool)
             .collect(),
@@ -63,12 +70,12 @@ pub fn built_in_tool_catalog(stateful: bool) -> ToolCatalog {
 }
 
 /// Build the list of static documentation resources exposed via MCP.
-fn doc_resources(stateful: bool) -> Vec<Resource> {
+fn doc_resources(heap: bool, fs: bool) -> Vec<Resource> {
     use crate::api::ApiDoc;
     use utoipa::OpenApi as _;
 
     let openapi_json = serde_json::to_string(&ApiDoc::openapi()).unwrap_or_default();
-    let tools_json = serde_json::to_string(&built_in_tool_catalog(stateful)).unwrap_or_default();
+    let tools_json = serde_json::to_string(&built_in_tool_catalog(heap, fs)).unwrap_or_default();
 
     // Store the generated JSON in thread-local statics to extend the lifetime
     // to 'static so we can use them in ResourceContents::text().
@@ -123,12 +130,12 @@ fn doc_resources(stateful: bool) -> Vec<Resource> {
 
 /// Read a single documentation resource by URI.
 /// Returns `None` when the URI is not recognised.
-fn read_doc_resource(uri: &str, stateful: bool) -> Option<ReadResourceResult> {
+fn read_doc_resource(uri: &str, heap: bool, fs: bool) -> Option<ReadResourceResult> {
     use crate::api::ApiDoc;
     use utoipa::OpenApi as _;
 
     let openapi_json = serde_json::to_string_pretty(&ApiDoc::openapi()).unwrap_or_default();
-    let tools_json = serde_json::to_string_pretty(&built_in_tool_catalog(stateful)).unwrap_or_default();
+    let tools_json = serde_json::to_string_pretty(&built_in_tool_catalog(heap, fs)).unwrap_or_default();
 
     let contents = match uri {
         "docs://readme" => vec![ResourceContents::TextResourceContents {
@@ -327,6 +334,54 @@ fn apply_run_js_description_override(tools: &mut [Tool], override_desc: Option<A
         for tool in tools.iter_mut() {
             if tool.name.as_ref() == "run_js" {
                 tool.description = Some(desc.to_string().into());
+            }
+        }
+    }
+}
+
+/// `run_js` description for a session-capable server WITHOUT heap persistence
+/// (fs-only): it must not claim JS globals persist between calls.
+const RUN_JS_FS_ONLY_DESC: &str = include_str!("run_js_tool_fs_only.md");
+
+/// Heap-only tools (heap-tag management). Hidden when heap persistence is off.
+const HEAP_ONLY_TOOLS: &[&str] =
+    &["get_heap_tags", "set_heap_tags", "delete_heap_tags", "query_heaps_by_tags"];
+
+/// Filesystem snapshot tools. Hidden when fs persistence is off.
+const FS_TOOLS: &[&str] =
+    &["fs_ls", "fs_pull", "fs_label", "fs_log", "fs_push", "fs_reset", "fs_merge"];
+
+/// True if `name` is a tool that requires a capability the engine doesn't have.
+fn tool_requires_missing_capability(name: &str, heap: bool, fs: bool) -> bool {
+    (!heap && HEAP_ONLY_TOOLS.contains(&name)) || (!fs && FS_TOOLS.contains(&name))
+}
+
+/// Strip heap-specific `run_js` parameters (`heap`, `tags`) from a tool's input
+/// schema when heap persistence is off, so the surface matches the capabilities.
+fn strip_run_js_heap_params(tool: &mut Tool) {
+    let schema = Arc::make_mut(&mut tool.input_schema);
+    if let Some(props) = schema.get_mut("properties").and_then(|v| v.as_object_mut()) {
+        props.remove("heap");
+        props.remove("tags");
+    }
+    if let Some(required) = schema.get_mut("required").and_then(|v| v.as_array_mut()) {
+        required.retain(|v| v.as_str() != Some("heap") && v.as_str() != Some("tags"));
+    }
+}
+
+/// Restrict the McpService tool surface to the engine's enabled capabilities:
+/// drop heap-only tools when heap is off and fs tools when fs is off, and pick a
+/// `run_js` description / schema that matches (no "globals persist" when heap is
+/// off). `run_js`, execution, and session tools are always kept.
+fn filter_tools_by_capability(tools: &mut Vec<Tool>, heap: bool, fs: bool) {
+    tools.retain(|t| !tool_requires_missing_capability(t.name.as_ref(), heap, fs));
+    if !heap {
+        for tool in tools.iter_mut() {
+            if tool.name.as_ref() == "run_js" {
+                if fs {
+                    tool.description = Some(RUN_JS_FS_ONLY_DESC.into());
+                }
+                strip_run_js_heap_params(tool);
             }
         }
     }
@@ -738,10 +793,17 @@ impl ServerHandler for McpService {
         let instructions = self.engine.instructions_override()
             .map(|s| s.to_string())
             .unwrap_or_else(|| {
-                "JavaScript execution service (stateful mode - with heap persistence). \
-                 Use resources/list and resources/read to explore docs://readme, \
-                 docs://llms-txt, docs://openapi, and docs://tools before calling tools."
-                .to_string()
+                let mode = match (self.engine.heap_enabled(), self.engine.fs_enabled()) {
+                    (true, true) => "with per-session V8 heap persistence (globals persist across calls) and a per-session content-addressed filesystem at /work",
+                    (true, false) => "with per-session V8 heap persistence (globals persist across calls)",
+                    (false, true) => "with a per-session content-addressed filesystem at /work (files persist across calls; JS globals do NOT)",
+                    (false, false) => "stateless (no state persists between calls)",
+                };
+                format!(
+                    "JavaScript execution service {mode}. \
+                     Use resources/list and resources/read to explore docs://readme, \
+                     docs://llms-txt, docs://openapi, and docs://tools before calling tools."
+                )
             });
         ServerInfo {
             instructions: Some(instructions),
@@ -760,7 +822,7 @@ impl ServerHandler for McpService {
     ) -> Result<ListResourcesResult, McpError> {
         Ok(ListResourcesResult {
             next_cursor: None,
-            resources: doc_resources(true),
+            resources: doc_resources(self.engine.heap_enabled(), self.engine.fs_enabled()),
         })
     }
 
@@ -769,7 +831,7 @@ impl ServerHandler for McpService {
         request: ReadResourceRequestParam,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
-        read_doc_resource(&request.uri, true)
+        read_doc_resource(&request.uri, self.engine.heap_enabled(), self.engine.fs_enabled())
             .ok_or_else(|| McpError::resource_not_found(
                 format!("Unknown resource URI: {}", request.uri),
                 None,
@@ -782,6 +844,9 @@ impl ServerHandler for McpService {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let mut tools = Self::tool_box().list();
+        // Restrict the surface to the engine's enabled capabilities (heap/fs)
+        // before applying any operator description override.
+        filter_tools_by_capability(&mut tools, self.engine.heap_enabled(), self.engine.fs_enabled());
         apply_run_js_description_override(&mut tools, self.engine.run_js_description_override());
         if let Some(client) = &self.mcp_client {
             tools.extend(client.stub_tools());
@@ -1012,7 +1077,7 @@ impl ServerHandler for StatelessMcpService {
     ) -> Result<ListResourcesResult, McpError> {
         Ok(ListResourcesResult {
             next_cursor: None,
-            resources: doc_resources(false),
+            resources: doc_resources(false, false),
         })
     }
 
@@ -1021,7 +1086,7 @@ impl ServerHandler for StatelessMcpService {
         request: ReadResourceRequestParam,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
-        read_doc_resource(&request.uri, false)
+        read_doc_resource(&request.uri, false, false)
             .ok_or_else(|| McpError::resource_not_found(
                 format!("Unknown resource URI: {}", request.uri),
                 None,
@@ -1034,6 +1099,9 @@ impl ServerHandler for StatelessMcpService {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let mut tools = Self::tool_box().list();
+        // Restrict the surface to the engine's enabled capabilities (heap/fs)
+        // before applying any operator description override.
+        filter_tools_by_capability(&mut tools, self.engine.heap_enabled(), self.engine.fs_enabled());
         apply_run_js_description_override(&mut tools, self.engine.run_js_description_override());
         if let Some(client) = &self.mcp_client {
             tools.extend(client.stub_tools());
@@ -1143,5 +1211,91 @@ mod tests {
         let mut tools = vec![tool("run_js", "original")];
         apply_run_js_description_override(&mut tools, None);
         assert_eq!(tools[0].description.as_deref(), Some("original"));
+    }
+
+    use super::filter_tools_by_capability;
+
+    fn run_js_with_heap_param() -> Tool {
+        let mut schema = serde_json::Map::new();
+        let mut props = serde_json::Map::new();
+        props.insert("code".to_string(), serde_json::json!({"type": "string"}));
+        props.insert("heap".to_string(), serde_json::json!({"type": "string"}));
+        props.insert("fs".to_string(), serde_json::json!({"type": "string"}));
+        props.insert("tags".to_string(), serde_json::json!({"type": "object"}));
+        schema.insert("properties".to_string(), serde_json::Value::Object(props));
+        Tool {
+            name: "run_js".into(),
+            description: Some("heapy".into()),
+            input_schema: Arc::new(schema),
+            annotations: None,
+        }
+    }
+
+    fn names(tools: &[Tool]) -> Vec<String> {
+        tools.iter().map(|t| t.name.to_string()).collect()
+    }
+
+    fn full_surface() -> Vec<Tool> {
+        vec![
+            run_js_with_heap_param(),
+            tool("get_execution", "x"),
+            tool("get_heap_tags", "x"),
+            tool("set_heap_tags", "x"),
+            tool("query_heaps_by_tags", "x"),
+            tool("fs_ls", "x"),
+            tool("fs_push", "x"),
+        ]
+    }
+
+    fn run_js_props(tools: &[Tool]) -> Vec<String> {
+        let rj = tools.iter().find(|t| t.name.as_ref() == "run_js").unwrap();
+        rj.input_schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn fs_only_hides_heap_tools_and_params() {
+        let mut tools = full_surface();
+        filter_tools_by_capability(&mut tools, false, true);
+        let n = names(&tools);
+        assert!(n.contains(&"run_js".to_string()));
+        assert!(n.contains(&"fs_ls".to_string()));
+        // Heap-tag tools gone.
+        assert!(!n.contains(&"get_heap_tags".to_string()));
+        assert!(!n.contains(&"query_heaps_by_tags".to_string()));
+        // run_js loses heap/tags params but keeps code/fs.
+        let props = run_js_props(&tools);
+        assert!(props.contains(&"code".to_string()));
+        assert!(props.contains(&"fs".to_string()));
+        assert!(!props.contains(&"heap".to_string()));
+        assert!(!props.contains(&"tags".to_string()));
+        // Description must not promise globals persist.
+        let rj = tools.iter().find(|t| t.name.as_ref() == "run_js").unwrap();
+        assert!(rj.description.as_deref().unwrap().contains("globals"));
+    }
+
+    #[test]
+    fn heap_only_hides_fs_tools_keeps_heap_params() {
+        let mut tools = full_surface();
+        filter_tools_by_capability(&mut tools, true, false);
+        let n = names(&tools);
+        assert!(n.contains(&"get_heap_tags".to_string()));
+        assert!(!n.contains(&"fs_ls".to_string()));
+        assert!(!n.contains(&"fs_push".to_string()));
+        // heap param retained when heap is on.
+        assert!(run_js_props(&tools).contains(&"heap".to_string()));
+    }
+
+    #[test]
+    fn both_keeps_everything() {
+        let mut tools = full_surface();
+        filter_tools_by_capability(&mut tools, true, true);
+        let n = names(&tools);
+        assert!(n.contains(&"get_heap_tags".to_string()));
+        assert!(n.contains(&"fs_ls".to_string()));
+        assert!(run_js_props(&tools).contains(&"heap".to_string()));
     }
 }

--- a/server/src/run_js_tool_fs_only.md
+++ b/server/src/run_js_tool_fs_only.md
@@ -1,0 +1,23 @@
+run javascript or typescript code in v8
+
+Submits code for **async execution** — returns an execution ID immediately. V8 runs in the background. Use `get_execution` to poll status and result, `get_execution_output` to read console output, and `cancel_execution` to stop a running execution.
+
+This server has a **persistent per-session filesystem** but **no heap persistence**: JavaScript globals/variables do NOT survive between calls. Persist anything you need across calls by writing it to the `/work` filesystem (`await fs.writeFile('/work/state.json', ...)`), which is content-addressed and restored automatically for the same session on the next run.
+
+TypeScript support is type removal only — types are stripped before execution, not checked. Invalid types will be silently removed, not reported as errors.
+
+params:
+- code (optional): the javascript or typescript code to run. Provide either `code` or `file`.
+- file (optional): path to a JavaScript/TypeScript file **on the server's own filesystem** to read and execute instead of inline `code`. Provide either `code` or `file`, not both. Disabled unless the server was started with `--allow-run-js-file` or a `run_js_file` policy.
+- fs (optional): a filesystem snapshot to mount (a label or a CA id). Omit to continue this session's filesystem, which is mounted automatically.
+- heap_memory_max_mb (optional): maximum V8 heap memory in megabytes (minimum: 4, default: 8). Override the server default for this execution.
+- execution_timeout_secs (optional): maximum execution time in seconds (1–300, default: 30). Override the server default for this execution.
+
+returns:
+- execution_id: UUID of the submitted execution. Use with get_execution, get_execution_output, and cancel_execution. `get_execution` also returns `fs` — the resulting filesystem snapshot CA id.
+
+Session identity comes from the `X-MCP-Session-Id` header during initialization, not from a `session` tool parameter. The session's latest `/work` filesystem is mounted automatically on each run and the result is snapshotted, so files persist across calls without tracking CA ids.
+
+## Console Output
+
+Use `console.log()` to produce output. `console.info`, `console.warn`, and `console.error` are also supported (with `[INFO]`, `[WARN]`, `[ERROR]` prefixes respectively).

--- a/server/tests/cli_endpoints_e2e.rs
+++ b/server/tests/cli_endpoints_e2e.rs
@@ -28,7 +28,7 @@ impl HttpServer {
         let port = find_available_port();
 
         let child = Command::new(env!("CARGO_BIN_EXE_server"))
-            .args(["--stateless", "--http-port", &port.to_string()])
+            .args(["--http-port", &port.to_string()])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/server/tests/common/mod.rs
+++ b/server/tests/common/mod.rs
@@ -7,7 +7,7 @@ use tokio::time::sleep;
 /// Start the MCP server for testing
 pub async fn start_server(port: u16, heap_dir: &str) -> Result<tokio::process::Child, std::io::Error> {
     let child = Command::new(env!("CARGO"))
-        .args(&["run", "--", "--directory-path", heap_dir, "--http-port", &port.to_string()])
+        .args(&["run", "--", "--heap-store", "dir", "--heap-dir", heap_dir, "--http-port", &port.to_string()])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()?;
@@ -21,7 +21,7 @@ pub async fn start_server(port: u16, heap_dir: &str) -> Result<tokio::process::C
 /// Start the MCP server with SSE transport for testing
 pub async fn start_sse_server(port: u16, heap_dir: &str) -> Result<tokio::process::Child, std::io::Error> {
     let child = Command::new(env!("CARGO"))
-        .args(&["run", "--", "--directory-path", heap_dir, "--sse-port", &port.to_string()])
+        .args(&["run", "--", "--heap-store", "dir", "--heap-dir", heap_dir, "--sse-port", &port.to_string()])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()?;

--- a/server/tests/console_log_e2e.rs
+++ b/server/tests/console_log_e2e.rs
@@ -30,7 +30,7 @@ impl HttpServer {
         let port = find_available_port();
 
         let child = Command::new(env!("CARGO_BIN_EXE_server"))
-            .args(&["--stateless", "--http-port", &port.to_string()])
+            .args(&["--http-port", &port.to_string()])
             .stdin(Stdio::null())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())

--- a/server/tests/exec_upload_e2e.rs
+++ b/server/tests/exec_upload_e2e.rs
@@ -26,7 +26,7 @@ impl HttpServer {
         let port = find_available_port();
 
         let child = Command::new(env!("CARGO_BIN_EXE_server"))
-            .args(["--stateless", "--http-port", &port.to_string()])
+            .args(["--http-port", &port.to_string()])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/server/tests/mcp_stub_e2e.rs
+++ b/server/tests/mcp_stub_e2e.rs
@@ -38,15 +38,17 @@ impl OuterServer {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let server_bin = env!("CARGO_BIN_EXE_server");
 
-        // The argument format is `name=stdio:command:arg1:arg2...`. We want
-        // the upstream invocation to be `<server_bin> --directory-path <upstream_heap>`.
+        // The argument format is `name=stdio:command:arg1:arg2...`. We want the
+        // upstream invocation to be `<server_bin> --heap-store dir --heap-dir <upstream_heap>`.
         let upstream_arg = format!(
-            "upstream=stdio:{}:--directory-path:{}",
+            "upstream=stdio:{}:--heap-store:dir:--heap-dir:{}",
             server_bin, upstream_heap
         );
 
         let mut args: Vec<String> = vec![
-            "--directory-path".to_string(),
+            "--heap-store".to_string(),
+            "dir".to_string(),
+            "--heap-dir".to_string(),
             outer_heap.to_string(),
             "--mcp-server".to_string(),
             upstream_arg,

--- a/server/tests/sse_e2e.rs
+++ b/server/tests/sse_e2e.rs
@@ -149,7 +149,7 @@ impl SseServer {
         let port = find_available_port();
 
         let child = Command::new(env!("CARGO_BIN_EXE_server"))
-            .args(&["--directory-path", heap_dir, "--sse-port", &port.to_string()])
+            .args(&["--heap-store", "dir", "--heap-dir", heap_dir, "--sse-port", &port.to_string()])
             .stdin(Stdio::null())
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())

--- a/server/tests/stdio_e2e.rs
+++ b/server/tests/stdio_e2e.rs
@@ -104,7 +104,7 @@ impl StdioServer {
     /// Start a new stdio MCP server for testing
     async fn start(heap_dir: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let mut child = Command::new(env!("CARGO_BIN_EXE_server"))
-            .args(&["--directory-path", heap_dir])
+            .args(&["--heap-store", "dir", "--heap-dir", heap_dir])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null()) // Suppress server logs during tests

--- a/server/tests/wasm_stub_e2e.rs
+++ b/server/tests/wasm_stub_e2e.rs
@@ -26,7 +26,9 @@ impl WasmServer {
     /// `extra_args` lets a test pass flags like `--wasm-stubs false` or
     /// `--wasm-stub-prefix rj_`.
     async fn start_with_args(
-        heap: &str,
+        // WASM is incompatible with heap persistence (heap snapshots disable
+        // WebAssembly), so this server runs heap-off; the dir is unused.
+        _heap: &str,
         extra_args: &[&str],
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let server_bin = env!("CARGO_BIN_EXE_server");
@@ -36,8 +38,6 @@ impl WasmServer {
             .join("add.wasm");
 
         let mut args: Vec<String> = vec![
-            "--directory-path".to_string(),
-            heap.to_string(),
             "--wasm-module".to_string(),
             format!("math={}", wasm_path.display()),
         ];

--- a/site-docs/reference/cli-flags.md
+++ b/site-docs/reference/cli-flags.md
@@ -9,13 +9,15 @@ using the same help headings exposed by the CLI itself.
 
 - [Cluster](#cluster)
 - [Core](#core)
-- [FS Snapshots](#fs-snapshots)
 - [Fetch](#fetch)
+- [Filesystem](#filesystem)
+- [Heap](#heap)
 - [MCP Server Module](#mcp-server-module)
 - [Module Import](#module-import)
 - [Policy](#policy)
 - [Prompt](#prompt)
 - [Run JS File](#run-js-file)
+- [Storage (S3)](#storage-s3)
 - [WASM](#wasm)
 
 ## Cluster
@@ -24,12 +26,14 @@ using the same help headings exposed by the CLI itself.
 
 Port for the Raft cluster HTTP server. Enables cluster mode when set
 
+- Environment: `MCP_V8_CLUSTER_PORT`
 - Value: `CLUSTER_PORT`
 
 ### `--node-id`
 
 Unique node identifier within the cluster
 
+- Environment: `MCP_V8_NODE_ID`
 - Default: `node1`
 - Value: `NODE_ID`
 
@@ -37,6 +41,7 @@ Unique node identifier within the cluster
 
 Comma-separated list of seed peer addresses. Format: id@host:port or host:port. Peers can also join dynamically via POST /raft/join
 
+- Environment: `MCP_V8_PEERS`
 - Value: `PEERS`
 - Delimiter: `,`
 - Repeatable: yes
@@ -45,22 +50,27 @@ Comma-separated list of seed peer addresses. Format: id@host:port or host:port. 
 
 Join an existing cluster by contacting this seed address (host:port). The node will register itself with the cluster leader via /raft/join
 
+- Environment: `MCP_V8_JOIN`
 - Value: `JOIN`
 
 ### `--join-as-learner`
 
 Join as a non-voting learner: the node replicates the log but is excluded from election and commit quorums and never starts elections. Use for ephemeral nodes whose churn must not affect availability
 
+- Environment: `MCP_V8_JOIN_AS_LEARNER`
+
 ### `--advertise-addr`
 
 Advertise address for this node (host:port). Used for peer discovery and write forwarding. Defaults to <node-id>:<cluster-port>
 
+- Environment: `MCP_V8_ADVERTISE_ADDR`
 - Value: `ADVERTISE_ADDR`
 
 ### `--heartbeat-interval`
 
 Heartbeat interval in milliseconds
 
+- Environment: `MCP_V8_HEARTBEAT_INTERVAL`
 - Default: `100`
 - Value: `HEARTBEAT_INTERVAL`
 
@@ -68,6 +78,7 @@ Heartbeat interval in milliseconds
 
 Minimum election timeout in milliseconds
 
+- Environment: `MCP_V8_ELECTION_TIMEOUT_MIN`
 - Default: `300`
 - Value: `ELECTION_TIMEOUT_MIN`
 
@@ -75,6 +86,7 @@ Minimum election timeout in milliseconds
 
 Maximum election timeout in milliseconds
 
+- Environment: `MCP_V8_ELECTION_TIMEOUT_MAX`
 - Default: `500`
 - Value: `ELECTION_TIMEOUT_MAX`
 
@@ -83,28 +95,6 @@ Maximum election timeout in milliseconds
 ### `--print-openapi`
 
 Print the OpenAPI JSON specification to stdout and exit. Use this to regenerate openapi.json: `./server --print-openapi > openapi.json`
-
-### `--s3-bucket`
-
-S3 bucket name (required if --use-s3)
-
-- Value: `S3_BUCKET`
-
-### `--cache-dir`
-
-Local filesystem cache directory for S3 write-through caching (only used with --s3-bucket)
-
-- Value: `CACHE_DIR`
-
-### `--directory-path`
-
-Directory path for filesystem storage (required if --use-filesystem)
-
-- Value: `DIRECTORY_PATH`
-
-### `--stateless`
-
-Run in stateless mode - no heap snapshots are saved or loaded
 
 ### `--jwks-url`
 
@@ -117,18 +107,29 @@ JWKS endpoint URL for fetching public keys (e.g., Keycloak OIDC certs URL). Enab
 
 HTTP port using Streamable HTTP transport (MCP 2025-03-26+, load-balanceable)
 
+- Environment: `MCP_V8_HTTP_PORT`
 - Value: `HTTP_PORT`
 
 ### `--sse-port`
 
 SSE port using the older HTTP+SSE transport
 
+- Environment: `MCP_V8_SSE_PORT`
 - Value: `SSE_PORT`
+
+### `--bind-host`
+
+Host/address the HTTP and SSE transports bind to. Defaults to all IPv4 interfaces (0.0.0.0). Set to "::" for a dual-stack IPv6 listener, which is required to be reachable over IPv6-resolving private networks (e.g. Railway)
+
+- Environment: `MCP_V8_BIND_HOST`
+- Default: `0.0.0.0`
+- Value: `BIND_HOST`
 
 ### `--heap-memory-max`
 
 Maximum V8 heap memory per isolate in megabytes (default: 8)
 
+- Environment: `MCP_V8_HEAP_MEMORY_MAX`
 - Default: `8`
 - Value: `HEAP_MEMORY_MAX`
 
@@ -136,6 +137,7 @@ Maximum V8 heap memory per isolate in megabytes (default: 8)
 
 Maximum execution timeout in seconds (default: 30, max: 300)
 
+- Environment: `MCP_V8_EXECUTION_TIMEOUT`
 - Default: `30`
 - Value: `EXECUTION_TIMEOUT`
 
@@ -143,34 +145,16 @@ Maximum execution timeout in seconds (default: 30, max: 300)
 
 Maximum concurrent V8 executions (default: CPU core count)
 
+- Environment: `MCP_V8_MAX_CONCURRENT_EXECUTIONS`
 - Value: `MAX_CONCURRENT_EXECUTIONS`
 
 ### `--session-db-path`
 
-Path to the sled database for session logging (default: /tmp/mcp-v8-sessions)
+Path to the sled database for the session log (per-session heap+fs history) and the execution registry. Also the default parent for the heap-tag store, fs blob store, and fs label db. Default: /tmp/mcp-v8-sessions
 
+- Environment: `MCP_V8_SESSION_DB_PATH`
 - Default: `/tmp/mcp-v8-sessions`
 - Value: `SESSION_DB_PATH`
-
-## FS Snapshots
-
-### `--enable-fs-snapshots`
-
-Enable the content-addressed, snapshottable filesystem. When set, the `fs` parameter of run_js can mount a snapshot (by label or CA id) and the `fs_*` tools / `/api/fs/...` endpoints become functional. In cluster mode labels replicate cluster-wide, but blobs/manifests are only shared when stored on shared storage. Node-local file blobs are single-node only; enabling fs snapshots in a cluster therefore requires `--s3-bucket` (optionally `--cache-dir` for a write-through cache), otherwise startup is refused.
-
-- Default: `false`
-
-### `--fs-store-dir`
-
-Directory for the fs snapshot blob store (chunks + manifests). Defaults to `<session-db-path>/fs-blobs`. Node-local and single-node only; in a cluster, configure `--s3-bucket` instead so blobs are shared across nodes (this directory is then used only as the write-through cache when `--cache-dir` is set)
-
-- Value: `DIR`
-
-### `--fs-labels-db`
-
-Path for the fs label/reflog database (sled). Defaults to `<session-db-path>/fs-labels`
-
-- Value: `PATH`
 
 ## Fetch
 
@@ -185,7 +169,49 @@ Inject headers into fetch requests matching host/method rules. Format: host=<hos
 
 Path to a JSON file with header injection rules. Format: [{"host": "api.github.com", "methods": ["GET","POST"], "headers": {"Authorization": "Bearer ..."}}]
 
+- Environment: `MCP_V8_FETCH_HEADER_CONFIG`
 - Value: `PATH`
+
+## Filesystem
+
+### `--fs-store`
+
+Content-addressed `/work` filesystem backend. `none` (default) = no fs persistence. `dir` = node-local blob store (`--fs-dir`). `s3` = shared `--s3-bucket`. When enabled, the `fs` parameter of run_js can mount a snapshot (by label or CA id) and the `fs_*` tools / `/api/fs/...` endpoints become functional. Works with any isolate (compatible with `--wasm-module`). In cluster mode labels replicate cluster-wide, but blobs/manifests are only shared when stored on shared storage — so `--fs-store s3` is required when running fs persistence in a cluster.
+
+- Environment: `MCP_V8_FS_STORE`
+- Default: `none`
+- Value: `FS_STORE`
+
+### `--fs-dir`
+
+Directory for the fs snapshot blob store (chunks + manifests) when `--fs-store dir`. Defaults to `<session-db-path>/fs-blobs`
+
+- Environment: `MCP_V8_FS_DIR`
+- Value: `DIR`
+
+### `--fs-labels-db`
+
+Path for the fs label/reflog database (sled). Defaults to `<session-db-path>/fs-labels`
+
+- Environment: `MCP_V8_FS_LABELS_DB`
+- Value: `PATH`
+
+## Heap
+
+### `--heap-store`
+
+V8 heap-snapshot backend. `none` (default) = no heap persistence; JS globals do NOT survive between runs. `dir` = node-local directory (`--heap-dir`). `s3` = shared `--s3-bucket` (optionally `--cache-dir`). Heap snapshots require a V8 SnapshotCreator isolate, which disables WebAssembly — so heap persistence is mutually exclusive with `--wasm-module`/`--wasm-config` (rejected at startup).
+
+- Environment: `MCP_V8_HEAP_STORE`
+- Default: `none`
+- Value: `HEAP_STORE`
+
+### `--heap-dir`
+
+Directory for the heap-snapshot store when `--heap-store dir`. Defaults to /tmp/mcp-v8-heaps
+
+- Environment: `MCP_V8_HEAP_DIR`
+- Value: `DIR`
 
 ## MCP Server Module
 
@@ -200,18 +226,21 @@ Connect to an external MCP server as a module. JS code can call its tools via th
 
 Path to a JSON config file for MCP server modules. Format: [{"name": "srv", "transport": "stdio", "command": "cmd", "args": ["a"]}, {"name": "srv2", "transport": "sse", "url": "http://..."}]
 
+- Environment: `MCP_V8_MCP_CONFIG`
 - Value: `PATH`
 
 ### `--mcp-stubs`
 
 Expose upstream MCP server tools on the MCPJS server itself as `<prefix><server>__<tool>` stubs. When `true` (the default whenever at least one --mcp-server is configured), an external client of MCPJS can discover those tools via tools/list and tool search; calling a stub returns instructional text telling the caller to invoke the tool from JavaScript via run_js + mcp.callTool(...). Pass `--mcp-stubs false` to disable
 
+- Environment: `MCP_V8_MCP_STUBS`
 - Default: `true`
 
 ### `--mcp-stub-prefix`
 
 Prefix applied to stub tool names. Defaults to `runjs__` so it is obvious to a calling agent that these tools execute through the JS runtime rather than dispatching directly. Has no effect when --mcp-stubs is false
 
+- Environment: `MCP_V8_MCP_STUB_PREFIX`
 - Default: `runjs__`
 - Value: `MCP_STUB_PREFIX`
 
@@ -221,6 +250,7 @@ Prefix applied to stub tool names. Defaults to `runjs__` so it is obvious to a c
 
 Allow external module imports (npm:, jsr:, and URL imports). When disabled (the default), code using import declarations for external packages will be rejected. Enable with --allow-external-modules
 
+- Environment: `MCP_V8_ALLOW_EXTERNAL_MODULES`
 - Default: `false`
 
 ## Policy
@@ -229,6 +259,7 @@ Allow external module imports (npm:, jsr:, and URL imports). When disabled (the 
 
 JSON policy configuration (inline JSON or path to a JSON file). Enables fetch() and/or module policy gating via local Rego files and/or remote OPA servers. Example: --policies-json '{"fetch":{"policies":[{"url":"file:///path/to/fetch.rego"}]}}' Schema: { "fetch": { "mode": "all"|"any", "policies": [{"url": "...", "policy_path": "...", "rule": "..."}] }, "modules": { ... } }
 
+- Environment: `MCP_V8_POLICIES_JSON`
 - Value: `JSON_OR_PATH`
 
 ## Prompt
@@ -237,12 +268,14 @@ JSON policy configuration (inline JSON or path to a JSON file). Enables fetch() 
 
 Override the MCP server `instructions` (the "system prompt" the server reports to clients during `initialize`). The value is used verbatim as inline text, unless it begins with `@`, in which case the remainder is treated as a path to a file whose contents are used (`@-` is not special; use `@@` for a literal leading `@`). Examples: --instructions "Run JS for me" --instructions @./prompt.txt
 
+- Environment: `MCP_V8_INSTRUCTIONS`
 - Value: `TEXT_OR_@FILE`
 
 ### `--run-js-description`
 
 Override the description advertised for the `run_js` tool in `tools/list`. The value is used verbatim as inline text, unless it begins with `@`, in which case the remainder is treated as a path to a file whose contents are used (use `@@` for a literal leading `@`). Examples: --run-js-description "Execute JS" --run-js-description @./run_js.md
 
+- Environment: `MCP_V8_RUN_JS_DESCRIPTION`
 - Value: `TEXT_OR_@FILE`
 
 ## Run JS File
@@ -251,27 +284,46 @@ Override the description advertised for the `run_js` tool in `tools/list`. The v
 
 Allow the `run_js` tool to read its code from a file on the server's own filesystem (the `file` parameter). OFF by default. When set, ANY path the server process can read is allowed — this is the easy "allow all" switch. For finer control, leave this off and configure a `run_js_file` policy in --policies-json instead (a Rego/OPA chain decides which paths are allowed); the policy input is `{ "operation": "read", "path": "<canonical path>" }`. This flag takes precedence over a configured run_js_file policy
 
+- Environment: `MCP_V8_ALLOW_RUN_JS_FILE`
 - Default: `false`
+
+## Storage (S3)
+
+### `--s3-bucket`
+
+S3 bucket backing whichever axes select `s3`. Required when `--heap-store s3` or `--fs-store s3` is set
+
+- Environment: `MCP_V8_S3_BUCKET`
+- Value: `S3_BUCKET`
+
+### `--cache-dir`
+
+Local filesystem cache directory for S3 write-through caching (only used with `--s3-bucket`)
+
+- Environment: `MCP_V8_CACHE_DIR`
+- Value: `CACHE_DIR`
 
 ## WASM
 
 ### `--wasm-module`
 
-Pre-load a WASM module as a global. Format: name=/path/to/module.wasm[:max_memory] The module's exports will be available as a global variable with the given name. Optional memory suffix caps the module's native memory (linear memory + tables). Supported suffixes: raw bytes, k/K (KiB), m/M (MiB), g/G (GiB). Examples: math=/path.wasm math=/path.wasm:16m math=/path.wasm:1048576 Can be specified multiple times for multiple modules
+Pre-load a WASM module as a global. Format: name=/path/to/module.wasm[:max_memory] The module's exports will be available as a global variable with the given name. Optional memory suffix caps the module's native memory (linear memory + tables). Supported suffixes: raw bytes, k/K (KiB), m/M (MiB), g/G (GiB). Examples: math=/path.wasm math=/path.wasm:16m math=/path.wasm:1048576 Can be specified multiple times for multiple modules. NOTE: incompatible with heap persistence (`--heap-store` other than none)
 
 - Value: `NAME=PATH[:LIMIT]`
 - Repeatable: yes
 
 ### `--wasm-config`
 
-Path to a JSON config file mapping global names to .wasm file paths or objects. String value: {"name": "/path/to/module.wasm"} Object value: {"name": {"path": "/path/to/module.wasm", "max_memory_bytes": 16777216, "description": "what the module does"}} The optional "description" sets the MCP stub tool's description
+Path to a JSON config file mapping global names to .wasm file paths or objects. String value: {"name": "/path/to/module.wasm"} Object value: {"name": {"path": "/path/to/module.wasm", "max_memory_bytes": 16777216, "description": "what the module does"}} The optional "description" sets the MCP stub tool's description. NOTE: incompatible with heap persistence (`--heap-store` other than none)
 
+- Environment: `MCP_V8_WASM_CONFIG`
 - Value: `PATH`
 
 ### `--wasm-default-max-memory`
 
 Default max native memory for WASM modules without a per-module limit. Supports suffixes: k/K (KiB), m/M (MiB), g/G (GiB), or raw bytes. This is separate from --heap-memory-max (JS heap); WASM linear memory is allocated as native memory outside the V8 heap
 
+- Environment: `MCP_V8_WASM_DEFAULT_MAX_MEMORY`
 - Default: `16m`
 - Value: `WASM_DEFAULT_MAX_MEMORY`
 
@@ -279,12 +331,14 @@ Default max native memory for WASM modules without a per-module limit. Supports 
 
 Expose pre-loaded WASM modules on the MCPJS server itself as `<prefix>wasm__<name>` stubs. When `true` (the default whenever at least one WASM module is loaded), an external client of MCPJS can discover the module via tools/list and tool search; calling a stub returns instructional text telling the caller to use the module from JavaScript via run_js (the module is available as the `__wasm_<name>` global). Pass `--wasm-stubs false` to disable
 
+- Environment: `MCP_V8_WASM_STUBS`
 - Default: `true`
 
 ### `--wasm-stub-prefix`
 
 Prefix applied to WASM stub tool names. Defaults to `runjs__` so it is obvious to a calling agent that these modules execute through the JS runtime rather than dispatching directly. Has no effect when --wasm-stubs is false
 
+- Environment: `MCP_V8_WASM_STUB_PREFIX`
 - Default: `runjs__`
 - Value: `WASM_STUB_PREFIX`
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -11,33 +11,33 @@ configuration.
 - [Stateful mode](#stateful-mode)
 - [Stateless mode](#stateless-mode)
 
-## Stateful mode
+## Heap+fs mode
 
-These tools keep execution records and heap state available across calls.
+These tools execute in isolated runs and return output directly.
 
 ### Tools
 
-- [`cancel_execution`](#stateful-cancel-execution)
-- [`delete_heap_tags`](#stateful-delete-heap-tags)
-- [`fs_label`](#stateful-fs-label)
-- [`fs_log`](#stateful-fs-log)
-- [`fs_ls`](#stateful-fs-ls)
-- [`fs_merge`](#stateful-fs-merge)
-- [`fs_pull`](#stateful-fs-pull)
-- [`fs_push`](#stateful-fs-push)
-- [`fs_reset`](#stateful-fs-reset)
-- [`get_execution`](#stateful-get-execution)
-- [`get_execution_output`](#stateful-get-execution-output)
-- [`get_heap_tags`](#stateful-get-heap-tags)
-- [`list_executions`](#stateful-list-executions)
-- [`list_session_snapshots`](#stateful-list-session-snapshots)
-- [`list_sessions`](#stateful-list-sessions)
-- [`query_heaps_by_tags`](#stateful-query-heaps-by-tags)
-- [`run_js`](#stateful-run-js)
-- [`set_heap_tags`](#stateful-set-heap-tags)
+- [`cancel_execution`](#heap+fs-cancel-execution)
+- [`delete_heap_tags`](#heap+fs-delete-heap-tags)
+- [`fs_label`](#heap+fs-fs-label)
+- [`fs_log`](#heap+fs-fs-log)
+- [`fs_ls`](#heap+fs-fs-ls)
+- [`fs_merge`](#heap+fs-fs-merge)
+- [`fs_pull`](#heap+fs-fs-pull)
+- [`fs_push`](#heap+fs-fs-push)
+- [`fs_reset`](#heap+fs-fs-reset)
+- [`get_execution`](#heap+fs-get-execution)
+- [`get_execution_output`](#heap+fs-get-execution-output)
+- [`get_heap_tags`](#heap+fs-get-heap-tags)
+- [`list_executions`](#heap+fs-list-executions)
+- [`list_session_snapshots`](#heap+fs-list-session-snapshots)
+- [`list_sessions`](#heap+fs-list-sessions)
+- [`query_heaps_by_tags`](#heap+fs-query-heaps-by-tags)
+- [`run_js`](#heap+fs-run-js)
+- [`set_heap_tags`](#heap+fs-set-heap-tags)
 
 ### `cancel_execution`
-<a id="stateful-cancel-execution"></a>
+<a id="heap+fs-cancel-execution"></a>
 
 Cancel a running execution. Terminates the V8 isolate.
 
@@ -48,7 +48,7 @@ Parameters:
 | `execution_id` | `string` | yes | - |
 
 ### `delete_heap_tags`
-<a id="stateful-delete-heap-tags"></a>
+<a id="heap+fs-delete-heap-tags"></a>
 
 Delete tags from a heap snapshot (stateful mode only). If keys is provided (comma-separated), only those tag keys are removed. If keys is omitted, all tags are deleted.
 
@@ -60,7 +60,7 @@ Parameters:
 | `keys` | `string | null` | no | - |
 
 ### `fs_label`
-<a id="stateful-fs-label"></a>
+<a id="heap+fs-fs-label"></a>
 
 Create or repoint a filesystem snapshot label to a CA id (hex). Pass an optional `message` (a commit-style note) to record on the reflog entry.
 
@@ -73,7 +73,7 @@ Parameters:
 | `name` | `string` | yes | - |
 
 ### `fs_log`
-<a id="stateful-fs-log"></a>
+<a id="heap+fs-fs-log"></a>
 
 Show the reflog (move history) for a filesystem snapshot label, oldest first. Each entry has at, from, to (CA ids), op (create/push/reset/force), and an optional message. Use a `to` value as the ca_id for fs_reset. Pass `limit` to return only the most recent N entries (bounding the scan over long histories).
 
@@ -85,14 +85,14 @@ Parameters:
 | `limit` | `integer | null` | no | - |
 
 ### `fs_ls`
-<a id="stateful-fs-ls"></a>
+<a id="heap+fs-fs-ls"></a>
 
 List filesystem snapshot labels. Returns each label name and its current head CA id (hex).
 
 This tool does not take structured parameters.
 
 ### `fs_merge`
-<a id="stateful-fs-merge"></a>
+<a id="heap+fs-fs-merge"></a>
 
 Three-way merge two filesystem snapshots (CA ids) into a new snapshot. Pass `base` — the snapshot both sides diverged from (e.g. the label head you mounted before two runs) — so only paths BOTH sides changed conflict; omit it for a 2-way merge. Text files are merged at line level: edits to different lines of the same file auto-merge cleanly. On success returns the merged snapshot's ca_id (push it to a label separately). On conflict returns status=conflict with, per path: each side's content id (null = absent), kind (text/binary/sqlite/modify-delete), and for text the diff3 conflict `markers` plus unified `diff_ours`/`diff_theirs` so you can resolve at line level (edit the markers, write the file back, push). Set prefer=ours|theirs to auto-resolve remaining conflicts to that side.
 
@@ -106,7 +106,7 @@ Parameters:
 | `theirs` | `string` | yes | - |
 
 ### `fs_pull`
-<a id="stateful-fs-pull"></a>
+<a id="heap+fs-fs-pull"></a>
 
 Resolve a filesystem snapshot label to its current head CA id (hex). Use this as the `fs` argument to run_js to mount it.
 
@@ -117,7 +117,7 @@ Parameters:
 | `label` | `string` | yes | - |
 
 ### `fs_push`
-<a id="stateful-fs-push"></a>
+<a id="heap+fs-fs-push"></a>
 
 Advance a filesystem snapshot label to a CA id (typically the `fs` value returned by a completed run_js execution). Default is reject-and-rebase: pass `expected` (the head you pulled) and the push fails if the label moved since. Set force=true to override, or detach=true to just return the CA id without touching the label. Pass an optional `message` (a commit-style note, max 4096 bytes) to record on the reflog entry.
 
@@ -133,7 +133,7 @@ Parameters:
 | `message` | `string | null` | no | - |
 
 ### `fs_reset`
-<a id="stateful-fs-reset"></a>
+<a id="heap+fs-fs-reset"></a>
 
 Reset a filesystem snapshot label to an earlier CA id from its reflog (rollback). The CA id must appear in the label's reflog (see fs_log) unless allow_unlogged=true. Pass an optional `message` (a commit-style note) to record on the reflog entry.
 
@@ -147,7 +147,7 @@ Parameters:
 | `message` | `string | null` | no | - |
 
 ### `get_execution`
-<a id="stateful-get-execution"></a>
+<a id="heap+fs-get-execution"></a>
 
 Get the status and result of an execution. Returns execution_id, status (running/completed/failed/cancelled/timed_out), result (if completed), heap (if stateful), fs (resulting filesystem snapshot CA id, if a mount was attached), error (if failed), started_at, and completed_at.
 
@@ -158,7 +158,7 @@ Parameters:
 | `execution_id` | `string` | yes | - |
 
 ### `get_execution_output`
-<a id="stateful-get-execution-output"></a>
+<a id="heap+fs-get-execution-output"></a>
 
 Get paginated console output for an execution. Supports two modes: line-based (line_offset + line_limit) or byte-based (byte_offset + byte_limit). If byte_offset is provided, byte mode takes precedence. Response includes both line and byte coordinates for cross-referencing. Use next_line_offset or next_byte_offset from a previous response to resume reading.
 
@@ -173,7 +173,7 @@ Parameters:
 | `line_offset` | `integer | null` | no | - |
 
 ### `get_heap_tags`
-<a id="stateful-get-heap-tags"></a>
+<a id="heap+fs-get-heap-tags"></a>
 
 Get tags for a heap snapshot (stateful mode only). Returns a map of key-value tags associated with the given heap content hash.
 
@@ -184,14 +184,14 @@ Parameters:
 | `heap` | `string` | yes | - |
 
 ### `list_executions`
-<a id="stateful-list-executions"></a>
+<a id="heap+fs-list-executions"></a>
 
 List all executions with their status.
 
 This tool does not take structured parameters.
 
 ### `list_session_snapshots`
-<a id="stateful-list-session-snapshots"></a>
+<a id="heap+fs-list-session-snapshots"></a>
 
 List all log entries for the current session (stateful mode only). Each entry contains the input heap hash, output heap hash, code executed, and timestamp. Use the fields parameter to select specific fields (comma-separated: index,input_heap,output_heap,code,timestamp).
 
@@ -202,14 +202,14 @@ Parameters:
 | `fields` | `string | null` | no | - |
 
 ### `list_sessions`
-<a id="stateful-list-sessions"></a>
+<a id="heap+fs-list-sessions"></a>
 
 List all named sessions (stateful mode only). Returns an array of session names that have been used via REST session fields or the X-MCP-Session-Id header.
 
 This tool does not take structured parameters.
 
 ### `query_heaps_by_tags`
-<a id="stateful-query-heaps-by-tags"></a>
+<a id="heap+fs-query-heaps-by-tags"></a>
 
 Query heap snapshots by tags (stateful mode only). Provide a map of key-value pairs to match. Returns all heaps whose tags contain all the specified key-value pairs.
 
@@ -220,7 +220,7 @@ Parameters:
 | `tags` | `object<string, string>` | yes | - |
 
 ### `run_js`
-<a id="stateful-run-js"></a>
+<a id="heap+fs-run-js"></a>
 
 run javascript or typescript code in v8
 
@@ -339,7 +339,7 @@ Parameters:
 | `tags` | `object | null` | no | - |
 
 ### `set_heap_tags`
-<a id="stateful-set-heap-tags"></a>
+<a id="heap+fs-set-heap-tags"></a>
 
 Set or replace tags on a heap snapshot (stateful mode only). Provide a map of key-value string pairs. This replaces all existing tags for the heap.
 

--- a/tests/stdio_e2e.rs
+++ b/tests/stdio_e2e.rs
@@ -20,7 +20,7 @@ impl StdioServer {
     /// Start a new stdio MCP server for testing
     async fn start(heap_dir: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let mut child = Command::new("cargo")
-            .args(&["run", "--", "--directory-path", heap_dir])
+            .args(&["run", "--", "--heap-store", "dir", "--heap-dir", heap_dir])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null()) // Suppress server logs during tests


### PR DESCRIPTION
## What

Two related changes (breaking → **v0.16.0**):

### 1. Decouple heap & filesystem persistence into independent axes
Heap snapshots and the content-addressed `/work` filesystem are now two independent, opt-in axes instead of a binary `--stateless`/stateful switch.

- **CLI (breaking):** `--heap-store <none|dir|s3>` / `--heap-dir`, `--fs-store <none|dir|s3>` / `--fs-dir`, shared `--s3-bucket`. Every flag is env-bindable (`MCP_V8_*`). Removed `--stateless`, `--directory-path`, `--enable-fs-snapshots`, `--fs-store-dir`. (`--bind-host` is now a real flag too.)
- Any combination valid: neither / heap-only / **fs-only** / both.
- **fs-only + WASM now works** — previously impossible: heap snapshots run in a V8 SnapshotCreator isolate that disables WebAssembly. Heap + `--wasm-module` is now rejected at startup with a clear message instead of failing at first run.
- MCP surface is capability-gated: `run_js` schema, tool list, `get_info` instructions, and the run_js description adapt to which axes are enabled (no "globals persist" claim when heap is off).
- Stateless execution path now records the per-run fs snapshot to the session log, giving fs-only engines per-session filesystem persistence.

### 2. Fix: run isolate ops on a dedicated current-thread runtime
deno_core's async op driver requires a current-thread tokio runtime, but the isolate was driven on the ambient multi-thread server runtime — so any pending async op (`fetch`, fs writes) **panicked in debug and deadlocked in release**. fs-snapshot writes never worked over the network.

Each execution's module load + evaluation + event loop now runs inside one `block_on` of a fresh current-thread runtime (built on the existing `spawn_blocking` thread — no dedicated OS thread). Crucially `mod_evaluate` (which runs top-level code synchronously, submitting the first ops) runs *inside* that `block_on`. S3/heap-blob I/O still bridges to the server runtime via its captured `Handle`.

## Test

- `cargo test -p server`: all green (the local-only `stdio_e2e` macOS timeout flake and a parallel sled-lock flake also reproduce on `main`).
- New capability-matrix unit tests for the MCP tool gating.
- Manual e2e (debug + release): fs write/read across runs in one session, session isolation, WASM (`math.add`) alongside fs, and `fetch` all succeed with zero panics.
- Regenerated `cli-flags.md` + `mcp-tools.md`; `openapi.json` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)