### PR TITLE
fix: optional fs overlay passthrough + bridge mcp.callTool (v0.16.1)

### DIFF
--- a/server/src/bin/generate-mcp-tools-markdown.rs
+++ b/server/src/bin/generate-mcp-tools-markdown.rs
@@ -230,7 +230,7 @@ fn main() {
         String::new(),
         "## Modes".to_string(),
         String::new(),
-        "- [Stateful mode](#stateful-mode)".to_string(),
+        "- [Heap+fs mode](#heapfs-mode)".to_string(),
         "- [Stateless mode](#stateless-mode)".to_string(),
         String::new(),
     ];

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -132,6 +132,15 @@ pub struct Cli {
     #[arg(long = "fs-labels-db", env = "MCP_V8_FS_LABELS_DB", value_name = "PATH", help_heading = "Filesystem")]
     pub fs_labels_db: Option<String>,
 
+    /// Overlay read behaviour when a per-session fs snapshot is mounted.
+    /// Off (default): overlay-only — the mounted snapshot is the entire fs view,
+    /// so a read that misses it is ENOENT (strict isolation). On: overlayfs-style
+    /// — fall through to the real filesystem as a read-only lower layer (still
+    /// gated by the filesystem policy), so bundled read-only paths like
+    /// `/opt/languages` resolve while `/work` stays the per-session overlay.
+    #[arg(long = "fs-passthrough", env = "MCP_V8_FS_PASSTHROUGH", default_value = "false", help_heading = "Filesystem")]
+    pub fs_passthrough: bool,
+
     // ── Shared S3 backend (used by heap-store=s3 and/or fs-store=s3) ──────────
     /// S3 bucket backing whichever axes select `s3`. Required when
     /// `--heap-store s3` or `--fs-store s3` is set.

--- a/server/src/engine/fs.rs
+++ b/server/src/engine/fs.rs
@@ -57,15 +57,26 @@ impl FsMountHandle {
 pub struct FsConfig {
     pub policy_chain: Arc<PolicyChain>,
     pub mcp_headers: Option<serde_json::Value>,
+    /// When a per-session overlay mount is attached, controls what happens on an
+    /// overlay miss: `false` (default) = overlay-only (the overlay is the whole
+    /// fs view; a miss is ENOENT). `true` = overlayfs-style — fall through to the
+    /// real filesystem as a read-only lower layer (still policy-gated), so
+    /// bundled paths like `/opt/languages` resolve while `/work` stays per-session.
+    pub passthrough: bool,
 }
 
 impl FsConfig {
     pub fn new(chain: Arc<PolicyChain>) -> Self {
-        Self { policy_chain: chain, mcp_headers: None }
+        Self { policy_chain: chain, mcp_headers: None, passthrough: false }
     }
 
     pub fn with_mcp_headers(mut self, mcp_headers: Option<serde_json::Value>) -> Self {
         self.mcp_headers = mcp_headers;
+        self
+    }
+
+    pub fn with_passthrough(mut self, passthrough: bool) -> Self {
+        self.passthrough = passthrough;
         self
     }
 }
@@ -131,7 +142,21 @@ async fn op_fs_read_file_text(
         check_policy(&config.policy_chain, "readFile", &path, None, None, Some("utf8"), config.mcp_headers.as_ref())
             .await
             .map_err(JsErrorBox::generic)?;
-        let content = m.0.lock().await.read(Path::new(&path)).await
+        if let Some(content) = m.0.lock().await.read_opt(Path::new(&path)).await
+            .map_err(|e| JsErrorBox::generic(format!("fs.readFile: {}: {}", path, e)))?
+        {
+            return String::from_utf8(content)
+                .map_err(|e| JsErrorBox::generic(format!("fs.readFile: invalid UTF-8 in {}: {}", path, e)));
+        }
+        // Overlay miss. With passthrough off (default) the overlay is the whole
+        // fs view, so this is ENOENT. With passthrough on, fall through to the
+        // real filesystem as a read-only lower layer (already policy-gated above)
+        // so bundled paths like /opt/languages resolve while /work stays the
+        // per-session overlay.
+        if !config.passthrough {
+            return Err(JsErrorBox::generic(format!("fs.readFile: {}: ENOENT", path)));
+        }
+        let content = std::fs::read(&path)
             .map_err(|e| JsErrorBox::generic(format!("fs.readFile: {}: {}", path, e)))?;
         return String::from_utf8(content)
             .map_err(|e| JsErrorBox::generic(format!("fs.readFile: invalid UTF-8 in {}: {}", path, e)));
@@ -166,7 +191,18 @@ async fn op_fs_read_file_buffer(
         check_policy(&config.policy_chain, "readFile", &path, None, None, Some("buffer"), config.mcp_headers.as_ref())
             .await
             .map_err(JsErrorBox::generic)?;
-        return m.0.lock().await.read(Path::new(&path)).await
+        if let Some(content) = m.0.lock().await.read_opt(Path::new(&path)).await
+            .map_err(|e| JsErrorBox::generic(format!("fs.readFile: {}: {}", path, e)))?
+        {
+            return Ok(content);
+        }
+        // Overlay miss: ENOENT unless passthrough is on, in which case fall
+        // through to the real filesystem (policy-gated above) so bundled
+        // read-only paths (e.g. /opt/languages) resolve.
+        if !config.passthrough {
+            return Err(JsErrorBox::generic(format!("fs.readFile: {}: ENOENT", path)));
+        }
+        return std::fs::read(&path)
             .map_err(|e| JsErrorBox::generic(format!("fs.readFile: {}: {}", path, e)));
     }
 

--- a/server/src/engine/fs_mount.rs
+++ b/server/src/engine/fs_mount.rs
@@ -103,6 +103,19 @@ impl SessionMount {
         }
     }
 
+    /// Like [`read`], but returns `Ok(None)` when the path is absent from the
+    /// overlay (instead of erroring), so callers can fall through to a lower
+    /// layer (the real filesystem), overlayfs-style. A whiteout (deleted in this
+    /// session) also yields `None`.
+    pub async fn read_opt(&self, p: &Path) -> anyhow::Result<Option<Vec<u8>>> {
+        let comps = components_of(p);
+        let key = path_of(&comps);
+        match self.effective(&comps, &key).await? {
+            Some(e) => Ok(Some(self.store.read_file(&e).await?)),
+            None => Ok(None),
+        }
+    }
+
     pub async fn write(&mut self, p: &Path, bytes: &[u8]) -> anyhow::Result<()> {
         let entry = self.store.put_file(bytes).await?;
         self.upper.insert(path_of(&components_of(p)), Write::Data(entry));

--- a/server/src/engine/mcp_client.rs
+++ b/server/src/engine/mcp_client.rs
@@ -188,6 +188,12 @@ pub struct McpClientManager {
     tools_by_server: Arc<HashMap<String, Vec<Tool>>>,
     servers: Arc<HashMap<String, Arc<ServerConn>>>,
     stub_config: StubConfig,
+    /// The runtime that owns the server connections (captured at `connect()`,
+    /// i.e. the multi-thread server runtime). `call_tool` bridges onto it: the
+    /// peers' transport I/O lives here, so awaiting a call from the isolate's
+    /// per-execution current-thread runtime would otherwise stall. Mirrors
+    /// `S3HeapStorage`'s `runtime` handle. `None` for test-only constructors.
+    runtime: Option<tokio::runtime::Handle>,
 }
 
 impl McpClientManager {
@@ -232,6 +238,7 @@ impl McpClientManager {
             tools_by_server: Arc::new(tools_by_server),
             servers: Arc::new(servers),
             stub_config: StubConfig::default(),
+            runtime: Some(tokio::runtime::Handle::current()),
         })
     }
 
@@ -256,6 +263,7 @@ impl McpClientManager {
             tools_by_server: Arc::new(tools_by_server),
             servers: Arc::new(HashMap::new()),
             stub_config: StubConfig::default(),
+            runtime: None,
         }
     }
 
@@ -337,66 +345,87 @@ impl McpClientManager {
         tool_name: &str,
         arguments: Option<serde_json::Map<String, serde_json::Value>>,
     ) -> Result<serde_json::Value, String> {
-        let server = self.servers.get(server_name).ok_or_else(|| {
-            format!(
-                "MCP server '{}' not found. Available: {:?}",
-                server_name,
-                self.server_names()
-            )
-        })?;
-
-        let make_req = || CallToolRequestParam {
-            name: tool_name.to_string().into(),
-            arguments: arguments.clone(),
-        };
-
-        let peer = { server.live.read().await.peer.clone() };
-        let result = match peer.call_tool(make_req()).await {
-            Ok(r) => r,
-            Err(e) => {
-                // A call can fail because the tool errored OR because the
-                // downstream connection died (e.g. the server restarted). Probe
-                // to tell them apart: if the connection is still healthy the
-                // error is genuine; otherwise reconnect and retry once so a
-                // restarted downstream heals transparently.
-                if is_healthy(&peer).await {
-                    return Err(format!("mcp.callTool({}.{}): {}", server_name, tool_name, e));
-                }
-                tracing::warn!(
-                    "MCP server '{}' looks disconnected ({}); reconnecting and retrying",
+        let server = self
+            .servers
+            .get(server_name)
+            .ok_or_else(|| {
+                format!(
+                    "MCP server '{}' not found. Available: {:?}",
                     server_name,
-                    e
-                );
-                reconnect(server).await.map_err(|re| {
-                    format!(
-                        "mcp.callTool({}.{}): reconnect failed: {}",
-                        server_name, tool_name, re
-                    )
-                })?;
-                let peer = { server.live.read().await.peer.clone() };
-                peer.call_tool(make_req()).await.map_err(|e| {
-                    format!(
-                        "mcp.callTool({}.{}): {} (after reconnect)",
-                        server_name, tool_name, e
-                    )
-                })?
-            }
+                    self.server_names()
+                )
+            })?
+            .clone();
+        let server_name = server_name.to_string();
+        let tool_name = tool_name.to_string();
+
+        // The downstream peer's transport I/O lives on the runtime that owns the
+        // connection (captured at `connect()`). run_js ops run on a per-execution
+        // current-thread runtime, from which awaiting the peer would stall, so run
+        // the whole call on the connection's runtime and await the JoinHandle
+        // (safe to poll from any runtime) — mirrors S3HeapStorage::*_blocking.
+        let call = async move {
+            let make_req = || CallToolRequestParam {
+                name: tool_name.clone().into(),
+                arguments: arguments.clone(),
+            };
+
+            let peer = { server.live.read().await.peer.clone() };
+            let result = match peer.call_tool(make_req()).await {
+                Ok(r) => r,
+                Err(e) => {
+                    // A call can fail because the tool errored OR because the
+                    // downstream connection died (e.g. the server restarted).
+                    // Probe to tell them apart: if the connection is still
+                    // healthy the error is genuine; otherwise reconnect and retry
+                    // once so a restarted downstream heals transparently.
+                    if is_healthy(&peer).await {
+                        return Err(format!("mcp.callTool({}.{}): {}", server_name, tool_name, e));
+                    }
+                    tracing::warn!(
+                        "MCP server '{}' looks disconnected ({}); reconnecting and retrying",
+                        server_name,
+                        e
+                    );
+                    reconnect(&server).await.map_err(|re| {
+                        format!(
+                            "mcp.callTool({}.{}): reconnect failed: {}",
+                            server_name, tool_name, re
+                        )
+                    })?;
+                    let peer = { server.live.read().await.peer.clone() };
+                    peer.call_tool(make_req()).await.map_err(|e| {
+                        format!(
+                            "mcp.callTool({}.{}): {} (after reconnect)",
+                            server_name, tool_name, e
+                        )
+                    })?
+                }
+            };
+
+            // Serialize content to JSON for JS consumption.
+            let content_json: Vec<serde_json::Value> = result
+                .content
+                .iter()
+                .map(|c| {
+                    serde_json::to_value(c)
+                        .unwrap_or(serde_json::json!({"error": "serialization failed"}))
+                })
+                .collect();
+
+            Ok(serde_json::json!({
+                "content": content_json,
+                "isError": result.is_error.unwrap_or(false),
+            }))
         };
 
-        // Serialize content to JSON for JS consumption.
-        let content_json: Vec<serde_json::Value> = result
-            .content
-            .iter()
-            .map(|c| {
-                serde_json::to_value(c)
-                    .unwrap_or(serde_json::json!({"error": "serialization failed"}))
-            })
-            .collect();
-
-        Ok(serde_json::json!({
-            "content": content_json,
-            "isError": result.is_error.unwrap_or(false),
-        }))
+        match &self.runtime {
+            Some(rt) => rt
+                .spawn(call)
+                .await
+                .map_err(|e| format!("mcp.callTool: task join error: {e}"))?,
+            None => call.await,
+        }
     }
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -383,9 +383,12 @@ async fn main() -> Result<()> {
     // A mount needs the fs surface present, so when snapshots are enabled but
     // no fs policy was supplied, default to an allow-all policy chain.
     let engine = if let Some(chain) = fs_policy_chain {
-        engine.with_fs_config(FsConfig::new(chain))
+        engine.with_fs_config(FsConfig::new(chain).with_passthrough(cli.fs_passthrough))
     } else if fs_enabled {
-        engine.with_fs_config(FsConfig::new(Arc::new(PolicyChain::new(vec![], EvalMode::All))))
+        engine.with_fs_config(
+            FsConfig::new(Arc::new(PolicyChain::new(vec![], EvalMode::All)))
+                .with_passthrough(cli.fs_passthrough),
+        )
     } else {
         engine
     };

--- a/site-docs/reference/cli-flags.md
+++ b/site-docs/reference/cli-flags.md
@@ -196,6 +196,13 @@ Path for the fs label/reflog database (sled). Defaults to `<session-db-path>/fs-
 - Environment: `MCP_V8_FS_LABELS_DB`
 - Value: `PATH`
 
+### `--fs-passthrough`
+
+Overlay read behaviour when a per-session fs snapshot is mounted. Off (default): overlay-only — the mounted snapshot is the entire fs view, so a read that misses it is ENOENT (strict isolation). On: overlayfs-style — fall through to the real filesystem as a read-only lower layer (still gated by the filesystem policy), so bundled read-only paths like `/opt/languages` resolve while `/work` stays the per-session overlay
+
+- Environment: `MCP_V8_FS_PASSTHROUGH`
+- Default: `false`
+
 ## Heap
 
 ### `--heap-store`

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -8,7 +8,7 @@ configuration.
 
 ## Modes
 
-- [Stateful mode](#stateful-mode)
+- [Heap+fs mode](#heapfs-mode)
 - [Stateless mode](#stateless-mode)
 
 ## Heap+fs mode


### PR DESCRIPTION
Two fixes on top of v0.16.0, both about the current-thread isolate interacting with per-session state.

## 1. `--fs-passthrough` — overlayfs-style lower layer (opt-in)
When a per-session fs snapshot is mounted, the overlay was the *entire* fs view, so any read that missed it returned ENOENT — which shadows bundled read-only paths like `/opt/languages` (where the WASM language bootstrap, incl. the in-process `craftos` sim, lives).

- New flag `--fs-passthrough` (env `MCP_V8_FS_PASSTHROUGH`, default **off**). Off = strict overlay-only isolation (unchanged behavior). On = on an overlay miss, fall through to the real filesystem as a read-only lower layer — **still gated by the filesystem policy** — so `/opt/languages` resolves while `/work` stays the per-session overlay.
- `SessionMount::read_opt` returns `None` on miss; `op_fs_read_file_{text,buffer}` fall through only when passthrough is enabled.

## 2. Bridge `mcp.callTool` onto the connection's runtime
The downstream MCP peer's transport lives on the runtime captured at `connect()` (the multi-thread server runtime); awaiting it from the isolate's per-execution current-thread runtime stalls (this is why an SSE upstream like craftos hung). `call_tool` now runs on the captured `Handle` and awaits the `JoinHandle` — same pattern as `S3HeapStorage`.

## Test
- `cargo test -p server` green (lib + fs_mount_overlay + fs_snapshot_e2e verified locally).
- Manual: with `--fs-passthrough`, `/work` overlay writes persist AND a real-fs path resolves; without it, the real-fs read is ENOENT (strict). Both policy-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)