### PR TITLE
feat(sandbox): make the 5 hardening mitigations opt-in per-flag (default off)

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -141,6 +141,33 @@ pub struct Cli {
     #[arg(long = "fs-passthrough", env = "MCP_V8_FS_PASSTHROUGH", default_value = "false", help_heading = "Filesystem")]
     pub fs_passthrough: bool,
 
+    // ── Sandbox hardening (all opt-in; OFF by default → unhardened) ───────────
+    /// Freeze `Deno.core.ops` so user code cannot replace/intercept any op
+    /// (e.g. a persistent trojan op surviving in stateful/snapshot mode).
+    #[arg(long = "harden-freeze-ops", env = "MCP_V8_HARDEN_FREEZE_OPS", default_value = "false", help_heading = "Sandbox")]
+    pub harden_freeze_ops: bool,
+
+    /// Neutralize `op_get_proxy_details` (otherwise it bypasses `Proxy` handlers
+    /// and can read a proxied target).
+    #[arg(long = "harden-neutralize-proxy-details", env = "MCP_V8_HARDEN_NEUTRALIZE_PROXY_DETAILS", default_value = "false", help_heading = "Sandbox")]
+    pub harden_neutralize_proxy_details: bool,
+
+    /// Neutralize `op_memory_usage` + `op_is_terminal` (host info leaks).
+    #[arg(long = "harden-neutralize-introspection", env = "MCP_V8_HARDEN_NEUTRALIZE_INTROSPECTION", default_value = "false", help_heading = "Sandbox")]
+    pub harden_neutralize_introspection: bool,
+
+    /// Remove `globalThis.__bootstrap` (event-loop hooks, primordials such as a
+    /// pristine `Function` constructor, and internal registries).
+    #[arg(long = "harden-remove-bootstrap", env = "MCP_V8_HARDEN_REMOVE_BOOTSTRAP", default_value = "false", help_heading = "Sandbox")]
+    pub harden_remove_bootstrap: bool,
+
+    /// Remove `globalThis.SharedArrayBuffer` + `globalThis.Atomics` — the
+    /// high-resolution Spectre-timer prerequisite. NOTE: these are also the
+    /// shared-memory primitives emscripten wasm-threads require, so leave this
+    /// OFF to run pthreads-based WASM modules.
+    #[arg(long = "harden-remove-shared-memory", env = "MCP_V8_HARDEN_REMOVE_SHARED_MEMORY", default_value = "false", help_heading = "Sandbox")]
+    pub harden_remove_shared_memory: bool,
+
     // ── Shared S3 backend (used by heap-store=s3 and/or fs-store=s3) ──────────
     /// S3 bucket backing whichever axes select `s3`. Required when
     /// `--heap-store s3` or `--fs-store s3` is set.

--- a/server/src/engine/console.rs
+++ b/server/src/engine/console.rs
@@ -243,42 +243,95 @@ const CONSOLE_JS_WRAPPER: &str = r#"
 /// inject_fs, inject_mcp, and inject_timers — otherwise it will freeze ops
 /// before they are set up, breaking the runtime.
 ///
-/// 1. Neutralizes dangerous introspection ops (op_get_proxy_details, etc.)
-/// 2. Freezes Deno.core.ops to prevent interception/replacement
-/// 3. Removes __bootstrap (event loop hooks, primordials, internals)
-/// 4. Removes SharedArrayBuffer (Spectre timer prerequisite)
-pub fn harden_runtime(runtime: &mut JsRuntime) -> Result<(), String> {
+/// Each mitigation is **opt-in** and OFF by default: with a default
+/// `HardeningConfig` this is a no-op and the runtime is left unhardened. Enable
+/// mitigations individually via the `--harden-*` CLI flags. Whatever is enabled
+/// is applied in an order that keeps op-neutralization before the
+/// `Object.freeze` that would otherwise lock those ops in place.
+///
+/// Mitigations (each gated by its `HardeningConfig` field):
+/// - `neutralize_proxy_details`: `op_get_proxy_details` → `undefined` (else it bypasses `Proxy` handlers)
+/// - `neutralize_introspection`: `op_memory_usage`/`op_is_terminal` neutralized (host info leaks)
+/// - `freeze_ops`: `Object.freeze(Deno.core.ops)` (no op interception/replacement)
+/// - `remove_bootstrap`: delete `__bootstrap` (event-loop hooks, primordials, internals)
+/// - `remove_shared_memory`: delete `SharedArrayBuffer`/`Atomics` (Spectre timer prerequisite; also the primitives emscripten wasm-threads need)
+pub fn harden_runtime(runtime: &mut JsRuntime, config: HardeningConfig) -> Result<(), String> {
+    if config.is_noop() {
+        return Ok(());
+    }
+    let mut js = String::from("(function() {\n");
+    // Op neutralization must run BEFORE Object.freeze (freeze locks the ops object).
+    if config.neutralize_proxy_details {
+        js.push_str("  Deno.core.ops.op_get_proxy_details = function() { return undefined; };\n");
+    }
+    if config.neutralize_introspection {
+        js.push_str("  Deno.core.ops.op_memory_usage = function() { return {}; };\n");
+        js.push_str("  Deno.core.ops.op_is_terminal = function() { return false; };\n");
+    }
+    if config.freeze_ops {
+        js.push_str("  Object.freeze(Deno.core.ops);\n");
+    }
+    if config.remove_bootstrap {
+        // __bootstrap exposes event-loop hooks (setMacrotaskCallback,
+        // setPromiseHooks, …), primordials (pristine Function constructor), and
+        // internal registration objects. deno_core's own bootstrap has already
+        // completed, so deleting it here is safe.
+        js.push_str("  delete globalThis.__bootstrap;\n");
+    }
+    if config.remove_shared_memory {
+        // SharedArrayBuffer is the prerequisite for a high-resolution Spectre
+        // timer (and for emscripten wasm-threads). V8 flags cannot disable it
+        // (stable spec feature), so remove from JS.
+        js.push_str("  delete globalThis.SharedArrayBuffer;\n");
+        js.push_str("  delete globalThis.Atomics;\n");
+    }
+    js.push_str("})();");
     runtime
-        .execute_script("<sandbox-hardening>", HARDENING_JS.to_string())
+        .execute_script("<sandbox-hardening>", js)
         .map_err(|e| format!("Failed to harden sandbox: {}", e))?;
     Ok(())
 }
 
-const HARDENING_JS: &str = r#"
-(function() {
-    // 1. Neutralize dangerous introspection/info-leak ops before freezing.
-    //    These must be replaced on the ops object before Object.freeze.
-    Deno.core.ops.op_get_proxy_details = function() { return undefined; };
-    Deno.core.ops.op_memory_usage = function() { return {}; };
-    Deno.core.ops.op_is_terminal = function() { return false; };
+/// Per-mitigation sandbox-hardening switches. All fields default to `false`
+/// (OFF) — mcp-v8 runs UNHARDENED unless mitigations are explicitly enabled (see
+/// the `--harden-*` CLI flags). Each field maps to one mitigation from the
+/// original combined hardening pass (commit a1d644d).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct HardeningConfig {
+    /// Freeze `Deno.core.ops` so no op can be replaced/intercepted (e.g. a
+    /// persistent trojan op surviving in stateful/snapshot mode).
+    pub freeze_ops: bool,
+    /// Neutralize `op_get_proxy_details` (otherwise it bypasses `Proxy` handlers
+    /// and can read a proxied target).
+    pub neutralize_proxy_details: bool,
+    /// Neutralize `op_memory_usage` + `op_is_terminal` (host info leaks).
+    pub neutralize_introspection: bool,
+    /// Remove `globalThis.__bootstrap` (event-loop hooks, primordials such as a
+    /// pristine `Function` constructor, and internal registries).
+    pub remove_bootstrap: bool,
+    /// Remove `globalThis.SharedArrayBuffer` + `globalThis.Atomics` — the
+    /// high-resolution Spectre-timer prerequisite (and the shared-memory
+    /// primitives emscripten wasm-threads require).
+    pub remove_shared_memory: bool,
+}
 
-    // 2. Freeze ops to prevent interception/replacement of any op.
-    //    All setup (console, fetch, fs, mcp) has completed by this point.
-    Object.freeze(Deno.core.ops);
+impl HardeningConfig {
+    /// Every mitigation enabled (the original combined hardening behavior).
+    pub fn all() -> Self {
+        Self {
+            freeze_ops: true,
+            neutralize_proxy_details: true,
+            neutralize_introspection: true,
+            remove_bootstrap: true,
+            remove_shared_memory: true,
+        }
+    }
 
-    // 3. Remove __bootstrap: exposes event-loop hooks (setMacrotaskCallback,
-    //    setPromiseHooks, addMainModuleHandler, etc.), primordials (pristine
-    //    Function constructor), and internal registration objects.
-    //    deno_core's own bootstrap has already completed, so this is safe.
-    delete globalThis.__bootstrap;
-
-    // 4. Remove SharedArrayBuffer: prerequisite for Spectre-style timing
-    //    attacks. Workers are not available, but defense-in-depth applies.
-    //    V8 flags cannot disable it (stable spec feature), so remove from JS.
-    delete globalThis.SharedArrayBuffer;
-    delete globalThis.Atomics;
-})();
-"#;
+    /// True when no mitigation is enabled — `harden_runtime` is a no-op.
+    pub fn is_noop(&self) -> bool {
+        *self == Self::default()
+    }
+}
 
 // ── Base64 globals (atob / btoa) ────────────────────────────────────────
 

--- a/server/src/engine/mod.rs
+++ b/server/src/engine/mod.rs
@@ -22,6 +22,8 @@ pub mod subprocess;
 pub mod timers;
 pub mod wasm_stub;
 
+pub use console::HardeningConfig;
+
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -812,6 +814,8 @@ pub struct ExecutionConfig<'a> {
     pub console_tree: Option<sled::Tree>,
     pub module_loader_config: Option<&'a module_loader::ModuleLoaderConfig>,
     pub mcp_config: Option<&'a mcp_client::McpConfig>,
+    /// Per-mitigation sandbox hardening. Default is all-off (unhardened).
+    pub hardening: console::HardeningConfig,
 }
 
 impl<'a> ExecutionConfig<'a> {
@@ -829,7 +833,14 @@ impl<'a> ExecutionConfig<'a> {
             console_tree: None,
             module_loader_config: None,
             mcp_config: None,
+            hardening: console::HardeningConfig::default(),
         }
+    }
+
+    /// Set the per-mitigation sandbox hardening configuration.
+    pub fn hardening(mut self, hardening: console::HardeningConfig) -> Self {
+        self.hardening = hardening;
+        self
     }
 
     pub fn mcp_headers(mut self, mcp_headers: Option<serde_json::Value>) -> Self {
@@ -915,6 +926,7 @@ pub fn execute_stateless(
         console_tree,
         module_loader_config,
         mcp_config,
+        hardening,
     } = config;
     let oom_flag = Arc::new(AtomicBool::new(false));
 
@@ -1047,7 +1059,7 @@ pub fn execute_stateless(
                 }
                 // Harden sandbox: freeze ops, neutralize introspection, remove __bootstrap.
                 // Must run after all inject_* calls and before user code.
-                if let Err(e) = console::harden_runtime(&mut runtime) {
+                if let Err(e) = console::harden_runtime(&mut runtime, hardening) {
                     return Err(e);
                 }
                 execute_module(&rt, &mut runtime, code)
@@ -1096,6 +1108,7 @@ pub fn execute_stateful(
         console_tree,
         module_loader_config,
         mcp_config,
+        hardening,
     } = config;
     let oom_flag = Arc::new(AtomicBool::new(false));
 
@@ -1257,7 +1270,7 @@ pub fn execute_stateful(
                     }
                     // Harden sandbox: freeze ops, neutralize introspection, remove __bootstrap.
                     // Must run after all inject_* calls and before user code.
-                    if let Err(e) = console::harden_runtime(&mut runtime) {
+                    if let Err(e) = console::harden_runtime(&mut runtime, hardening) {
                         return Err(e);
                     }
                     execute_module(&rt, &mut runtime, code)
@@ -1374,6 +1387,9 @@ pub struct Engine {
     label_store: Option<Arc<fs_labels::LabelStore>>,
     /// Policy chain gating fs snapshot pointer moves (pull/push/reset/label).
     fs_snapshot_policy_chain: Option<Arc<opa::PolicyChain>>,
+    /// Per-mitigation sandbox hardening. Default is all-off (unhardened); each
+    /// mitigation is opt-in via the `--harden-*` CLI flags.
+    hardening: console::HardeningConfig,
 }
 
 /// Builder for `Engine::run_js()`. Only `code` is required; everything else
@@ -1542,6 +1558,7 @@ impl Engine {
             fs_store: None,
             label_store: None,
             fs_snapshot_policy_chain: None,
+            hardening: console::HardeningConfig::default(),
         }
     }
 
@@ -1580,12 +1597,20 @@ impl Engine {
             fs_store: None,
             label_store: None,
             fs_snapshot_policy_chain: None,
+            hardening: console::HardeningConfig::default(),
         }
     }
 
     /// Set the default max native memory for WASM modules without a per-module limit.
     pub fn with_wasm_default_max_bytes(mut self, bytes: usize) -> Self {
         self.wasm_default_max_bytes = bytes;
+        self
+    }
+
+    /// Set the per-mitigation sandbox hardening configuration. Defaults to
+    /// all-off; mitigations are opt-in via the `--harden-*` CLI flags.
+    pub fn with_hardening(mut self, hardening: console::HardeningConfig) -> Self {
+        self.hardening = hardening;
         self
     }
 
@@ -2309,6 +2334,7 @@ impl Engine {
                 let ih = isolate_handle.clone();
                 let wasm = self.wasm_modules.clone();
                 let wasm_default = self.wasm_default_max_bytes;
+                let hardening = self.hardening;
                 let fc = self.fetch_config.clone();
                 let fsc = self.fs_config.clone();
                 let mh = mcp_headers.clone();
@@ -2326,6 +2352,7 @@ impl Engine {
                         .maybe_fs_mount(fm)
                         .wasm_modules(&wasm)
                         .wasm_default_max_bytes(wasm_default)
+                        .hardening(hardening)
                         .maybe_fetch_config(fc.as_deref())
                         .maybe_fs_config(fsc.as_deref())
                         .mcp_headers(mh)
@@ -2410,6 +2437,7 @@ impl Engine {
                 let ih = isolate_handle.clone();
                 let wasm = self.wasm_modules.clone();
                 let wasm_default = self.wasm_default_max_bytes;
+                let hardening = self.hardening;
                 let fc = self.fetch_config.clone();
                 let fsc = self.fs_config.clone();
                 let mh = mcp_headers.clone();
@@ -2427,6 +2455,7 @@ impl Engine {
                         .maybe_fs_mount(fm)
                         .wasm_modules(&wasm)
                         .wasm_default_max_bytes(wasm_default)
+                        .hardening(hardening)
                         .maybe_fetch_config(fc.as_deref())
                         .maybe_fs_config(fsc.as_deref())
                         .mcp_headers(mh)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -239,6 +239,14 @@ async fn main() -> Result<()> {
     };
 
     let engine = engine.with_wasm_default_max_bytes(wasm_default_max_bytes);
+    // Sandbox hardening: all mitigations are opt-in (OFF by default → unhardened).
+    let engine = engine.with_hardening(engine::HardeningConfig {
+        freeze_ops: cli.harden_freeze_ops,
+        neutralize_proxy_details: cli.harden_neutralize_proxy_details,
+        neutralize_introspection: cli.harden_neutralize_introspection,
+        remove_bootstrap: cli.harden_remove_bootstrap,
+        remove_shared_memory: cli.harden_remove_shared_memory,
+    });
     let has_wasm_modules = !wasm_modules.is_empty();
     let engine = if has_wasm_modules { engine.with_wasm_modules(wasm_modules) } else { engine };
     let engine = if has_wasm_modules {

--- a/server/tests/sandbox_ops.rs
+++ b/server/tests/sandbox_ops.rs
@@ -7,7 +7,7 @@
 /// console.log() to capture output via sled and assert on the captured content.
 
 use std::sync::Once;
-use server::engine::ExecutionConfig;
+use server::engine::{ExecutionConfig, HardeningConfig};
 
 static INIT: Once = Once::new();
 
@@ -285,7 +285,9 @@ fn test_ops_are_frozen() {
     ensure_v8();
     let heap_bytes = 8 * 1024 * 1024;
     let (tree, tmp) = console_tree();
-    let config = ExecutionConfig::new(heap_bytes).console_tree(tree.clone());
+    let config = ExecutionConfig::new(heap_bytes)
+        .console_tree(tree.clone())
+        .hardening(HardeningConfig::all());
     let (result, _oom) = server::engine::execute_stateless(
         r#"console.log("frozen=" + Object.isFrozen(Deno.core.ops));"#,
         config,
@@ -305,7 +307,9 @@ fn test_bootstrap_not_accessible() {
     ensure_v8();
     let heap_bytes = 8 * 1024 * 1024;
     let (tree, tmp) = console_tree();
-    let config = ExecutionConfig::new(heap_bytes).console_tree(tree.clone());
+    let config = ExecutionConfig::new(heap_bytes)
+        .console_tree(tree.clone())
+        .hardening(HardeningConfig::all());
     let (result, _oom) = server::engine::execute_stateless(
         r#"console.log("bootstrap=" + typeof globalThis.__bootstrap);"#,
         config,
@@ -325,7 +329,9 @@ fn test_proxy_details_neutralized() {
     ensure_v8();
     let heap_bytes = 8 * 1024 * 1024;
     let (tree, tmp) = console_tree();
-    let config = ExecutionConfig::new(heap_bytes).console_tree(tree.clone());
+    let config = ExecutionConfig::new(heap_bytes)
+        .console_tree(tree.clone())
+        .hardening(HardeningConfig::all());
     let (result, _oom) = server::engine::execute_stateless(
         r#"
         const secret = { password: "hunter2" };
@@ -350,7 +356,9 @@ fn test_ops_not_replaceable() {
     ensure_v8();
     let heap_bytes = 8 * 1024 * 1024;
     let (tree, tmp) = console_tree();
-    let config = ExecutionConfig::new(heap_bytes).console_tree(tree.clone());
+    let config = ExecutionConfig::new(heap_bytes)
+        .console_tree(tree.clone())
+        .hardening(HardeningConfig::all());
     let (result, _oom) = server::engine::execute_stateless(
         // ES modules run in strict mode — assigning to a frozen property throws
         r#"
@@ -378,7 +386,9 @@ fn test_shared_array_buffer_disabled() {
     ensure_v8();
     let heap_bytes = 8 * 1024 * 1024;
     let (tree, tmp) = console_tree();
-    let config = ExecutionConfig::new(heap_bytes).console_tree(tree.clone());
+    let config = ExecutionConfig::new(heap_bytes)
+        .console_tree(tree.clone())
+        .hardening(HardeningConfig::all());
     let (result, _oom) = server::engine::execute_stateless(
         r#"
         try {
@@ -395,6 +405,88 @@ fn test_shared_array_buffer_disabled() {
     assert!(
         output.contains("sab=disabled"),
         "SharedArrayBuffer should be disabled, got: {}",
+        output,
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ── Opt-in defaults: with no HardeningConfig, mitigations are OFF ────────────
+// These lock in the opt-in posture: a default ExecutionConfig leaves the
+// runtime unhardened, so each primitive is present until a `--harden-*` flag
+// (HardeningConfig field) enables its removal.
+
+#[test]
+fn test_shared_array_buffer_available_by_default() {
+    ensure_v8();
+    let heap_bytes = 8 * 1024 * 1024;
+    let (tree, tmp) = console_tree();
+    // No .hardening(...) — default is all-off.
+    let config = ExecutionConfig::new(heap_bytes).console_tree(tree.clone());
+    let (result, _oom) = server::engine::execute_stateless(
+        r#"
+        try {
+            const sab = new SharedArrayBuffer(8);
+            console.log("sab=available");
+        } catch (e) {
+            console.log("sab=disabled");
+        }
+        "#,
+        config,
+    );
+    assert!(result.is_ok(), "Should succeed, got: {:?}", result);
+    let output = read_console(&tree);
+    assert!(
+        output.contains("sab=available"),
+        "SharedArrayBuffer should be available when hardening is off, got: {}",
+        output,
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn test_ops_not_frozen_by_default() {
+    ensure_v8();
+    let heap_bytes = 8 * 1024 * 1024;
+    let (tree, tmp) = console_tree();
+    let config = ExecutionConfig::new(heap_bytes).console_tree(tree.clone());
+    let (result, _oom) = server::engine::execute_stateless(
+        r#"console.log("frozen=" + Object.isFrozen(Deno.core.ops));"#,
+        config,
+    );
+    assert!(result.is_ok(), "Should succeed, got: {:?}", result);
+    let output = read_console(&tree);
+    assert!(
+        output.contains("frozen=false"),
+        "Deno.core.ops should not be frozen when hardening is off, got: {}",
+        output,
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn test_only_requested_mitigation_applies() {
+    ensure_v8();
+    let heap_bytes = 8 * 1024 * 1024;
+    let (tree, tmp) = console_tree();
+    // Enable ONLY remove_shared_memory: SAB goes away but ops stay unfrozen.
+    let config = ExecutionConfig::new(heap_bytes)
+        .console_tree(tree.clone())
+        .hardening(HardeningConfig {
+            remove_shared_memory: true,
+            ..HardeningConfig::default()
+        });
+    let (result, _oom) = server::engine::execute_stateless(
+        r#"
+        console.log("sab=" + (typeof SharedArrayBuffer === "undefined" ? "disabled" : "available"));
+        console.log("frozen=" + Object.isFrozen(Deno.core.ops));
+        "#,
+        config,
+    );
+    assert!(result.is_ok(), "Should succeed, got: {:?}", result);
+    let output = read_console(&tree);
+    assert!(
+        output.contains("sab=disabled") && output.contains("frozen=false"),
+        "Only the requested mitigation should apply, got: {}",
         output,
     );
     let _ = std::fs::remove_dir_all(&tmp);

--- a/site-docs/reference/cli-flags.md
+++ b/site-docs/reference/cli-flags.md
@@ -17,6 +17,7 @@ using the same help headings exposed by the CLI itself.
 - [Policy](#policy)
 - [Prompt](#prompt)
 - [Run JS File](#run-js-file)
+- [Sandbox](#sandbox)
 - [Storage (S3)](#storage-s3)
 - [WASM](#wasm)
 
@@ -292,6 +293,43 @@ Override the description advertised for the `run_js` tool in `tools/list`. The v
 Allow the `run_js` tool to read its code from a file on the server's own filesystem (the `file` parameter). OFF by default. When set, ANY path the server process can read is allowed — this is the easy "allow all" switch. For finer control, leave this off and configure a `run_js_file` policy in --policies-json instead (a Rego/OPA chain decides which paths are allowed); the policy input is `{ "operation": "read", "path": "<canonical path>" }`. This flag takes precedence over a configured run_js_file policy
 
 - Environment: `MCP_V8_ALLOW_RUN_JS_FILE`
+- Default: `false`
+
+## Sandbox
+
+### `--harden-freeze-ops`
+
+Freeze `Deno.core.ops` so user code cannot replace/intercept any op (e.g. a persistent trojan op surviving in stateful/snapshot mode)
+
+- Environment: `MCP_V8_HARDEN_FREEZE_OPS`
+- Default: `false`
+
+### `--harden-neutralize-proxy-details`
+
+Neutralize `op_get_proxy_details` (otherwise it bypasses `Proxy` handlers and can read a proxied target)
+
+- Environment: `MCP_V8_HARDEN_NEUTRALIZE_PROXY_DETAILS`
+- Default: `false`
+
+### `--harden-neutralize-introspection`
+
+Neutralize `op_memory_usage` + `op_is_terminal` (host info leaks)
+
+- Environment: `MCP_V8_HARDEN_NEUTRALIZE_INTROSPECTION`
+- Default: `false`
+
+### `--harden-remove-bootstrap`
+
+Remove `globalThis.__bootstrap` (event-loop hooks, primordials such as a pristine `Function` constructor, and internal registries)
+
+- Environment: `MCP_V8_HARDEN_REMOVE_BOOTSTRAP`
+- Default: `false`
+
+### `--harden-remove-shared-memory`
+
+Remove `globalThis.SharedArrayBuffer` + `globalThis.Atomics` — the high-resolution Spectre-timer prerequisite. NOTE: these are also the shared-memory primitives emscripten wasm-threads require, so leave this OFF to run pthreads-based WASM modules
+
+- Environment: `MCP_V8_HARDEN_REMOVE_SHARED_MEMORY`
 - Default: `false`
 
 ## Storage (S3)


### PR DESCRIPTION
## What

Splits the monolithic sandbox-hardening pass (introduced in `a1d644d`) into **five independently configurable mitigations, each OFF by default (opt-in)**.

The original `harden_runtime` always:
1. froze `Deno.core.ops`
2. neutralized `op_get_proxy_details` (Proxy-handler bypass)
3. neutralized `op_memory_usage` + `op_is_terminal` (info leaks)
4. removed `__bootstrap` (event-loop hooks, primordials, internals)
5. removed `SharedArrayBuffer` + `Atomics` (Spectre high-resolution-timer prerequisite)

Mitigation #5 also strips the exact primitives **emscripten pthreads-based WASM** requires (shared `WebAssembly.Memory` + `Atomics.wait/notify`), so threaded WASM modules (e.g. the in-process CraftOS emulator) can't run. Making each mitigation opt-in lets a deployment keep the ones it wants while allowing shared memory where threaded WASM is needed.

## How

- `console.rs`: `HardeningConfig` (`Default` = all off) drives a dynamically-built hardening script; `harden_runtime` is a no-op when nothing is enabled. Op-neutralization is still ordered before `Object.freeze`. Adds `HardeningConfig::all()` / `is_noop()`.
- `mod.rs`: threads `HardeningConfig` through `ExecutionConfig` (field + builder), `Engine` (field + `with_hardening` + both constructors) and both `spawn_blocking` build chains; re-exports `HardeningConfig`.
- `cli.rs` / `main.rs`: five `--harden-*` flags (Sandbox heading), each with an `MCP_V8_HARDEN_*` env var, default `false`, wired into the engine.
- `sandbox_ops.rs`: the 5 mitigation regression tests now opt in via `HardeningConfig::all()`; adds tests asserting the **opt-in default** leaves the primitives present (SAB available, ops unfrozen) and that enabling only one mitigation applies only that one.
- Regenerated `site-docs/reference/cli-flags.md`.

### New flags

| Flag | Env | Mitigation |
|---|---|---|
| `--harden-freeze-ops` | `MCP_V8_HARDEN_FREEZE_OPS` | Freeze `Deno.core.ops` |
| `--harden-neutralize-proxy-details` | `MCP_V8_HARDEN_NEUTRALIZE_PROXY_DETAILS` | `op_get_proxy_details` → undefined |
| `--harden-neutralize-introspection` | `MCP_V8_HARDEN_NEUTRALIZE_INTROSPECTION` | neutralize `op_memory_usage` / `op_is_terminal` |
| `--harden-remove-bootstrap` | `MCP_V8_HARDEN_REMOVE_BOOTSTRAP` | delete `__bootstrap` |
| `--harden-remove-shared-memory` | `MCP_V8_HARDEN_REMOVE_SHARED_MEMORY` | delete `SharedArrayBuffer` + `Atomics` (leave OFF for pthreads WASM) |

## ⚠️ Behavior change

This **flips the default posture to UNHARDENED**. Deployments relying on the old always-on hardening must now pass the relevant `--harden-*` flags (or the matching `MCP_V8_HARDEN_*` env vars).

## Testing

- `cargo check -p server` + `--tests`: clean (only pre-existing warnings).
- `cargo test -p server --test sandbox_ops -- --test-threads=1`: 17 passed — matches how CI's `Run Tests` runs (`test.yml` uses `--test-threads=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)