### PR TITLE
Add Node.js fs compatibility: symlinks, lstat, readlink, and fs.promises

### DIFF
--- a/.github/workflows/nixos-integration-test.yml
+++ b/.github/workflows/nixos-integration-test.yml
@@ -24,6 +24,8 @@ jobs:
             check: fetch-opa-test
           - name: Filesystem OPA Integration Test
             check: fs-opa-test
+          - name: Isomorphic-Git Integration Test
+            check: isomorphic-git-test
 
     steps:
       - name: Checkout code

--- a/flake.nix
+++ b/flake.nix
@@ -270,6 +270,10 @@
             inherit pkgs;
             mcp-js = self.packages.x86_64-linux.default;
           });
+          isomorphic-git-test = pkgs.nixosTest (import ./tests/nixos/isomorphic-git.nix {
+            inherit pkgs;
+            mcp-js = self.packages.x86_64-linux.default;
+          });
           docs-generated-check = pkgs.stdenvNoCC.mkDerivation {
             pname = "mcp-js-docs-generated-check";
             version = "0.1.0";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,6 +47,12 @@ in
       description = "Run in stateless mode (no heap persistence).";
     };
 
+    allowExternalModules = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Allow external module imports (npm:/jsr:/URL). Adds --allow-external-modules.";
+    };
+
     heartbeatInterval = lib.mkOption {
       type = lib.types.int;
       default = 200;
@@ -151,12 +157,14 @@ in
               cfg.join
             ];
 
+            externalModulesArgs = lib.optionals cfg.allowExternalModules [ "--allow-external-modules" ];
+
             policiesArgs = lib.optionals (cfg.policiesJson != null) [
               "--policies-json"
               "'${cfg.policiesJson}'"
             ];
           in
-          lib.concatStringsSep " " (baseArgs ++ storageArgs ++ peerArgs ++ advertiseArgs ++ joinArgs ++ policiesArgs);
+          lib.concatStringsSep " " (baseArgs ++ storageArgs ++ peerArgs ++ advertiseArgs ++ joinArgs ++ externalModulesArgs ++ policiesArgs);
 
         Restart = "on-failure";
         RestartSec = "2s";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -120,7 +120,9 @@ in
             ];
 
             storageArgs = lib.optionals (!cfg.stateless) [
-              "--directory-path"
+              "--heap-store"
+              "dir"
+              "--heap-dir"
               cfg.dataDir
               "--session-db-path"
               "${cfg.dataDir}/sessions"
@@ -139,8 +141,6 @@ in
               (lib.concatStringsSep "," cfg.peers)
             ];
 
-            statelessArgs = lib.optionals cfg.stateless [ "--stateless" ];
-
             advertiseArgs = lib.optionals (cfg.advertiseAddr != null) [
               "--advertise-addr"
               cfg.advertiseAddr
@@ -156,7 +156,7 @@ in
               "'${cfg.policiesJson}'"
             ];
           in
-          lib.concatStringsSep " " (baseArgs ++ storageArgs ++ peerArgs ++ statelessArgs ++ advertiseArgs ++ joinArgs ++ policiesArgs);
+          lib.concatStringsSep " " (baseArgs ++ storageArgs ++ peerArgs ++ advertiseArgs ++ joinArgs ++ policiesArgs);
 
         Restart = "on-failure";
         RestartSec = "2s";

--- a/scripts/check_docs_browser.py
+++ b/scripts/check_docs_browser.py
@@ -82,8 +82,8 @@ def main() -> int:
     chrome = find_chrome(args.chrome)
 
     checks = [
-        ("/", ["mcp-v8", "Quick Start"]),
-        ("/quick-start/overview/", ["Quick Start Overview"]),
+        ("/", ["mcp-v8", "Install"]),
+        ("/install/overview/", ["Install"]),
         ("/reference/http-api/", ["HTTP API"]),
         ("/reference/mcp-tools/", ["MCP Tools"]),
     ]

--- a/server/README.md
+++ b/server/README.md
@@ -881,14 +881,24 @@ await fs.writeFile("/tmp/out.txt", "hello");              // string data
 await fs.writeFile("/tmp/out.bin", uint8array);           // binary data
 await fs.appendFile("/tmp/out.txt", " world");
 const entries = await fs.readdir("/tmp");                  // string[]
-const info = await fs.stat("/tmp/data.txt");               // {size,isFile,isDirectory,...}
+const info = await fs.stat("/tmp/data.txt");               // Stats: info.isFile(), info.size, ...
+const link = await fs.lstat("/tmp/link");                  // Stats without following a symlink
 await fs.mkdir("/tmp/newdir", { recursive: true });
 await fs.rm("/tmp/data.txt");
 await fs.rm("/tmp/newdir", { recursive: true });
 await fs.rename("/tmp/old.txt", "/tmp/new.txt");
 await fs.copyFile("/tmp/a.txt", "/tmp/b.txt");
+await fs.symlink("/tmp/data.txt", "/tmp/link");            // symlink(target, path)
+const target = await fs.readlink("/tmp/link");
 const bool = await fs.exists("/tmp/data.txt");
 ```
+
+The same methods are also exposed under `fs.promises`, and `fs.stat`/`fs.lstat`
+return a Node `fs.Stats`-like object (`isFile()`, `isDirectory()`,
+`isSymbolicLink()`, plus `size`/`mode`/timestamps). Errors carry a Node-style
+`code` (e.g. `err.code === "ENOENT"`). This lets libraries that expect a Node
+`fs` / `fs.promises` interface — such as `isomorphic-git` — use the sandbox `fs`
+object directly.
 
 **1. Write a Rego policy**
 
@@ -919,7 +929,7 @@ allow if {
 ```
 
 The policy input includes:
-- `operation`: the filesystem operation being performed (e.g., `"readFile"`, `"writeFile"`, `"mkdir"`, `"rm"`, `"rename"`, `"copyFile"`, `"appendFile"`, `"readdir"`, `"stat"`, `"exists"`)
+- `operation`: the filesystem operation being performed (e.g., `"readFile"`, `"writeFile"`, `"mkdir"`, `"rm"`, `"rename"`, `"copyFile"`, `"appendFile"`, `"readdir"`, `"stat"`, `"lstat"`, `"symlink"`, `"readlink"`, `"exists"`)
 - `path`: the file or directory path being accessed
 - `destination`: (optional) the destination path for operations like `rename` and `copyFile`
 - `recursive`: (optional, boolean) whether a recursive operation was requested (for `mkdir` and `rm`)

--- a/server/README.md
+++ b/server/README.md
@@ -875,8 +875,8 @@ When the server is started with a Rego policy configuration, JavaScript code can
 The `fs` module supports the following operations:
 
 ```javascript
-const data = await fs.readFile("/tmp/data.txt");          // string (utf-8)
-const data = await fs.readFile("/tmp/data.bin", "buffer"); // Uint8Array
+const data = await fs.readFile("/tmp/data.bin");          // Uint8Array (Node default)
+const text = await fs.readFile("/tmp/data.txt", "utf8");  // string
 await fs.writeFile("/tmp/out.txt", "hello");              // string data
 await fs.writeFile("/tmp/out.bin", uint8array);           // binary data
 await fs.appendFile("/tmp/out.txt", " world");
@@ -951,8 +951,8 @@ The `policies.json` file should contain policy configuration objects. See the [P
 All `fs` operations return Promises and can be used with `await`:
 
 ```javascript
-// Read a file
-const content = await fs.readFile("/tmp/data.txt");
+// Read a file as text
+const content = await fs.readFile("/tmp/data.txt", "utf8");
 console.log(content);
 
 // Write a file
@@ -990,10 +990,10 @@ If a policy denies an operation, the Promise returned by the `fs` operation is r
 
 **Binary Data**
 
-When reading binary files, specify `"buffer"` as the encoding parameter:
+`fs.readFile` returns a `Uint8Array` by default (Node semantics), so binary files need no special argument:
 
 ```javascript
-const buffer = await fs.readFile("/tmp/image.png", "buffer");
+const buffer = await fs.readFile("/tmp/image.png");
 // buffer is a Uint8Array
 
 // Write binary data

--- a/server/src/engine/console.rs
+++ b/server/src/engine/console.rs
@@ -429,6 +429,83 @@ pub fn inject_web_apis_snapshot(runtime: &mut deno_core::JsRuntimeForSnapshot) -
 
 const WEB_APIS_JS: &str = r#"
 (function() {
+    // ── TextEncoder / TextDecoder (UTF-8) ───────────────────────────────
+    // deno_core's bare runtime does not ship deno_web, so these standard
+    // globals are absent. Many libraries (isomorphic-git, etc.) assume they
+    // exist; provide a compact, correct UTF-8 implementation.
+    if (typeof globalThis.TextEncoder === 'undefined') {
+        globalThis.TextEncoder = class TextEncoder {
+            get encoding() { return 'utf-8'; }
+            encode(input) {
+                const str = String(input === undefined ? '' : input);
+                const out = [];
+                for (let i = 0; i < str.length; i++) {
+                    let code = str.charCodeAt(i);
+                    if (code >= 0xD800 && code <= 0xDBFF && i + 1 < str.length) {
+                        const next = str.charCodeAt(i + 1);
+                        if (next >= 0xDC00 && next <= 0xDFFF) {
+                            code = 0x10000 + ((code - 0xD800) << 10) + (next - 0xDC00);
+                            i++;
+                        }
+                    }
+                    if (code < 0x80) {
+                        out.push(code);
+                    } else if (code < 0x800) {
+                        out.push(0xC0 | (code >> 6), 0x80 | (code & 0x3F));
+                    } else if (code < 0x10000) {
+                        out.push(0xE0 | (code >> 12), 0x80 | ((code >> 6) & 0x3F), 0x80 | (code & 0x3F));
+                    } else {
+                        out.push(0xF0 | (code >> 18), 0x80 | ((code >> 12) & 0x3F), 0x80 | ((code >> 6) & 0x3F), 0x80 | (code & 0x3F));
+                    }
+                }
+                return new Uint8Array(out);
+            }
+            encodeInto(str, dest) {
+                const enc = this.encode(str);
+                const n = Math.min(enc.length, dest.length);
+                dest.set(enc.subarray(0, n));
+                return { read: str.length, written: n };
+            }
+        };
+    }
+    if (typeof globalThis.TextDecoder === 'undefined') {
+        globalThis.TextDecoder = class TextDecoder {
+            constructor(label, options) {
+                this.encoding = (label ? String(label) : 'utf-8').toLowerCase();
+                this.fatal = !!(options && options.fatal);
+                this.ignoreBOM = !!(options && options.ignoreBOM);
+            }
+            decode(input) {
+                if (input === undefined || input === null) return '';
+                let bytes;
+                if (input instanceof Uint8Array) bytes = input;
+                else if (input instanceof ArrayBuffer) bytes = new Uint8Array(input);
+                else if (ArrayBuffer.isView(input)) bytes = new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+                else bytes = new Uint8Array(input);
+                let out = '';
+                let i = 0;
+                const n = bytes.length;
+                while (i < n) {
+                    const c = bytes[i++];
+                    if (c < 0x80) {
+                        out += String.fromCharCode(c);
+                    } else if (c >= 0xC0 && c < 0xE0) {
+                        out += String.fromCharCode(((c & 0x1F) << 6) | (bytes[i++] & 0x3F));
+                    } else if (c >= 0xE0 && c < 0xF0) {
+                        out += String.fromCharCode(((c & 0x0F) << 12) | ((bytes[i++] & 0x3F) << 6) | (bytes[i++] & 0x3F));
+                    } else if (c >= 0xF0) {
+                        let cp = ((c & 0x07) << 18) | ((bytes[i++] & 0x3F) << 12) | ((bytes[i++] & 0x3F) << 6) | (bytes[i++] & 0x3F);
+                        cp -= 0x10000;
+                        out += String.fromCharCode(0xD800 + (cp >> 10), 0xDC00 + (cp & 0x3FF));
+                    }
+                    // Lone continuation bytes are skipped (lenient, non-fatal).
+                }
+                if (this.ignoreBOM === false && out.charCodeAt(0) === 0xFEFF) out = out.slice(1);
+                return out;
+            }
+        };
+    }
+
     globalThis.Blob = function Blob(parts, options) {
         const opt = options || {};
         this.type = opt.type || '';

--- a/server/src/engine/fetch.rs
+++ b/server/src/engine/fetch.rs
@@ -488,15 +488,42 @@ const FETCH_JS_WRAPPER: &str = r#"
             }
         }
 
-        let body;
-        if (typeof FormData !== 'undefined' && opts.body instanceof FormData) {
-            const serialized = opts.body._serialize();
-            body = serialized.body;
-            if (!('content-type' in normalizedHeaders)) {
-                normalizedHeaders['content-type'] = 'multipart/form-data; boundary=' + serialized.boundary;
+        // Request/response bodies cross the op boundary base64-encoded so binary
+        // payloads (e.g. git smart-HTTP packfiles) are preserved.
+        function _b64FromBytes(bytes) {
+            let bin = '';
+            const CHUNK = 0x8000;
+            for (let i = 0; i < bytes.length; i += CHUNK) {
+                bin += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
             }
-        } else {
-            body = opts.body !== undefined ? String(opts.body) : "";
+            return btoa(bin);
+        }
+        function _bytesFromB64(b64) {
+            const bin = atob(b64 || '');
+            const out = new Uint8Array(bin.length);
+            for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i) & 0xff;
+            return out;
+        }
+
+        let body = "";
+        if (opts.body !== undefined && opts.body !== null) {
+            let bytes;
+            if (typeof FormData !== 'undefined' && opts.body instanceof FormData) {
+                const serialized = opts.body._serialize();
+                bytes = new TextEncoder().encode(serialized.body);
+                if (!('content-type' in normalizedHeaders)) {
+                    normalizedHeaders['content-type'] = 'multipart/form-data; boundary=' + serialized.boundary;
+                }
+            } else if (opts.body instanceof Uint8Array) {
+                bytes = opts.body;
+            } else if (ArrayBuffer.isView(opts.body)) {
+                bytes = new Uint8Array(opts.body.buffer, opts.body.byteOffset, opts.body.byteLength);
+            } else if (opts.body instanceof ArrayBuffer) {
+                bytes = new Uint8Array(opts.body);
+            } else {
+                bytes = new TextEncoder().encode(String(opts.body));
+            }
+            body = _b64FromBytes(bytes);
         }
 
         const headersJson = JSON.stringify(normalizedHeaders);
@@ -505,40 +532,93 @@ const FETCH_JS_WRAPPER: &str = r#"
         const rawResult = await Deno.core.ops.op_fetch(resource, method, headersJson, body);
         const result = JSON.parse(rawResult);
 
-        const responseBody = result.body;
+        // result.body is base64 (bodyEncoding: "base64"); decode once to bytes.
+        const responseBytes = _bytesFromB64(result.body);
         const responseHeaders = new Headers(result.headers);
-
-        return {
-            ok: result.status >= 200 && result.status < 300,
-            status: result.status,
-            statusText: result.statusText,
-            url: result.url,
-            headers: responseHeaders,
-            redirected: result.redirected || false,
-            type: 'basic',
-            bodyUsed: false,
-            text: function() { return Promise.resolve(responseBody); },
-            json: function() { return Promise.resolve(JSON.parse(responseBody)); },
-            blob: function() { return Promise.resolve(new Blob([responseBody], { type: responseHeaders.get('content-type') || '' })); },
-            clone: function() {
-                return {
-                    ok: this.ok,
-                    status: this.status,
-                    statusText: this.statusText,
-                    url: this.url,
-                    headers: this.headers,
-                    redirected: this.redirected,
-                    type: this.type,
-                    bodyUsed: false,
-                    text: function() { return Promise.resolve(responseBody); },
-                    json: function() { return Promise.resolve(JSON.parse(responseBody)); },
-                    blob: function() { return Promise.resolve(new Blob([responseBody], { type: responseHeaders.get('content-type') || '' })); },
-                };
-            }
+        const decodeText = function() { return new TextDecoder().decode(responseBytes); };
+        const toArrayBuffer = function() {
+            return responseBytes.buffer.slice(
+                responseBytes.byteOffset,
+                responseBytes.byteOffset + responseBytes.byteLength
+            );
         };
+        const mkResponse = function() {
+            return {
+                ok: result.status >= 200 && result.status < 300,
+                status: result.status,
+                statusText: result.statusText,
+                url: result.url,
+                headers: responseHeaders,
+                redirected: result.redirected || false,
+                type: 'basic',
+                bodyUsed: false,
+                text: function() { return Promise.resolve(decodeText()); },
+                json: function() { return Promise.resolve(JSON.parse(decodeText())); },
+                arrayBuffer: function() { return Promise.resolve(toArrayBuffer()); },
+                bytes: function() { return Promise.resolve(new Uint8Array(responseBytes)); },
+                blob: function() { return Promise.resolve(new Blob([decodeText()], { type: responseHeaders.get('content-type') || '' })); },
+                clone: function() { return mkResponse(); },
+            };
+        };
+        return mkResponse();
     };
 })();
 "#;
+
+// ── base64 (binary-safe body transfer over the op boundary) ─────────────
+//
+// Request and response bodies cross the JS↔Rust op boundary as base64 so that
+// binary payloads (e.g. git's smart-HTTP packfiles) survive intact — a plain
+// String body would be mangled by UTF-8 (de)coding. Standard RFC 4648 alphabet
+// with padding; the JS side uses btoa/atob, which match.
+
+const B64_TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+fn b64_encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
+        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(B64_TABLE[((n >> 18) & 63) as usize] as char);
+        out.push(B64_TABLE[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 { B64_TABLE[((n >> 6) & 63) as usize] as char } else { '=' });
+        out.push(if chunk.len() > 2 { B64_TABLE[(n & 63) as usize] as char } else { '=' });
+    }
+    out
+}
+
+fn b64_decode(s: &str) -> Result<Vec<u8>, String> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let mut buf = 0u32;
+    let mut bits = 0u32;
+    let mut out = Vec::with_capacity(s.len() / 4 * 3);
+    for &c in s.as_bytes() {
+        match c {
+            b'=' => break,
+            b'\n' | b'\r' | b' ' | b'\t' => continue,
+            _ => {}
+        }
+        let v = val(c).ok_or_else(|| "fetch: invalid base64 in body".to_string())?;
+        buf = (buf << 6) | v;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+        }
+    }
+    Ok(out)
+}
 
 // ── Pure-Rust fetch implementation (no V8 types) ─────────────────────────
 
@@ -606,7 +686,10 @@ async fn do_fetch(
     }
 
     if let Some(body) = body {
-        req_builder = req_builder.body(body);
+        // The JS wrapper sends the request body base64-encoded so binary
+        // payloads (git packfiles, etc.) are preserved.
+        let body_bytes = b64_decode(&body)?;
+        req_builder = req_builder.body(body_bytes);
     }
 
     let resp = req_builder
@@ -633,10 +716,13 @@ async fn do_fetch(
         })
         .collect();
 
-    let resp_body = resp
-        .text()
+    // Read the response body as raw bytes and hand it back base64-encoded, so
+    // binary responses (git smart-HTTP, images, …) survive the op boundary.
+    let resp_bytes = resp
+        .bytes()
         .await
         .map_err(|e| format!("fetch: failed to read response body: {}", e))?;
+    let resp_body = b64_encode(&resp_bytes);
 
     let result = serde_json::json!({
         "status": status,
@@ -644,6 +730,7 @@ async fn do_fetch(
         "url": final_url,
         "headers": resp_headers,
         "body": resp_body,
+        "bodyEncoding": "base64",
         "redirected": final_url != url_str,
     });
 

--- a/server/src/engine/fetch.rs
+++ b/server/src/engine/fetch.rs
@@ -1295,13 +1295,17 @@ allow if {{
         .await
         .expect("fetch should succeed when policy sees injected auth");
 
+        // The response body is base64-encoded (binary-safe op boundary); decode
+        // it before parsing the echo server's JSON.
+        let response_value: serde_json::Value =
+            serde_json::from_str(&response).expect("response JSON should parse");
+        let body_b64 = response_value
+            .get("body")
+            .and_then(Value::as_str)
+            .expect("response body should exist");
+        let body_bytes = super::b64_decode(body_b64).expect("response body should base64-decode");
         let payload: FetchResponseBody =
-            serde_json::from_str::<serde_json::Value>(&response)
-                .expect("response JSON should parse")
-                .get("body")
-                .and_then(Value::as_str)
-                .map(|body| serde_json::from_str(body).expect("response body JSON should parse"))
-                .expect("response body should exist");
+            serde_json::from_slice(&body_bytes).expect("response body JSON should parse");
 
         assert!(payload.ok);
         assert_eq!(
@@ -1399,7 +1403,8 @@ allow if {{
             url,
             "POST".to_string(),
             headers_json,
-            Some(body.clone()),
+            // do_fetch expects the request body base64-encoded (binary-safe).
+            Some(super::b64_encode(body.as_bytes())),
             Arc::new(PolicyChain::new(vec![], EvalMode::All)),
             reqwest::Client::new(),
             vec![],
@@ -1416,5 +1421,25 @@ allow if {{
         assert!(reqs[0].1.contains("hello world"));
         assert!(reqs[0].1.contains("name=\"f\""));
         assert!(reqs[0].1.contains("filename=\"test.txt\""));
+    }
+
+    #[test]
+    fn test_b64_round_trips_binary() {
+        // Every byte value must survive the base64 round-trip used to carry
+        // fetch request/response bodies across the op boundary.
+        let all_bytes: Vec<u8> = (0u16..=255).map(|b| b as u8).collect();
+        assert_eq!(
+            super::b64_decode(&super::b64_encode(&all_bytes)).expect("decode"),
+            all_bytes
+        );
+        // Exercise every padding case (len % 3 == 0/1/2) and empty input.
+        for n in [0usize, 1, 2, 3, 4, 5, 100, 255] {
+            let d: Vec<u8> = (0..n).map(|i| (i * 31 + 7) as u8).collect();
+            assert_eq!(
+                super::b64_decode(&super::b64_encode(&d)).unwrap(),
+                d,
+                "round-trip failed for len {n}"
+            );
+        }
     }
 }

--- a/server/src/engine/fs.rs
+++ b/server/src/engine/fs.rs
@@ -9,8 +9,8 @@
 //!
 //! Available operations (all return Promises):
 //! ```js
-//! const data = await fs.readFile("/tmp/data.txt");          // string (utf-8)
-//! const data = await fs.readFile("/tmp/data.bin", "buffer"); // Uint8Array
+//! const data = await fs.readFile("/tmp/data.bin");          // Uint8Array (Node default)
+//! const text = await fs.readFile("/tmp/data.txt", "utf8");  // string
 //! await fs.writeFile("/tmp/out.txt", "hello");              // string data
 //! await fs.writeFile("/tmp/out.bin", uint8array);           // binary data
 //! await fs.appendFile("/tmp/out.txt", " world");
@@ -957,17 +957,12 @@ const FS_JS_WRAPPER: &str = r#"
         return await call('op_fs_read_file_buffer', path);
     }
 
-    // Top-level fs.readFile keeps mcp-v8's historical contract: UTF-8 text by
-    // default, raw bytes only when the encoding is the literal "buffer".
-    async function readFile(path, encoding) {
-        if (encoding === 'buffer') return await readFileBuffer(path);
-        return await readFileText(path);
-    }
-
-    // Node's fs.promises.readFile contract: a Uint8Array by default, a string
-    // when a text encoding is supplied. This is what Node-style consumers (e.g.
-    // isomorphic-git reading binary git objects) expect.
-    async function readFilePromises(path, options) {
+    // Node's readFile contract: a Uint8Array by default, a string when a text
+    // encoding ('utf8', 'utf-8', …) is supplied. fs.readFile and
+    // fs.promises.readFile share this single behavior, so binary reads (e.g.
+    // isomorphic-git git objects) are lossless and text reads opt in via an
+    // encoding argument — exactly as Node behaves.
+    async function readFile(path, options) {
         const enc = readEncoding(options);
         if (enc && enc !== 'buffer') return await readFileText(path);
         return await readFileBuffer(path);
@@ -1085,7 +1080,7 @@ const FS_JS_WRAPPER: &str = r#"
     // isomorphic-git among them — detect this enumerable property and bind its
     // methods, so every method they look up must exist.
     const promises = {
-        readFile: readFilePromises,
+        readFile,
         writeFile, appendFile, readdir, stat, lstat, mkdir, rm, rmdir,
         unlink, rename, copyFile, readlink, symlink, exists,
     };

--- a/server/src/engine/fs.rs
+++ b/server/src/engine/fs.rs
@@ -15,14 +15,26 @@
 //! await fs.writeFile("/tmp/out.bin", uint8array);           // binary data
 //! await fs.appendFile("/tmp/out.txt", " world");
 //! const entries = await fs.readdir("/tmp");                  // string[]
-//! const info = await fs.stat("/tmp/data.txt");               // {size,isFile,isDirectory,...}
+//! const info = await fs.stat("/tmp/data.txt");               // Stats: {size,isFile(),isDirectory(),...}
+//! const info = await fs.lstat("/tmp/link");                  // Stats without following symlinks
 //! await fs.mkdir("/tmp/newdir", { recursive: true });
 //! await fs.rm("/tmp/data.txt");
 //! await fs.rm("/tmp/newdir", { recursive: true });
 //! await fs.rename("/tmp/old.txt", "/tmp/new.txt");
 //! await fs.copyFile("/tmp/a.txt", "/tmp/b.txt");
+//! await fs.symlink("/tmp/data.txt", "/tmp/link");            // symlink(target, path)
+//! const target = await fs.readlink("/tmp/link");
 //! const bool = await fs.exists("/tmp/data.txt");
 //! ```
+//!
+//! ## Node-style compatibility
+//!
+//! The same methods are also exposed under `fs.promises`, and `fs.stat`/
+//! `fs.lstat` return a Node `fs.Stats`-like object with `isFile()`,
+//! `isDirectory()`, and `isSymbolicLink()` predicate methods. Errors carry a
+//! Node-style `code` (e.g. `ENOENT`, `EEXIST`). Together these let libraries
+//! that expect a Node `fs`/`fs.promises` interface — such as `isomorphic-git` —
+//! consume the sandbox `fs` object directly.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -157,7 +169,7 @@ async fn op_fs_read_file_text(
             return Err(JsErrorBox::generic(format!("fs.readFile: {}: ENOENT", path)));
         }
         let content = std::fs::read(&path)
-            .map_err(|e| JsErrorBox::generic(format!("fs.readFile: {}: {}", path, e)))?;
+            .map_err(|e| JsErrorBox::generic(io_err("readFile", &path, &e)))?;
         return String::from_utf8(content)
             .map_err(|e| JsErrorBox::generic(format!("fs.readFile: invalid UTF-8 in {}: {}", path, e)));
     }
@@ -166,7 +178,7 @@ async fn op_fs_read_file_text(
         check_policy(&config.policy_chain, "readFile", &path, None, None, Some("utf8"), config.mcp_headers.as_ref()).await?;
 
         let content = tokio::fs::read(&path).await
-            .map_err(|e| format!("fs.readFile: {}: {}", path, e))?;
+            .map_err(|e| io_err("readFile", &path, &e))?;
 
         String::from_utf8(content)
             .map_err(|e| format!("fs.readFile: invalid UTF-8 in {}: {}", path, e))
@@ -203,14 +215,14 @@ async fn op_fs_read_file_buffer(
             return Err(JsErrorBox::generic(format!("fs.readFile: {}: ENOENT", path)));
         }
         return std::fs::read(&path)
-            .map_err(|e| JsErrorBox::generic(format!("fs.readFile: {}: {}", path, e)));
+            .map_err(|e| JsErrorBox::generic(io_err("readFile", &path, &e)));
     }
 
     tokio::spawn(async move {
         check_policy(&config.policy_chain, "readFile", &path, None, None, Some("buffer"), config.mcp_headers.as_ref()).await?;
 
         tokio::fs::read(&path).await
-            .map_err(|e| format!("fs.readFile: {}: {}", path, e))
+            .map_err(|e| io_err("readFile", &path, &e))
     })
     .await
     .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
@@ -244,7 +256,7 @@ async fn op_fs_write_file_text(
         check_policy(&config.policy_chain, "writeFile", &path, None, None, None, config.mcp_headers.as_ref()).await?;
 
         tokio::fs::write(&path, data.as_bytes()).await
-            .map_err(|e| format!("fs.writeFile: {}: {}", path, e))?;
+            .map_err(|e| io_err("writeFile", &path, &e))?;
 
         Ok("{}".to_string())
     })
@@ -278,7 +290,7 @@ async fn op_fs_write_file_buffer(
         check_policy(&config.policy_chain, "writeFile", &path, None, None, None, config.mcp_headers.as_ref()).await?;
 
         tokio::fs::write(&path, &data).await
-            .map_err(|e| format!("fs.writeFile: {}: {}", path, e))?;
+            .map_err(|e| io_err("writeFile", &path, &e))?;
 
         Ok("{}".to_string())
     })
@@ -320,10 +332,10 @@ async fn op_fs_append_file(
             .append(true)
             .open(&path)
             .await
-            .map_err(|e| format!("fs.appendFile: {}: {}", path, e))?;
+            .map_err(|e| io_err("appendFile", &path, &e))?;
 
         file.write_all(data.as_bytes()).await
-            .map_err(|e| format!("fs.appendFile: {}: {}", path, e))?;
+            .map_err(|e| io_err("appendFile", &path, &e))?;
 
         Ok("{}".to_string())
     })
@@ -357,10 +369,10 @@ async fn op_fs_readdir(
 
         let mut entries = Vec::new();
         let mut dir = tokio::fs::read_dir(&path).await
-            .map_err(|e| format!("fs.readdir: {}: {}", path, e))?;
+            .map_err(|e| io_err("readdir", &path, &e))?;
 
         while let Some(entry) = dir.next_entry().await
-            .map_err(|e| format!("fs.readdir: {}: {}", path, e))? {
+            .map_err(|e| io_err("readdir", &path, &e))? {
             if let Some(name) = entry.file_name().to_str() {
                 entries.push(name.to_string());
             }
@@ -398,34 +410,128 @@ async fn op_fs_stat(
         check_policy(&config.policy_chain, "stat", &path, None, None, None, config.mcp_headers.as_ref()).await?;
 
         let metadata = tokio::fs::metadata(&path).await
-            .map_err(|e| format!("fs.stat: {}: {}", path, e))?;
+            .map_err(|e| io_err("stat", &path, &e))?;
 
-        let modified = metadata.modified().ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_millis() as f64);
-        let accessed = metadata.accessed().ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_millis() as f64);
-        let created = metadata.created().ok()
-            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| d.as_millis() as f64);
-
-        let result = deno_core::serde_json::json!({
-            "size": metadata.len(),
-            "isFile": metadata.is_file(),
-            "isDirectory": metadata.is_dir(),
-            "isSymlink": metadata.file_type().is_symlink(),
-            "readonly": metadata.permissions().readonly(),
-            "mtimeMs": modified,
-            "atimeMs": accessed,
-            "birthtimeMs": created,
-        });
-
-        Ok(result.to_string())
+        Ok(metadata_stat_json(&metadata))
     })
     .await
     .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
     .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Stat a path **without** following a final symlink (Node `fs.lstat`).
+#[op2(async)]
+#[string]
+async fn op_fs_lstat(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+) -> Result<String, JsErrorBox> {
+    let config = extract_config(&state)?;
+    let mount = extract_mount(&state);
+
+    // Mount branch runs inline (current-thread isolate runtime; deno_unsync needs it).
+    // The overlay never follows symlinks, so its stat already has lstat semantics.
+    if let Some(m) = mount {
+        check_policy(&config.policy_chain, "lstat", &path, None, None, None, config.mcp_headers.as_ref())
+            .await
+            .map_err(JsErrorBox::generic)?;
+        let s = m.0.lock().await.stat(Path::new(&path)).await
+            .map_err(|e| JsErrorBox::generic(format!("fs.lstat: {}: {}", path, e)))?;
+        return Ok(mount_stat_json(&s));
+    }
+
+    tokio::spawn(async move {
+        check_policy(&config.policy_chain, "lstat", &path, None, None, None, config.mcp_headers.as_ref()).await?;
+
+        let metadata = tokio::fs::symlink_metadata(&path).await
+            .map_err(|e| io_err("lstat", &path, &e))?;
+
+        Ok(metadata_stat_json(&metadata))
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Read a symlink's target, returned as a string.
+#[op2(async)]
+#[string]
+async fn op_fs_readlink(
+    state: Rc<RefCell<OpState>>,
+    #[string] path: String,
+) -> Result<String, JsErrorBox> {
+    let config = extract_config(&state)?;
+    let mount = extract_mount(&state);
+
+    // Mount branch runs inline (current-thread isolate runtime; deno_unsync needs it).
+    if let Some(m) = mount {
+        check_policy(&config.policy_chain, "readlink", &path, None, None, None, config.mcp_headers.as_ref())
+            .await
+            .map_err(JsErrorBox::generic)?;
+        let target = m.0.lock().await.readlink(Path::new(&path)).await
+            .map_err(|e| JsErrorBox::generic(format!("fs.readlink: {}: {}", path, e)))?;
+        return Ok(target.to_string_lossy().into_owned());
+    }
+
+    tokio::spawn(async move {
+        check_policy(&config.policy_chain, "readlink", &path, None, None, None, config.mcp_headers.as_ref()).await?;
+
+        let target = tokio::fs::read_link(&path).await
+            .map_err(|e| io_err("readlink", &path, &e))?;
+
+        Ok(target.to_string_lossy().into_owned())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+/// Create a symlink at `link` pointing to `target` (Node `fs.symlink(target, path)`).
+#[op2(async)]
+#[string]
+async fn op_fs_symlink(
+    state: Rc<RefCell<OpState>>,
+    #[string] target: String,
+    #[string] link: String,
+) -> Result<String, JsErrorBox> {
+    let config = extract_config(&state)?;
+    let mount = extract_mount(&state);
+
+    // The policy gates on the link path being created; the target is carried as
+    // the destination so a policy can constrain both sides.
+    if let Some(m) = mount {
+        check_policy(&config.policy_chain, "symlink", &link, Some(&target), None, None, config.mcp_headers.as_ref())
+            .await
+            .map_err(JsErrorBox::generic)?;
+        m.0.lock().await.symlink(Path::new(&target), Path::new(&link)).await
+            .map_err(|e| JsErrorBox::generic(format!("fs.symlink: {} -> {}: {}", link, target, e)))?;
+        return Ok("{}".to_string());
+    }
+
+    tokio::spawn(async move {
+        check_policy(&config.policy_chain, "symlink", &link, Some(&target), None, None, config.mcp_headers.as_ref()).await?;
+
+        symlink_impl(&target, &link).await
+            .map_err(|e| io_err2("symlink", &link, &target, &e))?;
+
+        Ok("{}".to_string())
+    })
+    .await
+    .map_err(|e| JsErrorBox::generic(format!("fs task join error: {}", e)))?
+    .map_err(|e: String| JsErrorBox::generic(e))
+}
+
+#[cfg(unix)]
+async fn symlink_impl(target: &str, link: &str) -> std::io::Result<()> {
+    tokio::fs::symlink(target, link).await
+}
+
+#[cfg(not(unix))]
+async fn symlink_impl(_target: &str, _link: &str) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "symlinks are not supported on this platform",
+    ))
 }
 
 /// Create a directory.
@@ -457,7 +563,7 @@ async fn op_fs_mkdir(
             tokio::fs::create_dir_all(&path).await
         } else {
             tokio::fs::create_dir(&path).await
-        }.map_err(|e| format!("fs.mkdir: {}: {}", path, e))?;
+        }.map_err(|e| io_err("mkdir", &path, &e))?;
 
         Ok("{}".to_string())
     })
@@ -492,7 +598,7 @@ async fn op_fs_rm(
         check_policy(&config.policy_chain, "rm", &path, None, Some(recursive), None, config.mcp_headers.as_ref()).await?;
 
         let metadata = tokio::fs::metadata(&path).await
-            .map_err(|e| format!("fs.rm: {}: {}", path, e))?;
+            .map_err(|e| io_err("rm", &path, &e))?;
 
         if metadata.is_dir() {
             if recursive {
@@ -502,7 +608,7 @@ async fn op_fs_rm(
             }
         } else {
             tokio::fs::remove_file(&path).await
-        }.map_err(|e| format!("fs.rm: {}: {}", path, e))?;
+        }.map_err(|e| io_err("rm", &path, &e))?;
 
         Ok("{}".to_string())
     })
@@ -536,7 +642,7 @@ async fn op_fs_rename(
         check_policy(&config.policy_chain, "rename", &from, Some(&to), None, None, config.mcp_headers.as_ref()).await?;
 
         tokio::fs::rename(&from, &to).await
-            .map_err(|e| format!("fs.rename: {} -> {}: {}", from, to, e))?;
+            .map_err(|e| io_err2("rename", &from, &to, &e))?;
 
         Ok("{}".to_string())
     })
@@ -571,7 +677,7 @@ async fn op_fs_copy_file(
         check_policy(&config.policy_chain, "copyFile", &from, Some(&to), None, None, config.mcp_headers.as_ref()).await?;
 
         tokio::fs::copy(&from, &to).await
-            .map_err(|e| format!("fs.copyFile: {} -> {}: {}", from, to, e))?;
+            .map_err(|e| io_err2("copyFile", &from, &to, &e))?;
 
         Ok("{}".to_string())
     })
@@ -643,7 +749,7 @@ async fn op_fs_write_stream_open(
         check_policy(&config.policy_chain, "writeFile", &path, None, None, None, config.mcp_headers.as_ref()).await?;
 
         let f = tokio::fs::File::create(&path).await
-            .map_err(|e| format!("fs.createWriteStream: {}: {}", path, e))?;
+            .map_err(|e| io_err("createWriteStream", &path, &e))?;
         let ow = OpenWrite::Real(f);
         let mut g = writers.0.lock().await;
         let id = g.next;
@@ -751,6 +857,9 @@ deno_core::extension!(
         op_fs_append_file,
         op_fs_readdir,
         op_fs_stat,
+        op_fs_lstat,
+        op_fs_readlink,
+        op_fs_symlink,
         op_fs_mkdir,
         op_fs_rm,
         op_fs_rename,
@@ -781,99 +890,210 @@ pub fn inject_fs(runtime: &mut JsRuntime) -> Result<(), String> {
 
 const FS_JS_WRAPPER: &str = r#"
 (function() {
+    const ops = Deno.core.ops;
+
+    // Known Node.js filesystem error codes. The Rust ops embed the matching
+    // token in their error message; we surface it as `err.code` so callers that
+    // branch on it (isomorphic-git, graceful-fs, …) behave as they do on Node.
+    const FS_CODES = /\b(ENOENT|EEXIST|EACCES|EPERM|ENOTDIR|EISDIR|ENOTEMPTY|EROFS|ELOOP|EINVAL|EXDEV|ENOSPC|EMFILE|ENFILE|EBADF|ENOSYS)\b/;
+    function tagError(e) {
+        try {
+            if (e && typeof e === 'object' && (e.code === undefined || e.code === null)) {
+                const msg = typeof e.message === 'string' ? e.message : String(e);
+                const m = msg.match(FS_CODES);
+                if (m) e.code = m[1];
+            }
+        } catch (_) { /* never let tagging mask the original error */ }
+        return e;
+    }
+    async function call(name, ...args) {
+        try {
+            return await ops[name](...args);
+        } catch (e) {
+            throw tagError(e);
+        }
+    }
+
+    // A Node `fs.Stats`-like object: the data fields plus the is*() predicate
+    // methods consumers call. Built from the JSON the stat/lstat ops return.
+    function makeStats(o) {
+        const n = (v) => (typeof v === 'number' ? v : 0);
+        const size = n(o.size);
+        const stats = {
+            dev: n(o.dev), ino: n(o.ino), mode: n(o.mode), nlink: n(o.nlink) || 1,
+            uid: n(o.uid), gid: n(o.gid), rdev: 0,
+            size: size, blksize: 4096, blocks: Math.ceil(size / 512),
+            atimeMs: n(o.atimeMs), mtimeMs: n(o.mtimeMs),
+            ctimeMs: n(o.ctimeMs), birthtimeMs: n(o.birthtimeMs),
+            atime: new Date(n(o.atimeMs)), mtime: new Date(n(o.mtimeMs)),
+            ctime: new Date(n(o.ctimeMs)), birthtime: new Date(n(o.birthtimeMs)),
+            readonly: !!o.readonly,
+        };
+        const isFile = !!o.isFile, isDirectory = !!o.isDirectory, isSymbolicLink = !!o.isSymlink;
+        stats.isFile = function() { return isFile; };
+        stats.isDirectory = function() { return isDirectory; };
+        stats.isSymbolicLink = function() { return isSymbolicLink; };
+        stats.isBlockDevice = function() { return false; };
+        stats.isCharacterDevice = function() { return false; };
+        stats.isFIFO = function() { return false; };
+        stats.isSocket = function() { return false; };
+        return stats;
+    }
+
+    // Node's readFile encoding argument: a string ('utf8') or an options object
+    // ({ encoding }). Returns null for "no encoding given".
+    function readEncoding(opt) {
+        if (typeof opt === 'string') return opt;
+        if (opt && typeof opt === 'object' && opt.encoding) return opt.encoding;
+        return null;
+    }
+
+    async function readFileText(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.readFile: path must be a string');
+        return await call('op_fs_read_file_text', path);
+    }
+    async function readFileBuffer(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.readFile: path must be a string');
+        return await call('op_fs_read_file_buffer', path);
+    }
+
+    // Top-level fs.readFile keeps mcp-v8's historical contract: UTF-8 text by
+    // default, raw bytes only when the encoding is the literal "buffer".
+    async function readFile(path, encoding) {
+        if (encoding === 'buffer') return await readFileBuffer(path);
+        return await readFileText(path);
+    }
+
+    // Node's fs.promises.readFile contract: a Uint8Array by default, a string
+    // when a text encoding is supplied. This is what Node-style consumers (e.g.
+    // isomorphic-git reading binary git objects) expect.
+    async function readFilePromises(path, options) {
+        const enc = readEncoding(options);
+        if (enc && enc !== 'buffer') return await readFileText(path);
+        return await readFileBuffer(path);
+    }
+
+    async function writeFile(path, data) {
+        if (typeof path !== 'string') throw new TypeError('fs.writeFile: path must be a string');
+        if (data instanceof Uint8Array) {
+            await call('op_fs_write_file_buffer', path, data);
+        } else if (ArrayBuffer.isView(data)) {
+            await call('op_fs_write_file_buffer', path, new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+        } else if (data instanceof ArrayBuffer) {
+            await call('op_fs_write_file_buffer', path, new Uint8Array(data));
+        } else {
+            await call('op_fs_write_file_text', path, String(data));
+        }
+    }
+
+    async function appendFile(path, data) {
+        if (typeof path !== 'string') throw new TypeError('fs.appendFile: path must be a string');
+        await call('op_fs_append_file', path, String(data));
+    }
+
+    async function readdir(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.readdir: path must be a string');
+        return JSON.parse(await call('op_fs_readdir', path));
+    }
+
+    async function stat(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.stat: path must be a string');
+        return makeStats(JSON.parse(await call('op_fs_stat', path)));
+    }
+
+    async function lstat(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.lstat: path must be a string');
+        return makeStats(JSON.parse(await call('op_fs_lstat', path)));
+    }
+
+    async function mkdir(path, options) {
+        if (typeof path !== 'string') throw new TypeError('fs.mkdir: path must be a string');
+        await call('op_fs_mkdir', path, (options && options.recursive) ? 1 : 0);
+    }
+
+    async function rm(path, options) {
+        if (typeof path !== 'string') throw new TypeError('fs.rm: path must be a string');
+        await call('op_fs_rm', path, (options && options.recursive) ? 1 : 0);
+    }
+
+    // Node's fs.rmdir; recursive removal of a directory tree when requested.
+    async function rmdir(path, options) {
+        if (typeof path !== 'string') throw new TypeError('fs.rmdir: path must be a string');
+        await call('op_fs_rm', path, (options && options.recursive) ? 1 : 0);
+    }
+
+    async function unlink(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.unlink: path must be a string');
+        await call('op_fs_rm', path, 0);
+    }
+
+    async function rename(oldPath, newPath) {
+        if (typeof oldPath !== 'string') throw new TypeError('fs.rename: oldPath must be a string');
+        if (typeof newPath !== 'string') throw new TypeError('fs.rename: newPath must be a string');
+        await call('op_fs_rename', oldPath, newPath);
+    }
+
+    async function copyFile(src, dest) {
+        if (typeof src !== 'string') throw new TypeError('fs.copyFile: src must be a string');
+        if (typeof dest !== 'string') throw new TypeError('fs.copyFile: dest must be a string');
+        await call('op_fs_copy_file', src, dest);
+    }
+
+    async function readlink(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.readlink: path must be a string');
+        return await call('op_fs_readlink', path);
+    }
+
+    // Node signature: symlink(target, path) creates a link at `path` -> `target`.
+    async function symlink(target, path) {
+        if (typeof target !== 'string') throw new TypeError('fs.symlink: target must be a string');
+        if (typeof path !== 'string') throw new TypeError('fs.symlink: path must be a string');
+        await call('op_fs_symlink', target, path);
+    }
+
+    async function exists(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.exists: path must be a string');
+        return (await call('op_fs_exists', path)) === 'true';
+    }
+
+    // Streaming write handle: feed a large file in pieces so neither JS nor the
+    // runtime ever holds the whole thing. The file becomes visible only after
+    // close().
+    async function createWriteStream(path) {
+        if (typeof path !== 'string') throw new TypeError('fs.createWriteStream: path must be a string');
+        const id = await call('op_fs_write_stream_open', path);
+        let closed = false;
+        return {
+            write: async function(chunk) {
+                if (closed) throw new Error('fs.createWriteStream: write after close');
+                if (chunk instanceof Uint8Array) {
+                    await call('op_fs_write_stream_chunk_buffer', id, chunk);
+                } else {
+                    await call('op_fs_write_stream_chunk_text', id, String(chunk));
+                }
+            },
+            close: async function() {
+                if (closed) return;
+                closed = true;
+                await call('op_fs_write_stream_close', id);
+            },
+        };
+    }
+
+    // The promise-based surface mirroring Node's `fs.promises`. readFile follows
+    // Node semantics here (bytes by default). Libraries that wrap a filesystem —
+    // isomorphic-git among them — detect this enumerable property and bind its
+    // methods, so every method they look up must exist.
+    const promises = {
+        readFile: readFilePromises,
+        writeFile, appendFile, readdir, stat, lstat, mkdir, rm, rmdir,
+        unlink, rename, copyFile, readlink, symlink, exists,
+    };
+
     globalThis.fs = {
-        readFile: async function(path, encoding) {
-            if (typeof path !== 'string') throw new TypeError('fs.readFile: path must be a string');
-            if (encoding === 'buffer') {
-                return await Deno.core.ops.op_fs_read_file_buffer(path);
-            }
-            return await Deno.core.ops.op_fs_read_file_text(path);
-        },
-
-        writeFile: async function(path, data) {
-            if (typeof path !== 'string') throw new TypeError('fs.writeFile: path must be a string');
-            if (data instanceof Uint8Array) {
-                await Deno.core.ops.op_fs_write_file_buffer(path, data);
-            } else {
-                await Deno.core.ops.op_fs_write_file_text(path, String(data));
-            }
-        },
-
-        appendFile: async function(path, data) {
-            if (typeof path !== 'string') throw new TypeError('fs.appendFile: path must be a string');
-            await Deno.core.ops.op_fs_append_file(path, String(data));
-        },
-
-        readdir: async function(path) {
-            if (typeof path !== 'string') throw new TypeError('fs.readdir: path must be a string');
-            const raw = await Deno.core.ops.op_fs_readdir(path);
-            return JSON.parse(raw);
-        },
-
-        stat: async function(path) {
-            if (typeof path !== 'string') throw new TypeError('fs.stat: path must be a string');
-            const raw = await Deno.core.ops.op_fs_stat(path);
-            return JSON.parse(raw);
-        },
-
-        mkdir: async function(path, options) {
-            if (typeof path !== 'string') throw new TypeError('fs.mkdir: path must be a string');
-            const recursive = (options && options.recursive) ? 1 : 0;
-            await Deno.core.ops.op_fs_mkdir(path, recursive);
-        },
-
-        rm: async function(path, options) {
-            if (typeof path !== 'string') throw new TypeError('fs.rm: path must be a string');
-            const recursive = (options && options.recursive) ? 1 : 0;
-            await Deno.core.ops.op_fs_rm(path, recursive);
-        },
-
-        unlink: async function(path) {
-            if (typeof path !== 'string') throw new TypeError('fs.unlink: path must be a string');
-            await Deno.core.ops.op_fs_rm(path, 0);
-        },
-
-        rename: async function(oldPath, newPath) {
-            if (typeof oldPath !== 'string') throw new TypeError('fs.rename: oldPath must be a string');
-            if (typeof newPath !== 'string') throw new TypeError('fs.rename: newPath must be a string');
-            await Deno.core.ops.op_fs_rename(oldPath, newPath);
-        },
-
-        copyFile: async function(src, dest) {
-            if (typeof src !== 'string') throw new TypeError('fs.copyFile: src must be a string');
-            if (typeof dest !== 'string') throw new TypeError('fs.copyFile: dest must be a string');
-            await Deno.core.ops.op_fs_copy_file(src, dest);
-        },
-
-        exists: async function(path) {
-            if (typeof path !== 'string') throw new TypeError('fs.exists: path must be a string');
-            const raw = await Deno.core.ops.op_fs_exists(path);
-            return raw === 'true';
-        },
-
-        // Streaming write handle: feed a large file in pieces so neither JS nor
-        // the runtime ever holds the whole thing. The file becomes visible only
-        // after close().
-        createWriteStream: async function(path) {
-            if (typeof path !== 'string') throw new TypeError('fs.createWriteStream: path must be a string');
-            const id = await Deno.core.ops.op_fs_write_stream_open(path);
-            let closed = false;
-            return {
-                write: async function(chunk) {
-                    if (closed) throw new Error('fs.createWriteStream: write after close');
-                    if (chunk instanceof Uint8Array) {
-                        await Deno.core.ops.op_fs_write_stream_chunk_buffer(id, chunk);
-                    } else {
-                        await Deno.core.ops.op_fs_write_stream_chunk_text(id, String(chunk));
-                    }
-                },
-                close: async function() {
-                    if (closed) return;
-                    closed = true;
-                    await Deno.core.ops.op_fs_write_stream_close(id);
-                },
-            };
-        },
+        readFile, writeFile, appendFile, readdir, stat, lstat, mkdir, rm, rmdir,
+        unlink, rename, copyFile, readlink, symlink, exists, createWriteStream,
+        promises,
     };
 })();
 "#;
@@ -903,16 +1123,131 @@ fn extract_writers(state: &Rc<RefCell<OpState>>) -> Result<FsWriters, JsErrorBox
         .ok_or_else(|| JsErrorBox::generic("fs: internal error — no write-stream registry"))
 }
 
+/// Map a `std::io::Error` to a Node.js-style error code (`ENOENT`, `EEXIST`,
+/// …). Returns `None` for kinds without a well-known POSIX name. The JS wrapper
+/// surfaces this token as `err.code` so callers that branch on it (isomorphic-git,
+/// etc.) behave the same as on Node.
+fn io_code(e: &std::io::Error) -> Option<&'static str> {
+    use std::io::ErrorKind::*;
+    Some(match e.kind() {
+        NotFound => "ENOENT",
+        PermissionDenied => "EACCES",
+        AlreadyExists => "EEXIST",
+        NotADirectory => "ENOTDIR",
+        IsADirectory => "EISDIR",
+        DirectoryNotEmpty => "ENOTEMPTY",
+        ReadOnlyFilesystem => "EROFS",
+        Unsupported => "ENOSYS",
+        _ => return None,
+    })
+}
+
+/// Format a single-path fs io error with the Node-style code embedded as a
+/// token the JS wrapper can extract: `fs.<op>: <path>: <CODE>: <message>` (the
+/// `<CODE>:` segment is omitted when the kind is unmapped).
+fn io_err(op: &str, path: &str, e: &std::io::Error) -> String {
+    match io_code(e) {
+        Some(code) => format!("fs.{op}: {path}: {code}: {e}"),
+        None => format!("fs.{op}: {path}: {e}"),
+    }
+}
+
+/// Like [`io_err`] but for two-path operations (`rename`, `copyFile`, `symlink`).
+fn io_err2(op: &str, from: &str, to: &str, e: &std::io::Error) -> String {
+    match io_code(e) {
+        Some(code) => format!("fs.{op}: {from} -> {to}: {code}: {e}"),
+        None => format!("fs.{op}: {from} -> {to}: {e}"),
+    }
+}
+
+/// Build the JSON stat blob fs.stat / fs.lstat return, from host metadata. The
+/// JS wrapper turns this into a Node `fs.Stats`-like object (with `isFile()` etc.).
+fn metadata_stat_json(metadata: &std::fs::Metadata) -> String {
+    let to_ms = |t: std::io::Result<std::time::SystemTime>| {
+        t.ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as f64)
+    };
+    let modified = to_ms(metadata.modified());
+    let accessed = to_ms(metadata.accessed());
+    let created = to_ms(metadata.created());
+
+    // Unix metadata carries the fields Node consumers read (mode/ino/uid/…);
+    // elsewhere synthesize a plausible mode from the file type so callers that
+    // derive type from `mode` still classify the entry correctly.
+    #[cfg(unix)]
+    let (mode, ino, dev, nlink, uid, gid, ctime_ms) = {
+        use std::os::unix::fs::MetadataExt;
+        let ctime_ms = metadata.ctime() as f64 * 1000.0 + metadata.ctime_nsec() as f64 / 1.0e6;
+        (
+            metadata.mode(),
+            metadata.ino(),
+            metadata.dev(),
+            metadata.nlink(),
+            metadata.uid(),
+            metadata.gid(),
+            Some(ctime_ms),
+        )
+    };
+    #[cfg(not(unix))]
+    let (mode, ino, dev, nlink, uid, gid, ctime_ms): (u32, u64, u64, u64, u32, u32, Option<f64>) = {
+        let mode = if metadata.is_dir() {
+            0o040755
+        } else if metadata.file_type().is_symlink() {
+            0o120777
+        } else {
+            0o100644
+        };
+        (mode, 0, 0, 1, 0, 0, modified)
+    };
+
+    deno_core::serde_json::json!({
+        "size": metadata.len(),
+        "isFile": metadata.is_file(),
+        "isDirectory": metadata.is_dir(),
+        "isSymlink": metadata.file_type().is_symlink(),
+        "readonly": metadata.permissions().readonly(),
+        "mode": mode,
+        "ino": ino,
+        "dev": dev,
+        "nlink": nlink,
+        "uid": uid,
+        "gid": gid,
+        "mtimeMs": modified,
+        "atimeMs": accessed,
+        "ctimeMs": ctime_ms,
+        "birthtimeMs": created,
+    })
+    .to_string()
+}
+
 /// Build the JSON stat blob fs.stat returns, from overlay metadata.
 fn mount_stat_json(s: &super::fs_mount::Stat) -> String {
+    let is_symlink = s.symlink.is_some();
+    // Synthesize a mode with the file-type bits set so consumers that derive
+    // type from `mode` (e.g. git tree builders) classify it correctly.
+    let mode = if s.is_dir {
+        0o040000 | (s.mode & 0o777)
+    } else if is_symlink {
+        0o120000 | (s.mode & 0o777)
+    } else {
+        0o100000 | (s.mode & 0o777)
+    };
     deno_core::serde_json::json!({
         "size": s.size,
-        "isFile": !s.is_dir,
+        "isFile": !s.is_dir && !is_symlink,
         "isDirectory": s.is_dir,
-        "isSymlink": s.symlink.is_some(),
+        "isSymlink": is_symlink,
         "readonly": false,
+        "mode": mode,
+        "ino": 0,
+        "dev": 0,
+        "nlink": 1,
+        "uid": 0,
+        "gid": 0,
         "mtimeMs": null,
         "atimeMs": null,
+        "ctimeMs": null,
         "birthtimeMs": null,
     })
     .to_string()

--- a/server/src/engine/fs_mount.rs
+++ b/server/src/engine/fs_mount.rs
@@ -9,7 +9,7 @@
 //! content-addressed tree lazily, and `push` rewrites only the changed nodes.
 //! So a session over a multi-TB snapshot costs O(touched paths), not O(total).
 
-use crate::engine::fs_store::{Entry, FsStore};
+use crate::engine::fs_store::{Content, Entry, FsStore};
 use crate::engine::fs_tree::{components_of, path_of};
 use blake3::Hash;
 use std::collections::{BTreeSet, HashMap};
@@ -206,6 +206,37 @@ impl SessionMount {
     /// of the files they contain. It succeeds so callers can mkdir-then-write.
     pub async fn mkdir(&mut self, _p: &Path) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    /// Create a symlink at `link` pointing to `target`. Stored as an entry whose
+    /// `symlink` field records the target and whose bytes are the target path,
+    /// so the symlink survives a `push` and round-trips through the content
+    /// store like any other file.
+    pub async fn symlink(&mut self, target: &Path, link: &Path) -> anyhow::Result<()> {
+        let target_bytes = target.to_string_lossy().into_owned().into_bytes();
+        let entry = Entry {
+            mode: 0o120777,
+            size: target_bytes.len() as u64,
+            content: Content::Inline(target_bytes),
+            symlink: Some(target.to_path_buf()),
+        };
+        self.upper
+            .insert(path_of(&components_of(link)), Write::Data(entry));
+        Ok(())
+    }
+
+    /// Read a symlink's target. Mirrors Node `fs.readlink`: `EINVAL` when the
+    /// path exists but is not a symlink, `ENOENT` when it is absent.
+    pub async fn readlink(&self, p: &Path) -> anyhow::Result<PathBuf> {
+        let comps = components_of(p);
+        let key = path_of(&comps);
+        match self.effective(&comps, &key).await? {
+            Some(e) => match e.symlink {
+                Some(t) => Ok(t),
+                None => anyhow::bail!("EINVAL: {} is not a symlink", key.display()),
+            },
+            None => anyhow::bail!("ENOENT: {}", key.display()),
+        }
     }
 
     pub async fn rename(&mut self, from: &Path, to: &Path) -> anyhow::Result<()> {

--- a/server/src/run_js_tool_description.md
+++ b/server/src/run_js_tool_description.md
@@ -77,7 +77,7 @@ Always pin versions for reproducible results. Dynamic `import()` is also support
 When the server is configured with policies, JavaScript code can use an `fs` module providing Node.js-compatible file operations. Every operation is evaluated against a Rego policy before execution.
 
 **Available operations:**
-- `await fs.readFile(path, [encoding])` — Read file as UTF-8 string (default) or `Uint8Array` (if `encoding="buffer"`)
+- `await fs.readFile(path, [encoding])` — Read file as a `Uint8Array` (default, Node semantics) or a string (if a text encoding like `"utf8"` is given)
 - `await fs.writeFile(path, data)` — Write string or `Uint8Array` to file
 - `await fs.appendFile(path, data)` — Append data to file
 - `await fs.readdir(path)` — List directory contents

--- a/server/src/run_js_tool_secure.md
+++ b/server/src/run_js_tool_secure.md
@@ -76,7 +76,7 @@ Always pin versions for reproducible results. Dynamic `import()` is also support
 When the server is configured with policies, JavaScript code can use an `fs` module providing Node.js-compatible file operations. Every operation is evaluated against a Rego policy before execution.
 
 **Available operations:**
-- `await fs.readFile(path, [encoding])` — Read file as UTF-8 string (default) or `Uint8Array` (if `encoding="buffer"`)
+- `await fs.readFile(path, [encoding])` — Read file as a `Uint8Array` (default, Node semantics) or a string (if a text encoding like `"utf8"` is given)
 - `await fs.writeFile(path, data)` — Write string or `Uint8Array` to file
 - `await fs.appendFile(path, data)` — Append data to file
 - `await fs.readdir(path)` — List directory contents

--- a/server/src/run_js_tool_stateless.md
+++ b/server/src/run_js_tool_stateless.md
@@ -51,7 +51,7 @@ Always pin versions for reproducible results. Dynamic `import()` is also support
 When the server is configured with policies, JavaScript code can use an `fs` module providing Node.js-compatible file operations. Every operation is evaluated against a Rego policy before execution.
 
 **Available operations:**
-- `await fs.readFile(path, [encoding])` — Read file as UTF-8 string (default) or `Uint8Array` (if `encoding="buffer"`)
+- `await fs.readFile(path, [encoding])` — Read file as a `Uint8Array` (default, Node semantics) or a string (if a text encoding like `"utf8"` is given)
 - `await fs.writeFile(path, data)` — Write string or `Uint8Array` to file
 - `await fs.appendFile(path, data)` — Append data to file
 - `await fs.readdir(path)` — List directory contents

--- a/server/tests/fs_node_compat.rs
+++ b/server/tests/fs_node_compat.rs
@@ -1,0 +1,253 @@
+//! Node-compatibility of the sandbox `fs` object.
+//!
+//! These lock in the contract that lets promise-based, Node-style filesystem
+//! consumers (e.g. `isomorphic-git`) use the sandbox `fs` directly:
+//!   * `fs.promises` is an enumerable namespace exposing every method such a
+//!     library binds (readFile/writeFile/mkdir/rmdir/unlink/stat/lstat/readdir/
+//!     readlink/symlink) — so its `*.bind(...)` wrapping never hits `undefined`;
+//!   * `fs.stat`/`fs.lstat` return a `fs.Stats`-like object with `isFile()` /
+//!     `isDirectory()` / `isSymbolicLink()` predicate methods;
+//!   * `fs.promises.readFile` returns bytes by default (Node semantics);
+//!   * rejected operations carry a Node-style `err.code` (e.g. `ENOENT`).
+//!
+//! Driven through `execute_stateless` against the real filesystem (a temp dir),
+//! with assertions read back from captured `console.log` output.
+
+use std::sync::Once;
+
+use server::engine::fs::FsConfig;
+use server::engine::opa::{EvalMode, PolicyChain};
+use server::engine::{initialize_v8, ExecutionConfig, HardeningConfig};
+
+static INIT: Once = Once::new();
+
+fn ensure_v8() {
+    INIT.call_once(initialize_v8);
+}
+
+/// An fs config whose policy chain allows every operation (empty chain in
+/// `All` mode is vacuously true).
+fn allow_all_fs() -> FsConfig {
+    FsConfig::new(std::sync::Arc::new(PolicyChain::new(vec![], EvalMode::All)))
+}
+
+/// A fresh temp directory that exists on disk; returned as a string path.
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "mcp-fs-node-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+fn console_tree() -> (sled::Tree, std::path::PathBuf) {
+    let tmp = std::env::temp_dir().join(format!(
+        "mcp-fs-node-console-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let db = sled::open(&tmp).expect("open sled db");
+    let tree = db.open_tree("console").expect("open tree");
+    (tree, tmp)
+}
+
+fn read_console(tree: &sled::Tree) -> String {
+    let mut buf = Vec::new();
+    for entry in tree.iter().flatten() {
+        buf.extend_from_slice(&entry.1);
+    }
+    String::from_utf8_lossy(&buf).to_string()
+}
+
+/// Run `code` with `fs` enabled (real filesystem) and return captured console.
+fn run_fs(code: &str) -> String {
+    run_fs_hardened(code, HardeningConfig::default())
+}
+
+/// As [`run_fs`], but with an explicit sandbox-hardening configuration.
+fn run_fs_hardened(code: &str, hardening: HardeningConfig) -> String {
+    let (tree, tmp) = console_tree();
+    let fsc = allow_all_fs();
+    let config = ExecutionConfig::new(32 * 1024 * 1024)
+        .console_tree(tree.clone())
+        .maybe_fs_config(Some(&fsc))
+        .hardening(hardening);
+    let (result, _oom) = server::engine::execute_stateless(code, config);
+    assert!(result.is_ok(), "execution failed: {:?}", result);
+    let out = read_console(&tree);
+    let _ = std::fs::remove_dir_all(&tmp);
+    out
+}
+
+#[test]
+fn fs_promises_namespace_is_present_and_bindable() {
+    ensure_v8();
+    // Mirrors how isomorphic-git's FileSystem wrapper detects and binds a
+    // filesystem: it reads `fs.promises` (must be an enumerable own property)
+    // and binds each method. Before the fix, the missing methods made
+    // `fs.promises.lstat.bind(...)` throw "Cannot read properties of undefined
+    // (reading 'bind')".
+    let out = run_fs(
+        r#"
+        const desc = Object.getOwnPropertyDescriptor(fs, 'promises');
+        console.log("enumerable=" + !!(desc && desc.enumerable));
+        function wrapLikeIsomorphicGit(fs) {
+            const promises = Object.getOwnPropertyDescriptor(fs, 'promises');
+            if (!(promises && promises.enumerable)) throw new Error("no enumerable promises");
+            const o = {};
+            o._readFile = fs.promises.readFile.bind(fs.promises);
+            o._writeFile = fs.promises.writeFile.bind(fs.promises);
+            o._mkdir = fs.promises.mkdir.bind(fs.promises);
+            o._rmdir = fs.promises.rmdir.bind(fs.promises);
+            o._unlink = fs.promises.unlink.bind(fs.promises);
+            o._stat = fs.promises.stat.bind(fs.promises);
+            o._lstat = fs.promises.lstat.bind(fs.promises);
+            o._readdir = fs.promises.readdir.bind(fs.promises);
+            o._readlink = fs.promises.readlink.bind(fs.promises);
+            o._symlink = fs.promises.symlink.bind(fs.promises);
+            return o;
+        }
+        try {
+            wrapLikeIsomorphicGit(fs);
+            console.log("wrap=ok");
+        } catch (e) {
+            console.log("wrap=err:" + e.message);
+        }
+        "#,
+    );
+    assert!(out.contains("enumerable=true"), "fs.promises must be enumerable, got: {out}");
+    assert!(
+        out.contains("wrap=ok"),
+        "isomorphic-git-style binding must not throw, got: {out}"
+    );
+}
+
+#[test]
+fn fs_promises_roundtrip_stats_and_error_codes() {
+    ensure_v8();
+    let dir = temp_dir("rt");
+    let dir_s = dir.to_str().unwrap();
+    let code = format!(
+        r#"(async () => {{
+            const dir = {dir:?};
+            await fs.promises.mkdir(dir + "/sub", {{ recursive: true }});
+            await fs.promises.writeFile(dir + "/sub/a.txt", "hello");
+
+            // Node semantics: default read returns bytes, encoding returns text.
+            const buf = await fs.promises.readFile(dir + "/sub/a.txt");
+            console.log("isU8=" + (buf instanceof Uint8Array));
+            console.log("bytes=" + String.fromCharCode.apply(null, Array.from(buf)));
+            const txt = await fs.promises.readFile(dir + "/sub/a.txt", "utf8");
+            console.log("isStr=" + (typeof txt === "string") + ",txt=" + txt);
+
+            // Stats object with predicate methods.
+            const fst = await fs.promises.stat(dir + "/sub/a.txt");
+            console.log("file_isFile=" + fst.isFile() + ",file_isDir=" + fst.isDirectory()
+                + ",file_isSym=" + fst.isSymbolicLink() + ",size=" + fst.size);
+            const dst = await fs.promises.lstat(dir + "/sub");
+            console.log("dir_isDir=" + dst.isDirectory() + ",dir_isFile=" + dst.isFile());
+
+            // Missing path rejects with a Node-style code.
+            try {{
+                await fs.promises.readFile(dir + "/nope.txt");
+                console.log("missing=no-error");
+            }} catch (e) {{
+                console.log("missing_code=" + e.code);
+            }}
+
+            // mkdir of an existing dir rejects with EEXIST (non-recursive).
+            try {{
+                await fs.promises.mkdir(dir + "/sub");
+                console.log("mkdir=no-error");
+            }} catch (e) {{
+                console.log("mkdir_code=" + e.code);
+            }}
+        }})()"#,
+        dir = dir_s,
+    );
+    let out = run_fs(&code);
+    assert!(out.contains("isU8=true"), "default promises.readFile must return Uint8Array, got: {out}");
+    assert!(out.contains("bytes=hello"), "byte content mismatch, got: {out}");
+    assert!(out.contains("isStr=true,txt=hello"), "utf8 read must return string, got: {out}");
+    assert!(
+        out.contains("file_isFile=true,file_isDir=false,file_isSym=false,size=5"),
+        "Stats predicates wrong for file, got: {out}"
+    );
+    assert!(out.contains("dir_isDir=true,dir_isFile=false"), "Stats predicates wrong for dir, got: {out}");
+    assert!(out.contains("missing_code=ENOENT"), "missing file must surface ENOENT, got: {out}");
+    assert!(out.contains("mkdir_code=EEXIST"), "mkdir of existing dir must surface EEXIST, got: {out}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn fs_symlink_lstat_readlink_roundtrip() {
+    ensure_v8();
+    let dir = temp_dir("sym");
+    let dir_s = dir.to_str().unwrap();
+    let code = format!(
+        r#"(async () => {{
+            const dir = {dir:?};
+            await fs.promises.writeFile(dir + "/target.txt", "T");
+            // Node signature: symlink(target, path).
+            await fs.promises.symlink(dir + "/target.txt", dir + "/link.txt");
+
+            const ls = await fs.promises.lstat(dir + "/link.txt");
+            console.log("link_isSym=" + ls.isSymbolicLink() + ",link_isFile=" + ls.isFile());
+
+            // stat() follows the link to the regular file.
+            const st = await fs.promises.stat(dir + "/link.txt");
+            console.log("target_isFile=" + st.isFile() + ",target_isSym=" + st.isSymbolicLink());
+
+            const tgt = await fs.promises.readlink(dir + "/link.txt");
+            console.log("readlink_ok=" + (tgt === dir + "/target.txt"));
+        }})()"#,
+        dir = dir_s,
+    );
+    let out = run_fs(&code);
+    assert!(out.contains("link_isSym=true,link_isFile=false"), "lstat must report a symlink, got: {out}");
+    assert!(out.contains("target_isFile=true,target_isSym=false"), "stat must follow the link, got: {out}");
+    assert!(out.contains("readlink_ok=true"), "readlink must return the target, got: {out}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn fs_node_compat_survives_full_hardening() {
+    ensure_v8();
+    // The fs wrapper dispatches through a captured `Deno.core.ops` reference;
+    // full hardening freezes that object. A frozen op table stays callable, so
+    // the promises surface and error-code tagging must keep working.
+    let dir = temp_dir("hard");
+    let dir_s = dir.to_str().unwrap();
+    let code = format!(
+        r#"(async () => {{
+            const dir = {dir:?};
+            const d = Object.getOwnPropertyDescriptor(fs, "promises");
+            console.log("frozen_ops=" + Object.isFrozen(Deno.core.ops));
+            console.log("enumerable=" + !!(d && d.enumerable));
+            await fs.promises.writeFile(dir + "/h.txt", "hi");
+            const buf = await fs.promises.readFile(dir + "/h.txt");
+            console.log("len=" + buf.length);
+            try {{
+                await fs.promises.readFile(dir + "/absent");
+                console.log("missing=no-error");
+            }} catch (e) {{
+                console.log("missing_code=" + e.code);
+            }}
+        }})()"#,
+        dir = dir_s,
+    );
+    let out = run_fs_hardened(&code, HardeningConfig::all());
+    assert!(out.contains("frozen_ops=true"), "ops should be frozen under full hardening, got: {out}");
+    assert!(out.contains("enumerable=true"), "fs.promises must stay enumerable, got: {out}");
+    assert!(out.contains("len=2"), "promises.readFile must work under hardening, got: {out}");
+    assert!(out.contains("missing_code=ENOENT"), "error codes must work under hardening, got: {out}");
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/server/tests/fs_snapshot_e2e.rs
+++ b/server/tests/fs_snapshot_e2e.rs
@@ -176,6 +176,54 @@ async fn run_without_fs_handle_has_no_fs_ca_id() {
 }
 
 #[tokio::test]
+async fn overlay_symlink_lstat_readlink_and_node_compat() {
+    ensure_v8();
+    let h = build_harness();
+
+    // Exercises the overlay (mount) branch of the Node-compatibility surface:
+    // fs.promises, symlink/lstat/readlink, Stats predicate methods, and the
+    // ENOENT code on a miss. The script throws on any mismatch, so a clean
+    // completion (a returned fs CA id) is the assertion.
+    let ca = run(
+        &h.engine,
+        r#"(async () => {
+            // fs.promises must be an enumerable own property so libraries detect it.
+            const d = Object.getOwnPropertyDescriptor(fs, "promises");
+            if (!(d && d.enumerable)) throw new Error("fs.promises must be enumerable");
+
+            await fs.promises.writeFile("/repo/target.txt", "T");
+            // Node signature: symlink(target, path).
+            await fs.promises.symlink("/repo/target.txt", "/repo/link.txt");
+
+            const ls = await fs.promises.lstat("/repo/link.txt");
+            if (!ls.isSymbolicLink()) throw new Error("lstat should report a symlink");
+            if (ls.isFile()) throw new Error("a symlink must not report isFile()");
+
+            const tgt = await fs.promises.readlink("/repo/link.txt");
+            if (tgt !== "/repo/target.txt") throw new Error("readlink mismatch: " + tgt);
+
+            const st = await fs.promises.stat("/repo/target.txt");
+            if (!st.isFile()) throw new Error("target should be a file");
+            if (st.isDirectory()) throw new Error("target should not be a directory");
+
+            let code = null;
+            try { await fs.promises.readFile("/repo/missing.txt"); }
+            catch (e) { code = e.code; }
+            if (code !== "ENOENT") throw new Error("expected ENOENT, got " + code);
+        })()"#,
+        Some("main"),
+    )
+    .await
+    .expect("overlay node-compat flow should yield an fs CA id");
+
+    // The symlink persists in the pushed snapshot and reads back as its target.
+    let id = blake3::Hash::from_bytes(parse_ca_hex(&ca).expect("valid ca hex"));
+    let mount = SessionMount::pull(h.store.as_ref().clone(), id).await.unwrap();
+    let target = mount.readlink("/repo/link.txt".as_ref()).await.unwrap();
+    assert_eq!(target, std::path::PathBuf::from("/repo/target.txt"));
+}
+
+#[tokio::test]
 async fn create_write_stream_assembles_a_large_file() {
     ensure_v8();
     let h = build_harness();

--- a/server/tests/fs_snapshot_e2e.rs
+++ b/server/tests/fs_snapshot_e2e.rs
@@ -112,7 +112,7 @@ async fn mount_write_push_then_read_back_by_ca_id() {
     let ca2 = run(
         &h.engine,
         r#"(async () => {
-            const c = await fs.readFile("/data/note.txt");
+            const c = await fs.readFile("/data/note.txt", "utf8");
             if (c !== "hello snapshot") throw new Error("readback mismatch: " + c);
             await fs.writeFile("/data/extra.txt", "more");
         })()"#,

--- a/site-docs/concepts/filesystem.md
+++ b/site-docs/concepts/filesystem.md
@@ -57,7 +57,7 @@ sequenceDiagram
 
 **`fs.unlink` shares the `rm` policy operation.** Internally `fs.unlink(path)` delegates to the same Rust op as `fs.rm(path)` with `recursive = false`. Policies see `operation = "rm"` for both, not `"unlink"`.
 
-**UTF-8 enforcement.** `fs.readFile` without `"buffer"` encoding validates that the file content is valid UTF-8 and throws if it is not. Reading arbitrary binary files requires the `"buffer"` argument.
+**Encoding.** Following Node semantics, `fs.readFile` returns a `Uint8Array` by default; pass a text encoding (e.g. `"utf8"`) to get a string instead. In text mode the content is validated as UTF-8 and the read throws if it is not valid UTF-8.
 
 **MCP session headers.** When the server is configured to forward MCP session headers, the header map is included as `mcp_headers` in the policy input. This lets a policy tie filesystem access to the authenticated session identity — for example, confining each session to its own directory subtree (see `policies/filesystem.rego`).
 

--- a/site-docs/how-to/filesystem.md
+++ b/site-docs/how-to/filesystem.md
@@ -120,15 +120,15 @@ Set `"mode": "all"` (the default) to require every evaluator to return `true`, o
 ### Read a text file
 
 ```js
-const text = await fs.readFile("/var/mcp-workspace/config.json");
+const text = await fs.readFile("/var/mcp-workspace/config.json", "utf8");
 const config = JSON.parse(text);
 ```
 
 ### Read a binary file
 
 ```js
-const bytes = await fs.readFile("/var/mcp-workspace/image.png", "buffer");
-// bytes is a Uint8Array
+const bytes = await fs.readFile("/var/mcp-workspace/image.png");
+// bytes is a Uint8Array (the Node-style default when no encoding is given)
 ```
 
 ### Write a text file (overwrites)

--- a/site-docs/how-to/filesystem.md
+++ b/site-docs/how-to/filesystem.md
@@ -79,9 +79,9 @@ allow if {
 }
 ```
 
-Operation names match exactly what the JS wrapper passes: `readFile`, `writeFile`, `appendFile`, `readdir`, `stat`, `mkdir`, `rm`, `rename`, `copyFile`, `exists`.
+Operation names match exactly what the JS wrapper passes: `readFile`, `writeFile`, `appendFile`, `readdir`, `stat`, `lstat`, `mkdir`, `rm`, `rename`, `copyFile`, `symlink`, `readlink`, `exists`.
 
-Note: `fs.unlink` reuses the `rm` op internally, so its policy operation is `"rm"`.
+Note: `fs.unlink` and `fs.rmdir` reuse the `rm` op internally, so their policy operation is `"rm"`.
 
 ## Use a remote OPA server
 
@@ -163,7 +163,8 @@ const names = await fs.readdir("/var/mcp-workspace");
 
 ```js
 const info = await fs.stat("/var/mcp-workspace/config.json");
-// { size, isFile, isDirectory, isSymlink, readonly, mtimeMs, atimeMs, birthtimeMs }
+// Node fs.Stats-like: info.isFile(), info.isDirectory(), info.isSymbolicLink(),
+// plus info.size, info.mode, info.mtimeMs, info.mtime (Date), ...
 ```
 
 ### Create a directory

--- a/site-docs/reference/filesystem.md
+++ b/site-docs/reference/filesystem.md
@@ -18,10 +18,9 @@ interface — such as [`isomorphic-git`](https://isomorphic-git.org/) — consum
 sandbox `fs` object directly. See [`fs.promises`](#fspromises) and
 [Error codes](#error-codes) below.
 
-> `fs.promises.readFile` follows Node semantics — it returns a `Uint8Array` by
-> default and a string only when a text encoding is given. The top-level
-> `fs.readFile` keeps its original contract (text by default, bytes when called
-> with `"buffer"`).
+> Both `fs.readFile` and `fs.promises.readFile` follow Node semantics — they
+> return a `Uint8Array` by default and a string only when a text encoding (e.g.
+> `"utf8"`) is given.
 
 ---
 
@@ -32,9 +31,9 @@ Read the entire contents of a file.
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `path` | `string` | yes | Absolute or relative path to the file |
-| `encoding` | `string` | no | Pass `"buffer"` to receive raw bytes; omit for UTF-8 text |
+| `encoding` | `string` | no | Pass a text encoding (e.g. `"utf8"`) to receive a string; omit for raw bytes |
 
-**Returns:** `Promise<string>` when `encoding` is omitted or any value other than `"buffer"`. `Promise<Uint8Array>` when `encoding === "buffer"`.
+**Returns:** `Promise<Uint8Array>` when `encoding` is omitted or `"buffer"` (the Node-style default). `Promise<string>` when a text encoding such as `"utf8"` is given.
 
 **Errors:**
 - `TypeError: fs.readFile: path must be a string` — `path` argument is not a string.

--- a/site-docs/reference/filesystem.md
+++ b/site-docs/reference/filesystem.md
@@ -10,6 +10,19 @@ The `fs` global is injected only when the server starts with a `filesystem` entr
 
 All methods are `async` and must be `await`ed.
 
+The same methods are also exposed under **`fs.promises`** (an enumerable own
+property), and rejected operations carry a Node-style **`code`** (e.g.
+`err.code === "ENOENT"`). Together with the `fs.Stats`-like object returned by
+`fs.stat`/`fs.lstat`, this lets libraries that expect a Node `fs` / `fs.promises`
+interface — such as [`isomorphic-git`](https://isomorphic-git.org/) — consume the
+sandbox `fs` object directly. See [`fs.promises`](#fspromises) and
+[Error codes](#error-codes) below.
+
+> `fs.promises.readFile` follows Node semantics — it returns a `Uint8Array` by
+> default and a string only when a text encoding is given. The top-level
+> `fs.readFile` keeps its original contract (text by default, bytes when called
+> with `"buffer"`).
+
 ---
 
 ### `fs.readFile(path, encoding?)`
@@ -94,33 +107,56 @@ List the entries in a directory.
 
 ### `fs.stat(path)`
 
-Retrieve metadata for a file or directory.
+Retrieve metadata for a file or directory. A final symlink is followed.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `path` | `string` | yes | Path to stat |
 
-**Returns:** `Promise<StatResult>`
+**Returns:** `Promise<Stats>` — a Node [`fs.Stats`](https://nodejs.org/api/fs.html#class-fsstats)-like object.
 
-**`StatResult` object:**
+**`Stats` object:**
 
-| Field | Type | Description |
+| Member | Type | Description |
 |---|---|---|
+| `isFile()` | `() => boolean` | True if the path is a regular file |
+| `isDirectory()` | `() => boolean` | True if the path is a directory |
+| `isSymbolicLink()` | `() => boolean` | True if the path is a symbolic link |
+| `isBlockDevice()`, `isCharacterDevice()`, `isFIFO()`, `isSocket()` | `() => boolean` | Always `false` (not represented) |
 | `size` | `number` | File size in bytes |
-| `isFile` | `boolean` | True if the path is a regular file |
-| `isDirectory` | `boolean` | True if the path is a directory |
-| `isSymlink` | `boolean` | True if the path is a symbolic link |
+| `mode` | `number` | File mode bits (type + permissions) |
+| `ino`, `dev`, `nlink`, `uid`, `gid` | `number` | POSIX metadata (`0`/`1` when unavailable, e.g. on a snapshot overlay) |
+| `mtimeMs`, `atimeMs`, `ctimeMs`, `birthtimeMs` | `number` | Timestamps in milliseconds since the Unix epoch (`0` if unavailable) |
+| `mtime`, `atime`, `ctime`, `birthtime` | `Date` | The same timestamps as `Date` objects |
 | `readonly` | `boolean` | True if the file permissions are read-only |
-| `mtimeMs` | `number \| null` | Modification time as milliseconds since Unix epoch; `null` if unavailable |
-| `atimeMs` | `number \| null` | Last access time as milliseconds since Unix epoch; `null` if unavailable |
-| `birthtimeMs` | `number \| null` | Creation time as milliseconds since Unix epoch; `null` if unavailable on the platform |
+
+> **Compatibility note:** `isFile`/`isDirectory`/`isSymbolicLink` are now **methods**
+> (call them: `stats.isFile()`), matching Node's `fs.Stats`. Earlier releases exposed
+> `isFile`/`isDirectory`/`isSymlink` as boolean properties.
 
 **Errors:**
 - `TypeError: fs.stat: path must be a string` — `path` argument is not a string.
-- `fs.stat: <path>: <io error>` — path does not exist, permission denied, or other OS error.
+- `fs.stat: <path>: <CODE>: <io error>` — path does not exist (`ENOENT`), permission denied (`EACCES`), or other OS error. The rejection's `code` carries `<CODE>`.
 - `fs.stat denied by policy: <path> is not allowed` — policy chain returned false.
 
 **Policy operation:** `"stat"`.
+
+---
+
+### `fs.lstat(path)`
+
+Like [`fs.stat`](#fsstatpath), but does **not** follow a final symlink — it returns
+the metadata of the link itself (so `isSymbolicLink()` is `true` for a symlink).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | `string` | yes | Path to stat without following a final symlink |
+
+**Returns:** `Promise<Stats>` — same shape as [`fs.stat`](#fsstatpath).
+
+**Errors:** Same shapes as `fs.stat`, prefixed `fs.lstat`.
+
+**Policy operation:** `"lstat"`.
 
 ---
 
@@ -182,6 +218,25 @@ Remove a file. Alias for `fs.rm(path)` without the `recursive` option.
 
 ---
 
+### `fs.rmdir(path, options?)`
+
+Remove a directory. Provided for Node `fs.promises` compatibility; backed by the
+same operation as [`fs.rm`](#fsrmpath-options).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | `string` | yes | Directory path to remove |
+| `options` | `object` | no | Options object |
+| `options.recursive` | `boolean` | no | If `true`, removes the directory and its contents. Default: `false` |
+
+**Returns:** `Promise<void>`
+
+**Errors:** Same as `fs.rm` (e.g. `ENOTEMPTY` when removing a non-empty directory without `recursive`).
+
+**Policy operation:** `"rm"` (same backend op as `fs.rm`).
+
+---
+
 ### `fs.rename(oldPath, newPath)`
 
 Rename or move a file or directory.
@@ -224,6 +279,46 @@ Copy a file. Overwrites the destination if it exists.
 
 ---
 
+### `fs.symlink(target, path)`
+
+Create a symbolic link at `path` pointing to `target`. Note the Node argument
+order: the **target comes first**.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `target` | `string` | yes | The path the link points to |
+| `path` | `string` | yes | The link to create |
+
+**Returns:** `Promise<void>`
+
+**Errors:**
+- `TypeError: fs.symlink: target must be a string` / `fs.symlink: path must be a string` — argument is not a string.
+- `fs.symlink: <path> -> <target>: <CODE>: <io error>` — e.g. the link already exists (`EEXIST`), or symlinks are unsupported on the platform (`ENOSYS`).
+- `fs.symlink denied by policy: <path> is not allowed` — policy chain returned false.
+
+**Policy operation:** `"symlink"`. Policy `path` field: the link being created; policy `destination` field: `target`.
+
+---
+
+### `fs.readlink(path)`
+
+Read the target of a symbolic link.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `path` | `string` | yes | Path to the symbolic link |
+
+**Returns:** `Promise<string>` — the link's target path.
+
+**Errors:**
+- `TypeError: fs.readlink: path must be a string` — `path` argument is not a string.
+- `fs.readlink: <path>: <CODE>: <io error>` — path does not exist (`ENOENT`) or is not a symlink (`EINVAL`).
+- `fs.readlink denied by policy: <path> is not allowed` — policy chain returned false.
+
+**Policy operation:** `"readlink"`.
+
+---
+
 ### `fs.exists(path)`
 
 Check whether a path exists.
@@ -242,15 +337,55 @@ Check whether a path exists.
 
 ---
 
+### `fs.promises`
+
+`fs.promises` is an enumerable object exposing the same promise-returning
+methods: `readFile`, `writeFile`, `appendFile`, `readdir`, `stat`, `lstat`,
+`mkdir`, `rm`, `rmdir`, `unlink`, `rename`, `copyFile`, `readlink`, `symlink`,
+and `exists`.
+
+It exists so libraries that detect a Node `fs.promises` interface — by reading
+the enumerable `promises` property and binding its methods — work against the
+sandbox `fs`. `fs.promises.readFile` follows Node semantics (a `Uint8Array` by
+default; a string when a text encoding is supplied).
+
+```js
+import git from "npm:isomorphic-git";
+await git.init({ fs, dir: "/repo" });   // pass the sandbox `fs` directly
+await fs.promises.writeFile("/repo/README.md", "# hi");
+await git.add({ fs, dir: "/repo", filepath: "README.md" });
+```
+
+---
+
+### Error codes
+
+Rejections from `fs.*` carry a Node-style `code` property where a POSIX code is
+known, so callers can branch on it:
+
+```js
+try {
+  await fs.promises.readFile("/no/such/file");
+} catch (e) {
+  if (e.code === "ENOENT") { /* handle missing file */ }
+}
+```
+
+Mapped codes include `ENOENT`, `EEXIST`, `EACCES`, `ENOTDIR`, `EISDIR`,
+`ENOTEMPTY`, `EROFS`, `ENOSYS`, and `EINVAL` (from `fs.readlink` on a
+non-symlink). The code is also embedded in the error message.
+
+---
+
 ## Policy input fields
 
 Every `fs.*` call evaluates the `filesystem` policy chain with the following input object. The Rego entrypoint is `data.mcp.filesystem.allow`.
 
 | Field | Type | Always present | Description |
 |---|---|---|---|
-| `operation` | `string` | yes | JS method name: one of `readFile`, `writeFile`, `appendFile`, `readdir`, `stat`, `mkdir`, `rm`, `rename`, `copyFile`, `exists` |
-| `path` | `string` | yes | The primary path argument |
-| `destination` | `string` | no | Present for `rename` (the `newPath`) and `copyFile` (the `dest`) |
+| `operation` | `string` | yes | JS method name: one of `readFile`, `writeFile`, `appendFile`, `readdir`, `stat`, `lstat`, `mkdir`, `rm`, `rename`, `copyFile`, `symlink`, `readlink`, `exists` |
+| `path` | `string` | yes | The primary path argument (for `symlink`, the link being created) |
+| `destination` | `string` | no | Present for `rename` (the `newPath`), `copyFile` (the `dest`), and `symlink` (the `target`) |
 | `recursive` | `boolean` | no | Present for `mkdir` and `rm`; reflects `options.recursive` |
 | `encoding` | `string` | no | Present for `readFile` only: `"utf8"` (text mode) or `"buffer"` (binary mode) |
 | `mcp_headers` | `object` | no | MCP session headers forwarded by the server when configured |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -301,7 +301,7 @@ Always pin versions for reproducible results. Dynamic `import()` is also support
 When the server is configured with policies, JavaScript code can use an `fs` module providing Node.js-compatible file operations. Every operation is evaluated against a Rego policy before execution.
 
 **Available operations:**
-- `await fs.readFile(path, [encoding])` — Read file as UTF-8 string (default) or `Uint8Array` (if `encoding="buffer"`)
+- `await fs.readFile(path, [encoding])` — Read file as a `Uint8Array` (default, Node semantics) or a string (if a text encoding like `"utf8"` is given)
 - `await fs.writeFile(path, data)` — Write string or `Uint8Array` to file
 - `await fs.appendFile(path, data)` — Append data to file
 - `await fs.readdir(path)` — List directory contents
@@ -415,7 +415,7 @@ Always pin versions for reproducible results. Dynamic `import()` is also support
 When the server is configured with policies, JavaScript code can use an `fs` module providing Node.js-compatible file operations. Every operation is evaluated against a Rego policy before execution.
 
 **Available operations:**
-- `await fs.readFile(path, [encoding])` — Read file as UTF-8 string (default) or `Uint8Array` (if `encoding="buffer"`)
+- `await fs.readFile(path, [encoding])` — Read file as a `Uint8Array` (default, Node semantics) or a string (if a text encoding like `"utf8"` is given)
 - `await fs.writeFile(path, data)` — Write string or `Uint8Array` to file
 - `await fs.appendFile(path, data)` — Append data to file
 - `await fs.readdir(path)` — List directory contents

--- a/tests/nixos/fs-opa.nix
+++ b/tests/nixos/fs-opa.nix
@@ -143,7 +143,7 @@ in
     with subtest("should allow stat in /tmp/allowed/"):
         result = exec_js("""
             const info = await fs.stat("/tmp/allowed/test.txt");
-            console.log(JSON.stringify({isFile: info.isFile, size: info.size}));
+            console.log(JSON.stringify({isFile: info.isFile(), size: info.size}));
         """)
         print("Stat result: " + str(result))
         body = json.loads(result["output"])

--- a/tests/nixos/fs-opa.nix
+++ b/tests/nixos/fs-opa.nix
@@ -106,7 +106,7 @@ in
     with subtest("should allow writeFile and readFile in /tmp/allowed/"):
         result = exec_js("""
             await fs.writeFile("/tmp/allowed/test.txt", "hello world");
-            const data = await fs.readFile("/tmp/allowed/test.txt");
+            const data = await fs.readFile("/tmp/allowed/test.txt", "utf8");
             console.log(data);
         """)
         print("Write+Read result: " + str(result))
@@ -184,7 +184,7 @@ in
         result = exec_js("""
             await fs.writeFile("/tmp/allowed/append.txt", "hello");
             await fs.appendFile("/tmp/allowed/append.txt", " world");
-            console.log(await fs.readFile("/tmp/allowed/append.txt"));
+            console.log(await fs.readFile("/tmp/allowed/append.txt", "utf8"));
         """)
         print("appendFile result: " + str(result))
         assert result["output"] == "hello world", "Expected 'hello world', got: " + str(result)
@@ -195,7 +195,7 @@ in
         result = exec_js("""
             await fs.writeFile("/tmp/allowed/old.txt", "renamed");
             await fs.rename("/tmp/allowed/old.txt", "/tmp/allowed/new.txt");
-            console.log(await fs.readFile("/tmp/allowed/new.txt"));
+            console.log(await fs.readFile("/tmp/allowed/new.txt", "utf8"));
         """)
         print("Rename result: " + str(result))
         assert result["output"] == "renamed", "Expected 'renamed', got: " + str(result)
@@ -206,7 +206,7 @@ in
         result = exec_js("""
             await fs.writeFile("/tmp/allowed/src.txt", "copied");
             await fs.copyFile("/tmp/allowed/src.txt", "/tmp/allowed/dst.txt");
-            console.log(await fs.readFile("/tmp/allowed/dst.txt"));
+            console.log(await fs.readFile("/tmp/allowed/dst.txt", "utf8"));
         """)
         print("CopyFile result: " + str(result))
         assert result["output"] == "copied", "Expected 'copied', got: " + str(result)

--- a/tests/nixos/isomorphic-git.nix
+++ b/tests/nixos/isomorphic-git.nix
@@ -151,6 +151,10 @@ in
       };
 
       networking.firewall.allowedTCPPorts = [ 3000 ];
+
+      # isomorphic-git runs with a 512 MB V8 heap; give the VM headroom on top
+      # of that plus the OS and the two helper servers.
+      virtualisation.memorySize = 2048;
     };
   };
 
@@ -200,7 +204,7 @@ in
             const dir = '/tmp/work/repo';
             await fs.mkdir(dir, {{ recursive: true }});
             await git.init({{ fs, dir, defaultBranch: 'main' }});
-            await fs.writeFile(dir + '/README.md', '# hello from isomorphic-git\\n');
+            await fs.writeFile(dir + '/README.md', '# hello from isomorphic-git');
             await git.add({{ fs, dir, filepath: 'README.md' }});
             const oid = await git.commit({{
                 fs, dir, message: 'initial commit',
@@ -230,9 +234,9 @@ in
         assert body["errors"] is None, "push reported errors: " + out
 
     with subtest("the bare remote received the commit"):
-        log = machine.succeed("git -C " + shlex.quote("${gitRoot}/repo.git") + " log --oneline -1").strip()
-        print("remote log: " + log)
-        assert commit_oid in log, f"remote missing commit {commit_oid}: {log}"
-        assert "initial commit" in log, "remote missing commit message: " + log
+        remote_log = machine.succeed("git -C " + shlex.quote("${gitRoot}/repo.git") + " log --oneline -1").strip()
+        print("remote log: " + remote_log)
+        assert commit_oid in remote_log, f"remote missing commit {commit_oid}: {remote_log}"
+        assert "initial commit" in remote_log, "remote missing commit message: " + remote_log
   '';
 }

--- a/tests/nixos/isomorphic-git.nix
+++ b/tests/nixos/isomorphic-git.nix
@@ -1,0 +1,238 @@
+{ pkgs, mcp-js, ... }:
+
+# End-to-end proof that the sandbox `fs` object is a working Node-style
+# filesystem: a real `isomorphic-git` (vendored, offline) drives
+# git.init → writeFile → git.add → git.commit → git.push against an mcp-v8
+# server, and we verify the commit lands in a bare repo on a separate
+# git-over-HTTP server.
+#
+# The runtime never reaches the public internet (NixOS VMs are offline):
+#   * isomorphic-git is a self-contained ESM bundle served over localhost and
+#     imported as a URL module (gated by the modules policy);
+#   * git.push talks to a local git-http-backend (gated by the fetch policy).
+
+let
+  # ── Vendored, self-contained isomorphic-git bundle (git + http/web) ──────
+  bundleDir = pkgs.runCommand "iso-git-bundle" { } ''
+    mkdir -p "$out"
+    cp ${./vendor/isomorphic-git-bundle.mjs} "$out/isomorphic-git-bundle.mjs"
+  '';
+
+  # ── Policies ─────────────────────────────────────────────────────────────
+  # fs: the agent works under /tmp/work/. modules: allow the localhost URL
+  # import. fetch: allow git pushes to the localhost git server.
+  fsPolicy = pkgs.writeText "fs.rego" ''
+    package mcp.filesystem
+    default allow = false
+    allow if { startswith(input.path, "/tmp/work/") }
+    allow if {
+        startswith(input.path, "/tmp/work/")
+        startswith(input.destination, "/tmp/work/")
+    }
+  '';
+  modPolicy = pkgs.writeText "modules.rego" ''
+    package mcp.modules
+    default allow = false
+    allow if {
+        input.specifier_type == "url"
+        input.url_parsed.host == "127.0.0.1"
+    }
+  '';
+  fetchPolicy = pkgs.writeText "fetch.rego" ''
+    package mcp.fetch
+    default allow = false
+    allow if { input.url_parsed.host == "127.0.0.1" }
+  '';
+
+  # ── Minimal git smart-HTTP server (git-http-backend CGI gateway) ─────────
+  gitHttp = pkgs.writeText "git-http.py" ''
+    import os, subprocess
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    BACKEND = os.environ["GIT_HTTP_BACKEND"]
+    ROOT = os.environ["GIT_PROJECT_ROOT"]
+    PORT = int(os.environ.get("GIT_HTTP_PORT", "8732"))
+
+    class H(BaseHTTPRequestHandler):
+        def _run(self, body=b""):
+            u = self.path.split("?", 1)
+            qs = u[1] if len(u) > 1 else ""
+            env = dict(os.environ)
+            env.update(dict(
+                GIT_PROJECT_ROOT=ROOT, GIT_HTTP_EXPORT_ALL="1",
+                PATH_INFO=u[0], QUERY_STRING=qs, REQUEST_METHOD=self.command,
+                CONTENT_TYPE=self.headers.get("Content-Type", ""),
+                CONTENT_LENGTH=str(len(body)),
+            ))
+            p = subprocess.run([BACKEND], input=body, env=env, capture_output=True)
+            hdr, _, out = p.stdout.partition(b"\r\n\r\n")
+            status = 200
+            lines = []
+            for ln in hdr.split(b"\r\n"):
+                if ln.lower().startswith(b"status:"):
+                    status = int(ln.split(b" ")[1])
+                elif b":" in ln:
+                    lines.append(ln)
+            self.send_response(status)
+            for ln in lines:
+                k, _, v = ln.partition(b":")
+                self.send_header(k.decode().strip(), v.decode().strip())
+            self.end_headers()
+            self.wfile.write(out)
+        def log_message(self, *a):
+            pass
+        def do_GET(self):
+            self._run()
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length", "0"))
+            self._run(self.rfile.read(n))
+
+    HTTPServer(("127.0.0.1", PORT), H).serve_forever()
+  '';
+
+  gitRoot = "/var/lib/gitremote";
+in
+{
+  name = "mcp-js-isomorphic-git";
+
+  nodes = {
+    machine = { ... }: {
+      imports = [ ../../nix/module.nix ];
+
+      # mcp-v8: stateless, fs + modules + fetch policies, external modules on.
+      services.mcp-js = {
+        enable = true;
+        package = mcp-js;
+        nodeId = "test";
+        stateless = true;
+        httpPort = 3000;
+        allowExternalModules = true;
+        policiesJson = builtins.toJSON {
+          filesystem.policies = [{ url = "file://${fsPolicy}"; }];
+          modules.policies = [{ url = "file://${modPolicy}"; }];
+          fetch.policies = [{ url = "file://${fetchPolicy}"; }];
+        };
+      };
+      # isomorphic-git + a git checkout need more than the 8 MB default heap.
+      systemd.services.mcp-js.environment.MCP_V8_HEAP_MEMORY_MAX = "512";
+
+      # Static server for the isomorphic-git bundle (imported as a URL module).
+      systemd.services.iso-bundle = {
+        description = "isomorphic-git bundle static server";
+        wantedBy = [ "multi-user.target" ];
+        before = [ "mcp-js.service" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.python3}/bin/python3 -m http.server 8731 --bind 127.0.0.1 --directory ${bundleDir}";
+          Restart = "on-failure";
+          DynamicUser = true;
+        };
+      };
+
+      # git smart-HTTP server with a push-enabled bare repo.
+      systemd.services.git-http = {
+        description = "git smart-HTTP server (push target)";
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.git ];
+        preStart = ''
+          if [ ! -d ${gitRoot}/repo.git ]; then
+            mkdir -p ${gitRoot}
+            ${pkgs.git}/bin/git init --bare -b main ${gitRoot}/repo.git
+            ${pkgs.git}/bin/git -C ${gitRoot}/repo.git config http.receivepack true
+          fi
+        '';
+        serviceConfig = {
+          Environment = [
+            "GIT_HTTP_BACKEND=${pkgs.git}/libexec/git-core/git-http-backend"
+            "GIT_PROJECT_ROOT=${gitRoot}"
+            "GIT_HTTP_PORT=8732"
+          ];
+          ExecStart = "${pkgs.python3}/bin/python3 ${gitHttp}";
+          Restart = "on-failure";
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = [ 3000 ];
+    };
+  };
+
+  testScript = ''
+    import json
+    import shlex
+    import time
+
+    machine.start()
+    machine.wait_for_unit("iso-bundle.service")
+    machine.wait_for_unit("git-http.service")
+    machine.wait_for_unit("mcp-js.service")
+    machine.wait_for_open_port(8731)
+    machine.wait_for_open_port(8732)
+    machine.wait_for_open_port(3000)
+
+    def exec_js(code):
+        body = json.dumps({"code": code})
+        raw = machine.succeed(
+            "curl -s -X POST http://localhost:3000/api/exec "
+            "-H 'Content-Type: application/json' "
+            "-d " + shlex.quote(body)
+        )
+        exec_id = json.loads(raw)["execution_id"]
+        for _ in range(120):
+            status_raw = machine.succeed(
+                "curl -s http://localhost:3000/api/executions/" + exec_id
+            )
+            resp = json.loads(status_raw)
+            status = resp.get("status", "")
+            if status.lower() == "completed":
+                out = machine.succeed(
+                    "curl -s http://localhost:3000/api/executions/" + exec_id + "/output"
+                )
+                return json.loads(out).get("data", "").strip()
+            if status.lower() in ("failed", "timedout", "cancelled"):
+                return "ERROR: " + str(resp.get("error", status))
+            time.sleep(0.5)
+        raise Exception("execution did not complete: " + exec_id)
+
+    BUNDLE = "http://127.0.0.1:8731/isomorphic-git-bundle.mjs"
+    REMOTE = "http://127.0.0.1:8732/repo.git"
+
+    with subtest("init, write, add and commit a repo via isomorphic-git"):
+        out = exec_js(f"""
+            import {{ git }} from '{BUNDLE}';
+            const dir = '/tmp/work/repo';
+            await fs.mkdir(dir, {{ recursive: true }});
+            await git.init({{ fs, dir, defaultBranch: 'main' }});
+            await fs.writeFile(dir + '/README.md', '# hello from isomorphic-git\\n');
+            await git.add({{ fs, dir, filepath: 'README.md' }});
+            const oid = await git.commit({{
+                fs, dir, message: 'initial commit',
+                author: {{ name: 'Test', email: 'test@example.com' }},
+            }});
+            const log = await git.log({{ fs, dir }});
+            console.log(JSON.stringify({{ oid: oid.slice(0, 8), count: log.length, msg: log[0].commit.message.trim() }}));
+        """)
+        print("commit result: " + out)
+        body = json.loads(out)
+        assert body["count"] == 1, "expected exactly one commit, got: " + out
+        assert body["msg"] == "initial commit", "unexpected commit message: " + out
+        commit_oid = body["oid"]
+
+    with subtest("push the commit to a git-over-HTTP remote"):
+        out = exec_js(f"""
+            import {{ git, http }} from '{BUNDLE}';
+            const dir = '/tmp/work/repo';
+            const res = await git.push({{
+                fs, http, dir, url: '{REMOTE}', ref: 'main', remoteRef: 'main',
+            }});
+            console.log(JSON.stringify({{ ok: res.ok, errors: res.errors || null }}));
+        """)
+        print("push result: " + out)
+        body = json.loads(out)
+        assert body["ok"] == True, "push did not succeed: " + out
+        assert body["errors"] is None, "push reported errors: " + out
+
+    with subtest("the bare remote received the commit"):
+        log = machine.succeed("git -C " + shlex.quote("${gitRoot}/repo.git") + " log --oneline -1").strip()
+        print("remote log: " + log)
+        assert commit_oid in log, f"remote missing commit {commit_oid}: {log}"
+        assert "initial commit" in log, "remote missing commit message: " + log
+  '';
+}

--- a/tests/nixos/isomorphic-git.nix
+++ b/tests/nixos/isomorphic-git.nix
@@ -152,6 +152,9 @@ in
 
       networking.firewall.allowedTCPPorts = [ 3000 ];
 
+      # git on the machine PATH so the test script can inspect the bare remote.
+      environment.systemPackages = [ pkgs.git ];
+
       # isomorphic-git runs with a 512 MB V8 heap; give the VM headroom on top
       # of that plus the OS and the two helper servers.
       virtualisation.memorySize = 2048;

--- a/tests/nixos/isomorphic-git.nix
+++ b/tests/nixos/isomorphic-git.nix
@@ -237,7 +237,9 @@ in
         assert body["errors"] is None, "push reported errors: " + out
 
     with subtest("the bare remote received the commit"):
-        remote_log = machine.succeed("git -C " + shlex.quote("${gitRoot}/repo.git") + " log --oneline -1").strip()
+        # %H is the full hash so the 8-char commit_oid prefix matches (--oneline
+        # would abbreviate to 7 chars and miss).
+        remote_log = machine.succeed("git -C " + shlex.quote("${gitRoot}/repo.git") + " log -1 --format='%H %s'").strip()
         print("remote log: " + remote_log)
         assert commit_oid in remote_log, f"remote missing commit {commit_oid}: {remote_log}"
         assert "initial commit" in remote_log, "remote missing commit message: " + remote_log

--- a/tests/nixos/vendor/README.md
+++ b/tests/nixos/vendor/README.md
@@ -1,0 +1,26 @@
+# Vendored test fixtures
+
+These files are committed so the NixOS integration tests run **fully offline**
+(NixOS test VMs have no internet, so `import npm:…` cannot fetch at runtime).
+
+## `isomorphic-git-bundle.mjs`
+
+A self-contained ESM bundle of [`isomorphic-git`](https://isomorphic-git.org/)
+(`1.27.1`) plus its `http/web` client and all dependencies (including a `Buffer`
+polyfill), exporting `{ git, http }`. It depends only on the global
+`TextEncoder`/`TextDecoder` (provided by the runtime) and the sandbox `fetch`.
+
+Used by `tests/nixos/isomorphic-git.nix` to prove the sandbox `fs` object is a
+working Node-style filesystem: it drives `git.init` → write → `git.add` →
+`git.commit` → `git.push` against a real mcp-v8 server.
+
+### Regenerating
+
+```sh
+npm i isomorphic-git@1.27.1 esbuild buffer
+npx esbuild entry.mjs --bundle --format=esm --platform=browser \
+  --target=es2022 --inject:bufinject.js --outfile=isomorphic-git-bundle.mjs
+```
+
+`entry.mjs` and `bufinject.js` (the esbuild entry point and the Buffer/process
+inject shim) are kept alongside the bundle to document exactly how it was built.

--- a/tests/nixos/vendor/bufinject.js
+++ b/tests/nixos/vendor/bufinject.js
@@ -1,0 +1,2 @@
+export { Buffer } from 'buffer';
+export const process = { env: { NODE_ENV: 'production' }, platform: 'linux', browser: true, cwd: () => '/', nextTick: (f, ...a) => Promise.resolve().then(() => f(...a)) };

--- a/tests/nixos/vendor/entry.mjs
+++ b/tests/nixos/vendor/entry.mjs
@@ -1,0 +1,3 @@
+import git from 'isomorphic-git';
+import http from 'isomorphic-git/http/web/index.js';
+export { git, http };

--- a/tests/nixos/vendor/isomorphic-git-bundle.mjs
+++ b/tests/nixos/vendor/isomorphic-git-bundle.mjs
@@ -1,0 +1,18753 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __esm = (fn, res, err) => function __init() {
+  if (err) throw err[0];
+  try {
+    return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+  } catch (e) {
+    throw err = [e], e;
+  }
+};
+var __commonJS = (cb, mod) => function __require() {
+  try {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  } catch (e) {
+    throw mod = 0, e;
+  }
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+
+// node_modules/base64-js/index.js
+var require_base64_js = __commonJS({
+  "node_modules/base64-js/index.js"(exports) {
+    "use strict";
+    init_bufinject();
+    exports.byteLength = byteLength;
+    exports.toByteArray = toByteArray;
+    exports.fromByteArray = fromByteArray;
+    var lookup = [];
+    var revLookup = [];
+    var Arr = typeof Uint8Array !== "undefined" ? Uint8Array : Array;
+    var code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    for (i = 0, len = code.length; i < len; ++i) {
+      lookup[i] = code[i];
+      revLookup[code.charCodeAt(i)] = i;
+    }
+    var i;
+    var len;
+    revLookup["-".charCodeAt(0)] = 62;
+    revLookup["_".charCodeAt(0)] = 63;
+    function getLens(b64) {
+      var len2 = b64.length;
+      if (len2 % 4 > 0) {
+        throw new Error("Invalid string. Length must be a multiple of 4");
+      }
+      var validLen = b64.indexOf("=");
+      if (validLen === -1) validLen = len2;
+      var placeHoldersLen = validLen === len2 ? 0 : 4 - validLen % 4;
+      return [validLen, placeHoldersLen];
+    }
+    function byteLength(b64) {
+      var lens = getLens(b64);
+      var validLen = lens[0];
+      var placeHoldersLen = lens[1];
+      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+    }
+    function _byteLength(b64, validLen, placeHoldersLen) {
+      return (validLen + placeHoldersLen) * 3 / 4 - placeHoldersLen;
+    }
+    function toByteArray(b64) {
+      var tmp;
+      var lens = getLens(b64);
+      var validLen = lens[0];
+      var placeHoldersLen = lens[1];
+      var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen));
+      var curByte = 0;
+      var len2 = placeHoldersLen > 0 ? validLen - 4 : validLen;
+      var i2;
+      for (i2 = 0; i2 < len2; i2 += 4) {
+        tmp = revLookup[b64.charCodeAt(i2)] << 18 | revLookup[b64.charCodeAt(i2 + 1)] << 12 | revLookup[b64.charCodeAt(i2 + 2)] << 6 | revLookup[b64.charCodeAt(i2 + 3)];
+        arr[curByte++] = tmp >> 16 & 255;
+        arr[curByte++] = tmp >> 8 & 255;
+        arr[curByte++] = tmp & 255;
+      }
+      if (placeHoldersLen === 2) {
+        tmp = revLookup[b64.charCodeAt(i2)] << 2 | revLookup[b64.charCodeAt(i2 + 1)] >> 4;
+        arr[curByte++] = tmp & 255;
+      }
+      if (placeHoldersLen === 1) {
+        tmp = revLookup[b64.charCodeAt(i2)] << 10 | revLookup[b64.charCodeAt(i2 + 1)] << 4 | revLookup[b64.charCodeAt(i2 + 2)] >> 2;
+        arr[curByte++] = tmp >> 8 & 255;
+        arr[curByte++] = tmp & 255;
+      }
+      return arr;
+    }
+    function tripletToBase64(num2) {
+      return lookup[num2 >> 18 & 63] + lookup[num2 >> 12 & 63] + lookup[num2 >> 6 & 63] + lookup[num2 & 63];
+    }
+    function encodeChunk(uint8, start, end) {
+      var tmp;
+      var output = [];
+      for (var i2 = start; i2 < end; i2 += 3) {
+        tmp = (uint8[i2] << 16 & 16711680) + (uint8[i2 + 1] << 8 & 65280) + (uint8[i2 + 2] & 255);
+        output.push(tripletToBase64(tmp));
+      }
+      return output.join("");
+    }
+    function fromByteArray(uint8) {
+      var tmp;
+      var len2 = uint8.length;
+      var extraBytes = len2 % 3;
+      var parts = [];
+      var maxChunkLength = 16383;
+      for (var i2 = 0, len22 = len2 - extraBytes; i2 < len22; i2 += maxChunkLength) {
+        parts.push(encodeChunk(uint8, i2, i2 + maxChunkLength > len22 ? len22 : i2 + maxChunkLength));
+      }
+      if (extraBytes === 1) {
+        tmp = uint8[len2 - 1];
+        parts.push(
+          lookup[tmp >> 2] + lookup[tmp << 4 & 63] + "=="
+        );
+      } else if (extraBytes === 2) {
+        tmp = (uint8[len2 - 2] << 8) + uint8[len2 - 1];
+        parts.push(
+          lookup[tmp >> 10] + lookup[tmp >> 4 & 63] + lookup[tmp << 2 & 63] + "="
+        );
+      }
+      return parts.join("");
+    }
+  }
+});
+
+// node_modules/ieee754/index.js
+var require_ieee754 = __commonJS({
+  "node_modules/ieee754/index.js"(exports) {
+    init_bufinject();
+    exports.read = function(buffer, offset, isLE, mLen, nBytes) {
+      var e, m;
+      var eLen = nBytes * 8 - mLen - 1;
+      var eMax = (1 << eLen) - 1;
+      var eBias = eMax >> 1;
+      var nBits = -7;
+      var i = isLE ? nBytes - 1 : 0;
+      var d = isLE ? -1 : 1;
+      var s = buffer[offset + i];
+      i += d;
+      e = s & (1 << -nBits) - 1;
+      s >>= -nBits;
+      nBits += eLen;
+      for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {
+      }
+      m = e & (1 << -nBits) - 1;
+      e >>= -nBits;
+      nBits += mLen;
+      for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {
+      }
+      if (e === 0) {
+        e = 1 - eBias;
+      } else if (e === eMax) {
+        return m ? NaN : (s ? -1 : 1) * Infinity;
+      } else {
+        m = m + Math.pow(2, mLen);
+        e = e - eBias;
+      }
+      return (s ? -1 : 1) * m * Math.pow(2, e - mLen);
+    };
+    exports.write = function(buffer, value, offset, isLE, mLen, nBytes) {
+      var e, m, c;
+      var eLen = nBytes * 8 - mLen - 1;
+      var eMax = (1 << eLen) - 1;
+      var eBias = eMax >> 1;
+      var rt = mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0;
+      var i = isLE ? 0 : nBytes - 1;
+      var d = isLE ? 1 : -1;
+      var s = value < 0 || value === 0 && 1 / value < 0 ? 1 : 0;
+      value = Math.abs(value);
+      if (isNaN(value) || value === Infinity) {
+        m = isNaN(value) ? 1 : 0;
+        e = eMax;
+      } else {
+        e = Math.floor(Math.log(value) / Math.LN2);
+        if (value * (c = Math.pow(2, -e)) < 1) {
+          e--;
+          c *= 2;
+        }
+        if (e + eBias >= 1) {
+          value += rt / c;
+        } else {
+          value += rt * Math.pow(2, 1 - eBias);
+        }
+        if (value * c >= 2) {
+          e++;
+          c /= 2;
+        }
+        if (e + eBias >= eMax) {
+          m = 0;
+          e = eMax;
+        } else if (e + eBias >= 1) {
+          m = (value * c - 1) * Math.pow(2, mLen);
+          e = e + eBias;
+        } else {
+          m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen);
+          e = 0;
+        }
+      }
+      for (; mLen >= 8; buffer[offset + i] = m & 255, i += d, m /= 256, mLen -= 8) {
+      }
+      e = e << mLen | m;
+      eLen += mLen;
+      for (; eLen > 0; buffer[offset + i] = e & 255, i += d, e /= 256, eLen -= 8) {
+      }
+      buffer[offset + i - d] |= s * 128;
+    };
+  }
+});
+
+// node_modules/buffer/index.js
+var require_buffer = __commonJS({
+  "node_modules/buffer/index.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var base64 = require_base64_js();
+    var ieee754 = require_ieee754();
+    var customInspectSymbol = typeof Symbol === "function" && typeof Symbol["for"] === "function" ? Symbol["for"]("nodejs.util.inspect.custom") : null;
+    exports.Buffer = Buffer3;
+    exports.SlowBuffer = SlowBuffer;
+    exports.INSPECT_MAX_BYTES = 50;
+    var K_MAX_LENGTH = 2147483647;
+    exports.kMaxLength = K_MAX_LENGTH;
+    Buffer3.TYPED_ARRAY_SUPPORT = typedArraySupport();
+    if (!Buffer3.TYPED_ARRAY_SUPPORT && typeof console !== "undefined" && typeof console.error === "function") {
+      console.error(
+        "This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support."
+      );
+    }
+    function typedArraySupport() {
+      try {
+        const arr = new Uint8Array(1);
+        const proto = { foo: function() {
+          return 42;
+        } };
+        Object.setPrototypeOf(proto, Uint8Array.prototype);
+        Object.setPrototypeOf(arr, proto);
+        return arr.foo() === 42;
+      } catch (e) {
+        return false;
+      }
+    }
+    Object.defineProperty(Buffer3.prototype, "parent", {
+      enumerable: true,
+      get: function() {
+        if (!Buffer3.isBuffer(this)) return void 0;
+        return this.buffer;
+      }
+    });
+    Object.defineProperty(Buffer3.prototype, "offset", {
+      enumerable: true,
+      get: function() {
+        if (!Buffer3.isBuffer(this)) return void 0;
+        return this.byteOffset;
+      }
+    });
+    function createBuffer(length) {
+      if (length > K_MAX_LENGTH) {
+        throw new RangeError('The value "' + length + '" is invalid for option "size"');
+      }
+      const buf = new Uint8Array(length);
+      Object.setPrototypeOf(buf, Buffer3.prototype);
+      return buf;
+    }
+    function Buffer3(arg, encodingOrOffset, length) {
+      if (typeof arg === "number") {
+        if (typeof encodingOrOffset === "string") {
+          throw new TypeError(
+            'The "string" argument must be of type string. Received type number'
+          );
+        }
+        return allocUnsafe(arg);
+      }
+      return from(arg, encodingOrOffset, length);
+    }
+    Buffer3.poolSize = 8192;
+    function from(value, encodingOrOffset, length) {
+      if (typeof value === "string") {
+        return fromString(value, encodingOrOffset);
+      }
+      if (ArrayBuffer.isView(value)) {
+        return fromArrayView(value);
+      }
+      if (value == null) {
+        throw new TypeError(
+          "The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value
+        );
+      }
+      if (isInstance(value, ArrayBuffer) || value && isInstance(value.buffer, ArrayBuffer)) {
+        return fromArrayBuffer(value, encodingOrOffset, length);
+      }
+      if (typeof SharedArrayBuffer !== "undefined" && (isInstance(value, SharedArrayBuffer) || value && isInstance(value.buffer, SharedArrayBuffer))) {
+        return fromArrayBuffer(value, encodingOrOffset, length);
+      }
+      if (typeof value === "number") {
+        throw new TypeError(
+          'The "value" argument must not be of type number. Received type number'
+        );
+      }
+      const valueOf = value.valueOf && value.valueOf();
+      if (valueOf != null && valueOf !== value) {
+        return Buffer3.from(valueOf, encodingOrOffset, length);
+      }
+      const b = fromObject(value);
+      if (b) return b;
+      if (typeof Symbol !== "undefined" && Symbol.toPrimitive != null && typeof value[Symbol.toPrimitive] === "function") {
+        return Buffer3.from(value[Symbol.toPrimitive]("string"), encodingOrOffset, length);
+      }
+      throw new TypeError(
+        "The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type " + typeof value
+      );
+    }
+    Buffer3.from = function(value, encodingOrOffset, length) {
+      return from(value, encodingOrOffset, length);
+    };
+    Object.setPrototypeOf(Buffer3.prototype, Uint8Array.prototype);
+    Object.setPrototypeOf(Buffer3, Uint8Array);
+    function assertSize(size) {
+      if (typeof size !== "number") {
+        throw new TypeError('"size" argument must be of type number');
+      } else if (size < 0) {
+        throw new RangeError('The value "' + size + '" is invalid for option "size"');
+      }
+    }
+    function alloc(size, fill, encoding) {
+      assertSize(size);
+      if (size <= 0) {
+        return createBuffer(size);
+      }
+      if (fill !== void 0) {
+        return typeof encoding === "string" ? createBuffer(size).fill(fill, encoding) : createBuffer(size).fill(fill);
+      }
+      return createBuffer(size);
+    }
+    Buffer3.alloc = function(size, fill, encoding) {
+      return alloc(size, fill, encoding);
+    };
+    function allocUnsafe(size) {
+      assertSize(size);
+      return createBuffer(size < 0 ? 0 : checked(size) | 0);
+    }
+    Buffer3.allocUnsafe = function(size) {
+      return allocUnsafe(size);
+    };
+    Buffer3.allocUnsafeSlow = function(size) {
+      return allocUnsafe(size);
+    };
+    function fromString(string, encoding) {
+      if (typeof encoding !== "string" || encoding === "") {
+        encoding = "utf8";
+      }
+      if (!Buffer3.isEncoding(encoding)) {
+        throw new TypeError("Unknown encoding: " + encoding);
+      }
+      const length = byteLength(string, encoding) | 0;
+      let buf = createBuffer(length);
+      const actual = buf.write(string, encoding);
+      if (actual !== length) {
+        buf = buf.slice(0, actual);
+      }
+      return buf;
+    }
+    function fromArrayLike(array) {
+      const length = array.length < 0 ? 0 : checked(array.length) | 0;
+      const buf = createBuffer(length);
+      for (let i = 0; i < length; i += 1) {
+        buf[i] = array[i] & 255;
+      }
+      return buf;
+    }
+    function fromArrayView(arrayView) {
+      if (isInstance(arrayView, Uint8Array)) {
+        const copy = new Uint8Array(arrayView);
+        return fromArrayBuffer(copy.buffer, copy.byteOffset, copy.byteLength);
+      }
+      return fromArrayLike(arrayView);
+    }
+    function fromArrayBuffer(array, byteOffset, length) {
+      if (byteOffset < 0 || array.byteLength < byteOffset) {
+        throw new RangeError('"offset" is outside of buffer bounds');
+      }
+      if (array.byteLength < byteOffset + (length || 0)) {
+        throw new RangeError('"length" is outside of buffer bounds');
+      }
+      let buf;
+      if (byteOffset === void 0 && length === void 0) {
+        buf = new Uint8Array(array);
+      } else if (length === void 0) {
+        buf = new Uint8Array(array, byteOffset);
+      } else {
+        buf = new Uint8Array(array, byteOffset, length);
+      }
+      Object.setPrototypeOf(buf, Buffer3.prototype);
+      return buf;
+    }
+    function fromObject(obj) {
+      if (Buffer3.isBuffer(obj)) {
+        const len = checked(obj.length) | 0;
+        const buf = createBuffer(len);
+        if (buf.length === 0) {
+          return buf;
+        }
+        obj.copy(buf, 0, 0, len);
+        return buf;
+      }
+      if (obj.length !== void 0) {
+        if (typeof obj.length !== "number" || numberIsNaN(obj.length)) {
+          return createBuffer(0);
+        }
+        return fromArrayLike(obj);
+      }
+      if (obj.type === "Buffer" && Array.isArray(obj.data)) {
+        return fromArrayLike(obj.data);
+      }
+    }
+    function checked(length) {
+      if (length >= K_MAX_LENGTH) {
+        throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x" + K_MAX_LENGTH.toString(16) + " bytes");
+      }
+      return length | 0;
+    }
+    function SlowBuffer(length) {
+      if (+length != length) {
+        length = 0;
+      }
+      return Buffer3.alloc(+length);
+    }
+    Buffer3.isBuffer = function isBuffer(b) {
+      return b != null && b._isBuffer === true && b !== Buffer3.prototype;
+    };
+    Buffer3.compare = function compare(a, b) {
+      if (isInstance(a, Uint8Array)) a = Buffer3.from(a, a.offset, a.byteLength);
+      if (isInstance(b, Uint8Array)) b = Buffer3.from(b, b.offset, b.byteLength);
+      if (!Buffer3.isBuffer(a) || !Buffer3.isBuffer(b)) {
+        throw new TypeError(
+          'The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array'
+        );
+      }
+      if (a === b) return 0;
+      let x = a.length;
+      let y = b.length;
+      for (let i = 0, len = Math.min(x, y); i < len; ++i) {
+        if (a[i] !== b[i]) {
+          x = a[i];
+          y = b[i];
+          break;
+        }
+      }
+      if (x < y) return -1;
+      if (y < x) return 1;
+      return 0;
+    };
+    Buffer3.isEncoding = function isEncoding(encoding) {
+      switch (String(encoding).toLowerCase()) {
+        case "hex":
+        case "utf8":
+        case "utf-8":
+        case "ascii":
+        case "latin1":
+        case "binary":
+        case "base64":
+        case "ucs2":
+        case "ucs-2":
+        case "utf16le":
+        case "utf-16le":
+          return true;
+        default:
+          return false;
+      }
+    };
+    Buffer3.concat = function concat(list, length) {
+      if (!Array.isArray(list)) {
+        throw new TypeError('"list" argument must be an Array of Buffers');
+      }
+      if (list.length === 0) {
+        return Buffer3.alloc(0);
+      }
+      let i;
+      if (length === void 0) {
+        length = 0;
+        for (i = 0; i < list.length; ++i) {
+          length += list[i].length;
+        }
+      }
+      const buffer = Buffer3.allocUnsafe(length);
+      let pos = 0;
+      for (i = 0; i < list.length; ++i) {
+        let buf = list[i];
+        if (isInstance(buf, Uint8Array)) {
+          if (pos + buf.length > buffer.length) {
+            if (!Buffer3.isBuffer(buf)) buf = Buffer3.from(buf);
+            buf.copy(buffer, pos);
+          } else {
+            Uint8Array.prototype.set.call(
+              buffer,
+              buf,
+              pos
+            );
+          }
+        } else if (!Buffer3.isBuffer(buf)) {
+          throw new TypeError('"list" argument must be an Array of Buffers');
+        } else {
+          buf.copy(buffer, pos);
+        }
+        pos += buf.length;
+      }
+      return buffer;
+    };
+    function byteLength(string, encoding) {
+      if (Buffer3.isBuffer(string)) {
+        return string.length;
+      }
+      if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
+        return string.byteLength;
+      }
+      if (typeof string !== "string") {
+        throw new TypeError(
+          'The "string" argument must be one of type string, Buffer, or ArrayBuffer. Received type ' + typeof string
+        );
+      }
+      const len = string.length;
+      const mustMatch = arguments.length > 2 && arguments[2] === true;
+      if (!mustMatch && len === 0) return 0;
+      let loweredCase = false;
+      for (; ; ) {
+        switch (encoding) {
+          case "ascii":
+          case "latin1":
+          case "binary":
+            return len;
+          case "utf8":
+          case "utf-8":
+            return utf8ToBytes(string).length;
+          case "ucs2":
+          case "ucs-2":
+          case "utf16le":
+          case "utf-16le":
+            return len * 2;
+          case "hex":
+            return len >>> 1;
+          case "base64":
+            return base64ToBytes(string).length;
+          default:
+            if (loweredCase) {
+              return mustMatch ? -1 : utf8ToBytes(string).length;
+            }
+            encoding = ("" + encoding).toLowerCase();
+            loweredCase = true;
+        }
+      }
+    }
+    Buffer3.byteLength = byteLength;
+    function slowToString(encoding, start, end) {
+      let loweredCase = false;
+      if (start === void 0 || start < 0) {
+        start = 0;
+      }
+      if (start > this.length) {
+        return "";
+      }
+      if (end === void 0 || end > this.length) {
+        end = this.length;
+      }
+      if (end <= 0) {
+        return "";
+      }
+      end >>>= 0;
+      start >>>= 0;
+      if (end <= start) {
+        return "";
+      }
+      if (!encoding) encoding = "utf8";
+      while (true) {
+        switch (encoding) {
+          case "hex":
+            return hexSlice(this, start, end);
+          case "utf8":
+          case "utf-8":
+            return utf8Slice(this, start, end);
+          case "ascii":
+            return asciiSlice(this, start, end);
+          case "latin1":
+          case "binary":
+            return latin1Slice(this, start, end);
+          case "base64":
+            return base64Slice(this, start, end);
+          case "ucs2":
+          case "ucs-2":
+          case "utf16le":
+          case "utf-16le":
+            return utf16leSlice(this, start, end);
+          default:
+            if (loweredCase) throw new TypeError("Unknown encoding: " + encoding);
+            encoding = (encoding + "").toLowerCase();
+            loweredCase = true;
+        }
+      }
+    }
+    Buffer3.prototype._isBuffer = true;
+    function swap(b, n, m) {
+      const i = b[n];
+      b[n] = b[m];
+      b[m] = i;
+    }
+    Buffer3.prototype.swap16 = function swap16() {
+      const len = this.length;
+      if (len % 2 !== 0) {
+        throw new RangeError("Buffer size must be a multiple of 16-bits");
+      }
+      for (let i = 0; i < len; i += 2) {
+        swap(this, i, i + 1);
+      }
+      return this;
+    };
+    Buffer3.prototype.swap32 = function swap32() {
+      const len = this.length;
+      if (len % 4 !== 0) {
+        throw new RangeError("Buffer size must be a multiple of 32-bits");
+      }
+      for (let i = 0; i < len; i += 4) {
+        swap(this, i, i + 3);
+        swap(this, i + 1, i + 2);
+      }
+      return this;
+    };
+    Buffer3.prototype.swap64 = function swap64() {
+      const len = this.length;
+      if (len % 8 !== 0) {
+        throw new RangeError("Buffer size must be a multiple of 64-bits");
+      }
+      for (let i = 0; i < len; i += 8) {
+        swap(this, i, i + 7);
+        swap(this, i + 1, i + 6);
+        swap(this, i + 2, i + 5);
+        swap(this, i + 3, i + 4);
+      }
+      return this;
+    };
+    Buffer3.prototype.toString = function toString() {
+      const length = this.length;
+      if (length === 0) return "";
+      if (arguments.length === 0) return utf8Slice(this, 0, length);
+      return slowToString.apply(this, arguments);
+    };
+    Buffer3.prototype.toLocaleString = Buffer3.prototype.toString;
+    Buffer3.prototype.equals = function equals(b) {
+      if (!Buffer3.isBuffer(b)) throw new TypeError("Argument must be a Buffer");
+      if (this === b) return true;
+      return Buffer3.compare(this, b) === 0;
+    };
+    Buffer3.prototype.inspect = function inspect() {
+      let str = "";
+      const max = exports.INSPECT_MAX_BYTES;
+      str = this.toString("hex", 0, max).replace(/(.{2})/g, "$1 ").trim();
+      if (this.length > max) str += " ... ";
+      return "<Buffer " + str + ">";
+    };
+    if (customInspectSymbol) {
+      Buffer3.prototype[customInspectSymbol] = Buffer3.prototype.inspect;
+    }
+    Buffer3.prototype.compare = function compare(target, start, end, thisStart, thisEnd) {
+      if (isInstance(target, Uint8Array)) {
+        target = Buffer3.from(target, target.offset, target.byteLength);
+      }
+      if (!Buffer3.isBuffer(target)) {
+        throw new TypeError(
+          'The "target" argument must be one of type Buffer or Uint8Array. Received type ' + typeof target
+        );
+      }
+      if (start === void 0) {
+        start = 0;
+      }
+      if (end === void 0) {
+        end = target ? target.length : 0;
+      }
+      if (thisStart === void 0) {
+        thisStart = 0;
+      }
+      if (thisEnd === void 0) {
+        thisEnd = this.length;
+      }
+      if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
+        throw new RangeError("out of range index");
+      }
+      if (thisStart >= thisEnd && start >= end) {
+        return 0;
+      }
+      if (thisStart >= thisEnd) {
+        return -1;
+      }
+      if (start >= end) {
+        return 1;
+      }
+      start >>>= 0;
+      end >>>= 0;
+      thisStart >>>= 0;
+      thisEnd >>>= 0;
+      if (this === target) return 0;
+      let x = thisEnd - thisStart;
+      let y = end - start;
+      const len = Math.min(x, y);
+      const thisCopy = this.slice(thisStart, thisEnd);
+      const targetCopy = target.slice(start, end);
+      for (let i = 0; i < len; ++i) {
+        if (thisCopy[i] !== targetCopy[i]) {
+          x = thisCopy[i];
+          y = targetCopy[i];
+          break;
+        }
+      }
+      if (x < y) return -1;
+      if (y < x) return 1;
+      return 0;
+    };
+    function bidirectionalIndexOf(buffer, val, byteOffset, encoding, dir) {
+      if (buffer.length === 0) return -1;
+      if (typeof byteOffset === "string") {
+        encoding = byteOffset;
+        byteOffset = 0;
+      } else if (byteOffset > 2147483647) {
+        byteOffset = 2147483647;
+      } else if (byteOffset < -2147483648) {
+        byteOffset = -2147483648;
+      }
+      byteOffset = +byteOffset;
+      if (numberIsNaN(byteOffset)) {
+        byteOffset = dir ? 0 : buffer.length - 1;
+      }
+      if (byteOffset < 0) byteOffset = buffer.length + byteOffset;
+      if (byteOffset >= buffer.length) {
+        if (dir) return -1;
+        else byteOffset = buffer.length - 1;
+      } else if (byteOffset < 0) {
+        if (dir) byteOffset = 0;
+        else return -1;
+      }
+      if (typeof val === "string") {
+        val = Buffer3.from(val, encoding);
+      }
+      if (Buffer3.isBuffer(val)) {
+        if (val.length === 0) {
+          return -1;
+        }
+        return arrayIndexOf(buffer, val, byteOffset, encoding, dir);
+      } else if (typeof val === "number") {
+        val = val & 255;
+        if (typeof Uint8Array.prototype.indexOf === "function") {
+          if (dir) {
+            return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset);
+          } else {
+            return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset);
+          }
+        }
+        return arrayIndexOf(buffer, [val], byteOffset, encoding, dir);
+      }
+      throw new TypeError("val must be string, number or Buffer");
+    }
+    function arrayIndexOf(arr, val, byteOffset, encoding, dir) {
+      let indexSize = 1;
+      let arrLength = arr.length;
+      let valLength = val.length;
+      if (encoding !== void 0) {
+        encoding = String(encoding).toLowerCase();
+        if (encoding === "ucs2" || encoding === "ucs-2" || encoding === "utf16le" || encoding === "utf-16le") {
+          if (arr.length < 2 || val.length < 2) {
+            return -1;
+          }
+          indexSize = 2;
+          arrLength /= 2;
+          valLength /= 2;
+          byteOffset /= 2;
+        }
+      }
+      function read(buf, i2) {
+        if (indexSize === 1) {
+          return buf[i2];
+        } else {
+          return buf.readUInt16BE(i2 * indexSize);
+        }
+      }
+      let i;
+      if (dir) {
+        let foundIndex = -1;
+        for (i = byteOffset; i < arrLength; i++) {
+          if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
+            if (foundIndex === -1) foundIndex = i;
+            if (i - foundIndex + 1 === valLength) return foundIndex * indexSize;
+          } else {
+            if (foundIndex !== -1) i -= i - foundIndex;
+            foundIndex = -1;
+          }
+        }
+      } else {
+        if (byteOffset + valLength > arrLength) byteOffset = arrLength - valLength;
+        for (i = byteOffset; i >= 0; i--) {
+          let found = true;
+          for (let j = 0; j < valLength; j++) {
+            if (read(arr, i + j) !== read(val, j)) {
+              found = false;
+              break;
+            }
+          }
+          if (found) return i;
+        }
+      }
+      return -1;
+    }
+    Buffer3.prototype.includes = function includes(val, byteOffset, encoding) {
+      return this.indexOf(val, byteOffset, encoding) !== -1;
+    };
+    Buffer3.prototype.indexOf = function indexOf(val, byteOffset, encoding) {
+      return bidirectionalIndexOf(this, val, byteOffset, encoding, true);
+    };
+    Buffer3.prototype.lastIndexOf = function lastIndexOf(val, byteOffset, encoding) {
+      return bidirectionalIndexOf(this, val, byteOffset, encoding, false);
+    };
+    function hexWrite(buf, string, offset, length) {
+      offset = Number(offset) || 0;
+      const remaining = buf.length - offset;
+      if (!length) {
+        length = remaining;
+      } else {
+        length = Number(length);
+        if (length > remaining) {
+          length = remaining;
+        }
+      }
+      const strLen = string.length;
+      if (length > strLen / 2) {
+        length = strLen / 2;
+      }
+      let i;
+      for (i = 0; i < length; ++i) {
+        const parsed = parseInt(string.substr(i * 2, 2), 16);
+        if (numberIsNaN(parsed)) return i;
+        buf[offset + i] = parsed;
+      }
+      return i;
+    }
+    function utf8Write(buf, string, offset, length) {
+      return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length);
+    }
+    function asciiWrite(buf, string, offset, length) {
+      return blitBuffer(asciiToBytes(string), buf, offset, length);
+    }
+    function base64Write(buf, string, offset, length) {
+      return blitBuffer(base64ToBytes(string), buf, offset, length);
+    }
+    function ucs2Write(buf, string, offset, length) {
+      return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length);
+    }
+    Buffer3.prototype.write = function write(string, offset, length, encoding) {
+      if (offset === void 0) {
+        encoding = "utf8";
+        length = this.length;
+        offset = 0;
+      } else if (length === void 0 && typeof offset === "string") {
+        encoding = offset;
+        length = this.length;
+        offset = 0;
+      } else if (isFinite(offset)) {
+        offset = offset >>> 0;
+        if (isFinite(length)) {
+          length = length >>> 0;
+          if (encoding === void 0) encoding = "utf8";
+        } else {
+          encoding = length;
+          length = void 0;
+        }
+      } else {
+        throw new Error(
+          "Buffer.write(string, encoding, offset[, length]) is no longer supported"
+        );
+      }
+      const remaining = this.length - offset;
+      if (length === void 0 || length > remaining) length = remaining;
+      if (string.length > 0 && (length < 0 || offset < 0) || offset > this.length) {
+        throw new RangeError("Attempt to write outside buffer bounds");
+      }
+      if (!encoding) encoding = "utf8";
+      let loweredCase = false;
+      for (; ; ) {
+        switch (encoding) {
+          case "hex":
+            return hexWrite(this, string, offset, length);
+          case "utf8":
+          case "utf-8":
+            return utf8Write(this, string, offset, length);
+          case "ascii":
+          case "latin1":
+          case "binary":
+            return asciiWrite(this, string, offset, length);
+          case "base64":
+            return base64Write(this, string, offset, length);
+          case "ucs2":
+          case "ucs-2":
+          case "utf16le":
+          case "utf-16le":
+            return ucs2Write(this, string, offset, length);
+          default:
+            if (loweredCase) throw new TypeError("Unknown encoding: " + encoding);
+            encoding = ("" + encoding).toLowerCase();
+            loweredCase = true;
+        }
+      }
+    };
+    Buffer3.prototype.toJSON = function toJSON() {
+      return {
+        type: "Buffer",
+        data: Array.prototype.slice.call(this._arr || this, 0)
+      };
+    };
+    function base64Slice(buf, start, end) {
+      if (start === 0 && end === buf.length) {
+        return base64.fromByteArray(buf);
+      } else {
+        return base64.fromByteArray(buf.slice(start, end));
+      }
+    }
+    function utf8Slice(buf, start, end) {
+      end = Math.min(buf.length, end);
+      const res = [];
+      let i = start;
+      while (i < end) {
+        const firstByte = buf[i];
+        let codePoint = null;
+        let bytesPerSequence = firstByte > 239 ? 4 : firstByte > 223 ? 3 : firstByte > 191 ? 2 : 1;
+        if (i + bytesPerSequence <= end) {
+          let secondByte, thirdByte, fourthByte, tempCodePoint;
+          switch (bytesPerSequence) {
+            case 1:
+              if (firstByte < 128) {
+                codePoint = firstByte;
+              }
+              break;
+            case 2:
+              secondByte = buf[i + 1];
+              if ((secondByte & 192) === 128) {
+                tempCodePoint = (firstByte & 31) << 6 | secondByte & 63;
+                if (tempCodePoint > 127) {
+                  codePoint = tempCodePoint;
+                }
+              }
+              break;
+            case 3:
+              secondByte = buf[i + 1];
+              thirdByte = buf[i + 2];
+              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128) {
+                tempCodePoint = (firstByte & 15) << 12 | (secondByte & 63) << 6 | thirdByte & 63;
+                if (tempCodePoint > 2047 && (tempCodePoint < 55296 || tempCodePoint > 57343)) {
+                  codePoint = tempCodePoint;
+                }
+              }
+              break;
+            case 4:
+              secondByte = buf[i + 1];
+              thirdByte = buf[i + 2];
+              fourthByte = buf[i + 3];
+              if ((secondByte & 192) === 128 && (thirdByte & 192) === 128 && (fourthByte & 192) === 128) {
+                tempCodePoint = (firstByte & 15) << 18 | (secondByte & 63) << 12 | (thirdByte & 63) << 6 | fourthByte & 63;
+                if (tempCodePoint > 65535 && tempCodePoint < 1114112) {
+                  codePoint = tempCodePoint;
+                }
+              }
+          }
+        }
+        if (codePoint === null) {
+          codePoint = 65533;
+          bytesPerSequence = 1;
+        } else if (codePoint > 65535) {
+          codePoint -= 65536;
+          res.push(codePoint >>> 10 & 1023 | 55296);
+          codePoint = 56320 | codePoint & 1023;
+        }
+        res.push(codePoint);
+        i += bytesPerSequence;
+      }
+      return decodeCodePointsArray(res);
+    }
+    var MAX_ARGUMENTS_LENGTH = 4096;
+    function decodeCodePointsArray(codePoints) {
+      const len = codePoints.length;
+      if (len <= MAX_ARGUMENTS_LENGTH) {
+        return String.fromCharCode.apply(String, codePoints);
+      }
+      let res = "";
+      let i = 0;
+      while (i < len) {
+        res += String.fromCharCode.apply(
+          String,
+          codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH)
+        );
+      }
+      return res;
+    }
+    function asciiSlice(buf, start, end) {
+      let ret = "";
+      end = Math.min(buf.length, end);
+      for (let i = start; i < end; ++i) {
+        ret += String.fromCharCode(buf[i] & 127);
+      }
+      return ret;
+    }
+    function latin1Slice(buf, start, end) {
+      let ret = "";
+      end = Math.min(buf.length, end);
+      for (let i = start; i < end; ++i) {
+        ret += String.fromCharCode(buf[i]);
+      }
+      return ret;
+    }
+    function hexSlice(buf, start, end) {
+      const len = buf.length;
+      if (!start || start < 0) start = 0;
+      if (!end || end < 0 || end > len) end = len;
+      let out = "";
+      for (let i = start; i < end; ++i) {
+        out += hexSliceLookupTable[buf[i]];
+      }
+      return out;
+    }
+    function utf16leSlice(buf, start, end) {
+      const bytes = buf.slice(start, end);
+      let res = "";
+      for (let i = 0; i < bytes.length - 1; i += 2) {
+        res += String.fromCharCode(bytes[i] + bytes[i + 1] * 256);
+      }
+      return res;
+    }
+    Buffer3.prototype.slice = function slice(start, end) {
+      const len = this.length;
+      start = ~~start;
+      end = end === void 0 ? len : ~~end;
+      if (start < 0) {
+        start += len;
+        if (start < 0) start = 0;
+      } else if (start > len) {
+        start = len;
+      }
+      if (end < 0) {
+        end += len;
+        if (end < 0) end = 0;
+      } else if (end > len) {
+        end = len;
+      }
+      if (end < start) end = start;
+      const newBuf = this.subarray(start, end);
+      Object.setPrototypeOf(newBuf, Buffer3.prototype);
+      return newBuf;
+    };
+    function checkOffset(offset, ext, length) {
+      if (offset % 1 !== 0 || offset < 0) throw new RangeError("offset is not uint");
+      if (offset + ext > length) throw new RangeError("Trying to access beyond buffer length");
+    }
+    Buffer3.prototype.readUintLE = Buffer3.prototype.readUIntLE = function readUIntLE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) checkOffset(offset, byteLength2, this.length);
+      let val = this[offset];
+      let mul = 1;
+      let i = 0;
+      while (++i < byteLength2 && (mul *= 256)) {
+        val += this[offset + i] * mul;
+      }
+      return val;
+    };
+    Buffer3.prototype.readUintBE = Buffer3.prototype.readUIntBE = function readUIntBE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) {
+        checkOffset(offset, byteLength2, this.length);
+      }
+      let val = this[offset + --byteLength2];
+      let mul = 1;
+      while (byteLength2 > 0 && (mul *= 256)) {
+        val += this[offset + --byteLength2] * mul;
+      }
+      return val;
+    };
+    Buffer3.prototype.readUint8 = Buffer3.prototype.readUInt8 = function readUInt8(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 1, this.length);
+      return this[offset];
+    };
+    Buffer3.prototype.readUint16LE = Buffer3.prototype.readUInt16LE = function readUInt16LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 2, this.length);
+      return this[offset] | this[offset + 1] << 8;
+    };
+    Buffer3.prototype.readUint16BE = Buffer3.prototype.readUInt16BE = function readUInt16BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 2, this.length);
+      return this[offset] << 8 | this[offset + 1];
+    };
+    Buffer3.prototype.readUint32LE = Buffer3.prototype.readUInt32LE = function readUInt32LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 4, this.length);
+      return (this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16) + this[offset + 3] * 16777216;
+    };
+    Buffer3.prototype.readUint32BE = Buffer3.prototype.readUInt32BE = function readUInt32BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 4, this.length);
+      return this[offset] * 16777216 + (this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3]);
+    };
+    Buffer3.prototype.readBigUInt64LE = defineBigIntMethod(function readBigUInt64LE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, "offset");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const lo = first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24;
+      const hi = this[++offset] + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + last * 2 ** 24;
+      return BigInt(lo) + (BigInt(hi) << BigInt(32));
+    });
+    Buffer3.prototype.readBigUInt64BE = defineBigIntMethod(function readBigUInt64BE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, "offset");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const hi = first * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+      const lo = this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last;
+      return (BigInt(hi) << BigInt(32)) + BigInt(lo);
+    });
+    Buffer3.prototype.readIntLE = function readIntLE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) checkOffset(offset, byteLength2, this.length);
+      let val = this[offset];
+      let mul = 1;
+      let i = 0;
+      while (++i < byteLength2 && (mul *= 256)) {
+        val += this[offset + i] * mul;
+      }
+      mul *= 128;
+      if (val >= mul) val -= Math.pow(2, 8 * byteLength2);
+      return val;
+    };
+    Buffer3.prototype.readIntBE = function readIntBE(offset, byteLength2, noAssert) {
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) checkOffset(offset, byteLength2, this.length);
+      let i = byteLength2;
+      let mul = 1;
+      let val = this[offset + --i];
+      while (i > 0 && (mul *= 256)) {
+        val += this[offset + --i] * mul;
+      }
+      mul *= 128;
+      if (val >= mul) val -= Math.pow(2, 8 * byteLength2);
+      return val;
+    };
+    Buffer3.prototype.readInt8 = function readInt8(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 1, this.length);
+      if (!(this[offset] & 128)) return this[offset];
+      return (255 - this[offset] + 1) * -1;
+    };
+    Buffer3.prototype.readInt16LE = function readInt16LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 2, this.length);
+      const val = this[offset] | this[offset + 1] << 8;
+      return val & 32768 ? val | 4294901760 : val;
+    };
+    Buffer3.prototype.readInt16BE = function readInt16BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 2, this.length);
+      const val = this[offset + 1] | this[offset] << 8;
+      return val & 32768 ? val | 4294901760 : val;
+    };
+    Buffer3.prototype.readInt32LE = function readInt32LE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 4, this.length);
+      return this[offset] | this[offset + 1] << 8 | this[offset + 2] << 16 | this[offset + 3] << 24;
+    };
+    Buffer3.prototype.readInt32BE = function readInt32BE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 4, this.length);
+      return this[offset] << 24 | this[offset + 1] << 16 | this[offset + 2] << 8 | this[offset + 3];
+    };
+    Buffer3.prototype.readBigInt64LE = defineBigIntMethod(function readBigInt64LE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, "offset");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const val = this[offset + 4] + this[offset + 5] * 2 ** 8 + this[offset + 6] * 2 ** 16 + (last << 24);
+      return (BigInt(val) << BigInt(32)) + BigInt(first + this[++offset] * 2 ** 8 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 24);
+    });
+    Buffer3.prototype.readBigInt64BE = defineBigIntMethod(function readBigInt64BE(offset) {
+      offset = offset >>> 0;
+      validateNumber(offset, "offset");
+      const first = this[offset];
+      const last = this[offset + 7];
+      if (first === void 0 || last === void 0) {
+        boundsError(offset, this.length - 8);
+      }
+      const val = (first << 24) + // Overflow
+      this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + this[++offset];
+      return (BigInt(val) << BigInt(32)) + BigInt(this[++offset] * 2 ** 24 + this[++offset] * 2 ** 16 + this[++offset] * 2 ** 8 + last);
+    });
+    Buffer3.prototype.readFloatLE = function readFloatLE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 4, this.length);
+      return ieee754.read(this, offset, true, 23, 4);
+    };
+    Buffer3.prototype.readFloatBE = function readFloatBE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 4, this.length);
+      return ieee754.read(this, offset, false, 23, 4);
+    };
+    Buffer3.prototype.readDoubleLE = function readDoubleLE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 8, this.length);
+      return ieee754.read(this, offset, true, 52, 8);
+    };
+    Buffer3.prototype.readDoubleBE = function readDoubleBE(offset, noAssert) {
+      offset = offset >>> 0;
+      if (!noAssert) checkOffset(offset, 8, this.length);
+      return ieee754.read(this, offset, false, 52, 8);
+    };
+    function checkInt(buf, value, offset, ext, max, min) {
+      if (!Buffer3.isBuffer(buf)) throw new TypeError('"buffer" argument must be a Buffer instance');
+      if (value > max || value < min) throw new RangeError('"value" argument is out of bounds');
+      if (offset + ext > buf.length) throw new RangeError("Index out of range");
+    }
+    Buffer3.prototype.writeUintLE = Buffer3.prototype.writeUIntLE = function writeUIntLE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) {
+        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+        checkInt(this, value, offset, byteLength2, maxBytes, 0);
+      }
+      let mul = 1;
+      let i = 0;
+      this[offset] = value & 255;
+      while (++i < byteLength2 && (mul *= 256)) {
+        this[offset + i] = value / mul & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer3.prototype.writeUintBE = Buffer3.prototype.writeUIntBE = function writeUIntBE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      byteLength2 = byteLength2 >>> 0;
+      if (!noAssert) {
+        const maxBytes = Math.pow(2, 8 * byteLength2) - 1;
+        checkInt(this, value, offset, byteLength2, maxBytes, 0);
+      }
+      let i = byteLength2 - 1;
+      let mul = 1;
+      this[offset + i] = value & 255;
+      while (--i >= 0 && (mul *= 256)) {
+        this[offset + i] = value / mul & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer3.prototype.writeUint8 = Buffer3.prototype.writeUInt8 = function writeUInt8(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 1, 255, 0);
+      this[offset] = value & 255;
+      return offset + 1;
+    };
+    Buffer3.prototype.writeUint16LE = Buffer3.prototype.writeUInt16LE = function writeUInt16LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 2, 65535, 0);
+      this[offset] = value & 255;
+      this[offset + 1] = value >>> 8;
+      return offset + 2;
+    };
+    Buffer3.prototype.writeUint16BE = Buffer3.prototype.writeUInt16BE = function writeUInt16BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 2, 65535, 0);
+      this[offset] = value >>> 8;
+      this[offset + 1] = value & 255;
+      return offset + 2;
+    };
+    Buffer3.prototype.writeUint32LE = Buffer3.prototype.writeUInt32LE = function writeUInt32LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 4, 4294967295, 0);
+      this[offset + 3] = value >>> 24;
+      this[offset + 2] = value >>> 16;
+      this[offset + 1] = value >>> 8;
+      this[offset] = value & 255;
+      return offset + 4;
+    };
+    Buffer3.prototype.writeUint32BE = Buffer3.prototype.writeUInt32BE = function writeUInt32BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 4, 4294967295, 0);
+      this[offset] = value >>> 24;
+      this[offset + 1] = value >>> 16;
+      this[offset + 2] = value >>> 8;
+      this[offset + 3] = value & 255;
+      return offset + 4;
+    };
+    function wrtBigUInt64LE(buf, value, offset, min, max) {
+      checkIntBI(value, min, max, buf, offset, 7);
+      let lo = Number(value & BigInt(4294967295));
+      buf[offset++] = lo;
+      lo = lo >> 8;
+      buf[offset++] = lo;
+      lo = lo >> 8;
+      buf[offset++] = lo;
+      lo = lo >> 8;
+      buf[offset++] = lo;
+      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+      buf[offset++] = hi;
+      hi = hi >> 8;
+      buf[offset++] = hi;
+      hi = hi >> 8;
+      buf[offset++] = hi;
+      hi = hi >> 8;
+      buf[offset++] = hi;
+      return offset;
+    }
+    function wrtBigUInt64BE(buf, value, offset, min, max) {
+      checkIntBI(value, min, max, buf, offset, 7);
+      let lo = Number(value & BigInt(4294967295));
+      buf[offset + 7] = lo;
+      lo = lo >> 8;
+      buf[offset + 6] = lo;
+      lo = lo >> 8;
+      buf[offset + 5] = lo;
+      lo = lo >> 8;
+      buf[offset + 4] = lo;
+      let hi = Number(value >> BigInt(32) & BigInt(4294967295));
+      buf[offset + 3] = hi;
+      hi = hi >> 8;
+      buf[offset + 2] = hi;
+      hi = hi >> 8;
+      buf[offset + 1] = hi;
+      hi = hi >> 8;
+      buf[offset] = hi;
+      return offset + 8;
+    }
+    Buffer3.prototype.writeBigUInt64LE = defineBigIntMethod(function writeBigUInt64LE(value, offset = 0) {
+      return wrtBigUInt64LE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
+    });
+    Buffer3.prototype.writeBigUInt64BE = defineBigIntMethod(function writeBigUInt64BE(value, offset = 0) {
+      return wrtBigUInt64BE(this, value, offset, BigInt(0), BigInt("0xffffffffffffffff"));
+    });
+    Buffer3.prototype.writeIntLE = function writeIntLE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        const limit = Math.pow(2, 8 * byteLength2 - 1);
+        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+      }
+      let i = 0;
+      let mul = 1;
+      let sub = 0;
+      this[offset] = value & 255;
+      while (++i < byteLength2 && (mul *= 256)) {
+        if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
+          sub = 1;
+        }
+        this[offset + i] = (value / mul >> 0) - sub & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer3.prototype.writeIntBE = function writeIntBE(value, offset, byteLength2, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        const limit = Math.pow(2, 8 * byteLength2 - 1);
+        checkInt(this, value, offset, byteLength2, limit - 1, -limit);
+      }
+      let i = byteLength2 - 1;
+      let mul = 1;
+      let sub = 0;
+      this[offset + i] = value & 255;
+      while (--i >= 0 && (mul *= 256)) {
+        if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
+          sub = 1;
+        }
+        this[offset + i] = (value / mul >> 0) - sub & 255;
+      }
+      return offset + byteLength2;
+    };
+    Buffer3.prototype.writeInt8 = function writeInt8(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 1, 127, -128);
+      if (value < 0) value = 255 + value + 1;
+      this[offset] = value & 255;
+      return offset + 1;
+    };
+    Buffer3.prototype.writeInt16LE = function writeInt16LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 2, 32767, -32768);
+      this[offset] = value & 255;
+      this[offset + 1] = value >>> 8;
+      return offset + 2;
+    };
+    Buffer3.prototype.writeInt16BE = function writeInt16BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 2, 32767, -32768);
+      this[offset] = value >>> 8;
+      this[offset + 1] = value & 255;
+      return offset + 2;
+    };
+    Buffer3.prototype.writeInt32LE = function writeInt32LE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 4, 2147483647, -2147483648);
+      this[offset] = value & 255;
+      this[offset + 1] = value >>> 8;
+      this[offset + 2] = value >>> 16;
+      this[offset + 3] = value >>> 24;
+      return offset + 4;
+    };
+    Buffer3.prototype.writeInt32BE = function writeInt32BE(value, offset, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) checkInt(this, value, offset, 4, 2147483647, -2147483648);
+      if (value < 0) value = 4294967295 + value + 1;
+      this[offset] = value >>> 24;
+      this[offset + 1] = value >>> 16;
+      this[offset + 2] = value >>> 8;
+      this[offset + 3] = value & 255;
+      return offset + 4;
+    };
+    Buffer3.prototype.writeBigInt64LE = defineBigIntMethod(function writeBigInt64LE(value, offset = 0) {
+      return wrtBigUInt64LE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
+    });
+    Buffer3.prototype.writeBigInt64BE = defineBigIntMethod(function writeBigInt64BE(value, offset = 0) {
+      return wrtBigUInt64BE(this, value, offset, -BigInt("0x8000000000000000"), BigInt("0x7fffffffffffffff"));
+    });
+    function checkIEEE754(buf, value, offset, ext, max, min) {
+      if (offset + ext > buf.length) throw new RangeError("Index out of range");
+      if (offset < 0) throw new RangeError("Index out of range");
+    }
+    function writeFloat(buf, value, offset, littleEndian, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        checkIEEE754(buf, value, offset, 4, 34028234663852886e22, -34028234663852886e22);
+      }
+      ieee754.write(buf, value, offset, littleEndian, 23, 4);
+      return offset + 4;
+    }
+    Buffer3.prototype.writeFloatLE = function writeFloatLE(value, offset, noAssert) {
+      return writeFloat(this, value, offset, true, noAssert);
+    };
+    Buffer3.prototype.writeFloatBE = function writeFloatBE(value, offset, noAssert) {
+      return writeFloat(this, value, offset, false, noAssert);
+    };
+    function writeDouble(buf, value, offset, littleEndian, noAssert) {
+      value = +value;
+      offset = offset >>> 0;
+      if (!noAssert) {
+        checkIEEE754(buf, value, offset, 8, 17976931348623157e292, -17976931348623157e292);
+      }
+      ieee754.write(buf, value, offset, littleEndian, 52, 8);
+      return offset + 8;
+    }
+    Buffer3.prototype.writeDoubleLE = function writeDoubleLE(value, offset, noAssert) {
+      return writeDouble(this, value, offset, true, noAssert);
+    };
+    Buffer3.prototype.writeDoubleBE = function writeDoubleBE(value, offset, noAssert) {
+      return writeDouble(this, value, offset, false, noAssert);
+    };
+    Buffer3.prototype.copy = function copy(target, targetStart, start, end) {
+      if (!Buffer3.isBuffer(target)) throw new TypeError("argument should be a Buffer");
+      if (!start) start = 0;
+      if (!end && end !== 0) end = this.length;
+      if (targetStart >= target.length) targetStart = target.length;
+      if (!targetStart) targetStart = 0;
+      if (end > 0 && end < start) end = start;
+      if (end === start) return 0;
+      if (target.length === 0 || this.length === 0) return 0;
+      if (targetStart < 0) {
+        throw new RangeError("targetStart out of bounds");
+      }
+      if (start < 0 || start >= this.length) throw new RangeError("Index out of range");
+      if (end < 0) throw new RangeError("sourceEnd out of bounds");
+      if (end > this.length) end = this.length;
+      if (target.length - targetStart < end - start) {
+        end = target.length - targetStart + start;
+      }
+      const len = end - start;
+      if (this === target && typeof Uint8Array.prototype.copyWithin === "function") {
+        this.copyWithin(targetStart, start, end);
+      } else {
+        Uint8Array.prototype.set.call(
+          target,
+          this.subarray(start, end),
+          targetStart
+        );
+      }
+      return len;
+    };
+    Buffer3.prototype.fill = function fill(val, start, end, encoding) {
+      if (typeof val === "string") {
+        if (typeof start === "string") {
+          encoding = start;
+          start = 0;
+          end = this.length;
+        } else if (typeof end === "string") {
+          encoding = end;
+          end = this.length;
+        }
+        if (encoding !== void 0 && typeof encoding !== "string") {
+          throw new TypeError("encoding must be a string");
+        }
+        if (typeof encoding === "string" && !Buffer3.isEncoding(encoding)) {
+          throw new TypeError("Unknown encoding: " + encoding);
+        }
+        if (val.length === 1) {
+          const code = val.charCodeAt(0);
+          if (encoding === "utf8" && code < 128 || encoding === "latin1") {
+            val = code;
+          }
+        }
+      } else if (typeof val === "number") {
+        val = val & 255;
+      } else if (typeof val === "boolean") {
+        val = Number(val);
+      }
+      if (start < 0 || this.length < start || this.length < end) {
+        throw new RangeError("Out of range index");
+      }
+      if (end <= start) {
+        return this;
+      }
+      start = start >>> 0;
+      end = end === void 0 ? this.length : end >>> 0;
+      if (!val) val = 0;
+      let i;
+      if (typeof val === "number") {
+        for (i = start; i < end; ++i) {
+          this[i] = val;
+        }
+      } else {
+        const bytes = Buffer3.isBuffer(val) ? val : Buffer3.from(val, encoding);
+        const len = bytes.length;
+        if (len === 0) {
+          throw new TypeError('The value "' + val + '" is invalid for argument "value"');
+        }
+        for (i = 0; i < end - start; ++i) {
+          this[i + start] = bytes[i % len];
+        }
+      }
+      return this;
+    };
+    var errors = {};
+    function E(sym, getMessage, Base) {
+      errors[sym] = class NodeError extends Base {
+        constructor() {
+          super();
+          Object.defineProperty(this, "message", {
+            value: getMessage.apply(this, arguments),
+            writable: true,
+            configurable: true
+          });
+          this.name = `${this.name} [${sym}]`;
+          this.stack;
+          delete this.name;
+        }
+        get code() {
+          return sym;
+        }
+        set code(value) {
+          Object.defineProperty(this, "code", {
+            configurable: true,
+            enumerable: true,
+            value,
+            writable: true
+          });
+        }
+        toString() {
+          return `${this.name} [${sym}]: ${this.message}`;
+        }
+      };
+    }
+    E(
+      "ERR_BUFFER_OUT_OF_BOUNDS",
+      function(name) {
+        if (name) {
+          return `${name} is outside of buffer bounds`;
+        }
+        return "Attempt to access memory outside buffer bounds";
+      },
+      RangeError
+    );
+    E(
+      "ERR_INVALID_ARG_TYPE",
+      function(name, actual) {
+        return `The "${name}" argument must be of type number. Received type ${typeof actual}`;
+      },
+      TypeError
+    );
+    E(
+      "ERR_OUT_OF_RANGE",
+      function(str, range, input) {
+        let msg = `The value of "${str}" is out of range.`;
+        let received = input;
+        if (Number.isInteger(input) && Math.abs(input) > 2 ** 32) {
+          received = addNumericalSeparator(String(input));
+        } else if (typeof input === "bigint") {
+          received = String(input);
+          if (input > BigInt(2) ** BigInt(32) || input < -(BigInt(2) ** BigInt(32))) {
+            received = addNumericalSeparator(received);
+          }
+          received += "n";
+        }
+        msg += ` It must be ${range}. Received ${received}`;
+        return msg;
+      },
+      RangeError
+    );
+    function addNumericalSeparator(val) {
+      let res = "";
+      let i = val.length;
+      const start = val[0] === "-" ? 1 : 0;
+      for (; i >= start + 4; i -= 3) {
+        res = `_${val.slice(i - 3, i)}${res}`;
+      }
+      return `${val.slice(0, i)}${res}`;
+    }
+    function checkBounds(buf, offset, byteLength2) {
+      validateNumber(offset, "offset");
+      if (buf[offset] === void 0 || buf[offset + byteLength2] === void 0) {
+        boundsError(offset, buf.length - (byteLength2 + 1));
+      }
+    }
+    function checkIntBI(value, min, max, buf, offset, byteLength2) {
+      if (value > max || value < min) {
+        const n = typeof min === "bigint" ? "n" : "";
+        let range;
+        if (byteLength2 > 3) {
+          if (min === 0 || min === BigInt(0)) {
+            range = `>= 0${n} and < 2${n} ** ${(byteLength2 + 1) * 8}${n}`;
+          } else {
+            range = `>= -(2${n} ** ${(byteLength2 + 1) * 8 - 1}${n}) and < 2 ** ${(byteLength2 + 1) * 8 - 1}${n}`;
+          }
+        } else {
+          range = `>= ${min}${n} and <= ${max}${n}`;
+        }
+        throw new errors.ERR_OUT_OF_RANGE("value", range, value);
+      }
+      checkBounds(buf, offset, byteLength2);
+    }
+    function validateNumber(value, name) {
+      if (typeof value !== "number") {
+        throw new errors.ERR_INVALID_ARG_TYPE(name, "number", value);
+      }
+    }
+    function boundsError(value, length, type) {
+      if (Math.floor(value) !== value) {
+        validateNumber(value, type);
+        throw new errors.ERR_OUT_OF_RANGE(type || "offset", "an integer", value);
+      }
+      if (length < 0) {
+        throw new errors.ERR_BUFFER_OUT_OF_BOUNDS();
+      }
+      throw new errors.ERR_OUT_OF_RANGE(
+        type || "offset",
+        `>= ${type ? 1 : 0} and <= ${length}`,
+        value
+      );
+    }
+    var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g;
+    function base64clean(str) {
+      str = str.split("=")[0];
+      str = str.trim().replace(INVALID_BASE64_RE, "");
+      if (str.length < 2) return "";
+      while (str.length % 4 !== 0) {
+        str = str + "=";
+      }
+      return str;
+    }
+    function utf8ToBytes(string, units) {
+      units = units || Infinity;
+      let codePoint;
+      const length = string.length;
+      let leadSurrogate = null;
+      const bytes = [];
+      for (let i = 0; i < length; ++i) {
+        codePoint = string.charCodeAt(i);
+        if (codePoint > 55295 && codePoint < 57344) {
+          if (!leadSurrogate) {
+            if (codePoint > 56319) {
+              if ((units -= 3) > -1) bytes.push(239, 191, 189);
+              continue;
+            } else if (i + 1 === length) {
+              if ((units -= 3) > -1) bytes.push(239, 191, 189);
+              continue;
+            }
+            leadSurrogate = codePoint;
+            continue;
+          }
+          if (codePoint < 56320) {
+            if ((units -= 3) > -1) bytes.push(239, 191, 189);
+            leadSurrogate = codePoint;
+            continue;
+          }
+          codePoint = (leadSurrogate - 55296 << 10 | codePoint - 56320) + 65536;
+        } else if (leadSurrogate) {
+          if ((units -= 3) > -1) bytes.push(239, 191, 189);
+        }
+        leadSurrogate = null;
+        if (codePoint < 128) {
+          if ((units -= 1) < 0) break;
+          bytes.push(codePoint);
+        } else if (codePoint < 2048) {
+          if ((units -= 2) < 0) break;
+          bytes.push(
+            codePoint >> 6 | 192,
+            codePoint & 63 | 128
+          );
+        } else if (codePoint < 65536) {
+          if ((units -= 3) < 0) break;
+          bytes.push(
+            codePoint >> 12 | 224,
+            codePoint >> 6 & 63 | 128,
+            codePoint & 63 | 128
+          );
+        } else if (codePoint < 1114112) {
+          if ((units -= 4) < 0) break;
+          bytes.push(
+            codePoint >> 18 | 240,
+            codePoint >> 12 & 63 | 128,
+            codePoint >> 6 & 63 | 128,
+            codePoint & 63 | 128
+          );
+        } else {
+          throw new Error("Invalid code point");
+        }
+      }
+      return bytes;
+    }
+    function asciiToBytes(str) {
+      const byteArray = [];
+      for (let i = 0; i < str.length; ++i) {
+        byteArray.push(str.charCodeAt(i) & 255);
+      }
+      return byteArray;
+    }
+    function utf16leToBytes(str, units) {
+      let c, hi, lo;
+      const byteArray = [];
+      for (let i = 0; i < str.length; ++i) {
+        if ((units -= 2) < 0) break;
+        c = str.charCodeAt(i);
+        hi = c >> 8;
+        lo = c % 256;
+        byteArray.push(lo);
+        byteArray.push(hi);
+      }
+      return byteArray;
+    }
+    function base64ToBytes(str) {
+      return base64.toByteArray(base64clean(str));
+    }
+    function blitBuffer(src, dst, offset, length) {
+      let i;
+      for (i = 0; i < length; ++i) {
+        if (i + offset >= dst.length || i >= src.length) break;
+        dst[i + offset] = src[i];
+      }
+      return i;
+    }
+    function isInstance(obj, type) {
+      return obj instanceof type || obj != null && obj.constructor != null && obj.constructor.name != null && obj.constructor.name === type.name;
+    }
+    function numberIsNaN(obj) {
+      return obj !== obj;
+    }
+    var hexSliceLookupTable = (function() {
+      const alphabet = "0123456789abcdef";
+      const table = new Array(256);
+      for (let i = 0; i < 16; ++i) {
+        const i16 = i * 16;
+        for (let j = 0; j < 16; ++j) {
+          table[i16 + j] = alphabet[i] + alphabet[j];
+        }
+      }
+      return table;
+    })();
+    function defineBigIntMethod(fn) {
+      return typeof BigInt === "undefined" ? BufferBigIntNotDefined : fn;
+    }
+    function BufferBigIntNotDefined() {
+      throw new Error("BigInt not supported");
+    }
+  }
+});
+
+// bufinject.js
+var import_buffer, process;
+var init_bufinject = __esm({
+  "bufinject.js"() {
+    import_buffer = __toESM(require_buffer());
+    process = { env: { NODE_ENV: "production" }, platform: "linux", browser: true, cwd: () => "/", nextTick: (f, ...a) => Promise.resolve().then(() => f(...a)) };
+  }
+});
+
+// node_modules/async-lock/lib/index.js
+var require_lib = __commonJS({
+  "node_modules/async-lock/lib/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var AsyncLock2 = function(opts) {
+      opts = opts || {};
+      this.Promise = opts.Promise || Promise;
+      this.queues = /* @__PURE__ */ Object.create(null);
+      this.domainReentrant = opts.domainReentrant || false;
+      if (this.domainReentrant) {
+        if (typeof process === "undefined" || typeof process.domain === "undefined") {
+          throw new Error(
+            "Domain-reentrant locks require `process.domain` to exist. Please flip `opts.domainReentrant = false`, use a NodeJS version that still implements Domain, or install a browser polyfill."
+          );
+        }
+        this.domains = /* @__PURE__ */ Object.create(null);
+      }
+      this.timeout = opts.timeout || AsyncLock2.DEFAULT_TIMEOUT;
+      this.maxOccupationTime = opts.maxOccupationTime || AsyncLock2.DEFAULT_MAX_OCCUPATION_TIME;
+      this.maxExecutionTime = opts.maxExecutionTime || AsyncLock2.DEFAULT_MAX_EXECUTION_TIME;
+      if (opts.maxPending === Infinity || Number.isInteger(opts.maxPending) && opts.maxPending >= 0) {
+        this.maxPending = opts.maxPending;
+      } else {
+        this.maxPending = AsyncLock2.DEFAULT_MAX_PENDING;
+      }
+    };
+    AsyncLock2.DEFAULT_TIMEOUT = 0;
+    AsyncLock2.DEFAULT_MAX_OCCUPATION_TIME = 0;
+    AsyncLock2.DEFAULT_MAX_EXECUTION_TIME = 0;
+    AsyncLock2.DEFAULT_MAX_PENDING = 1e3;
+    AsyncLock2.prototype.acquire = function(key, fn, cb, opts) {
+      if (Array.isArray(key)) {
+        return this._acquireBatch(key, fn, cb, opts);
+      }
+      if (typeof fn !== "function") {
+        throw new Error("You must pass a function to execute");
+      }
+      var deferredResolve = null;
+      var deferredReject = null;
+      var deferred = null;
+      if (typeof cb !== "function") {
+        opts = cb;
+        cb = null;
+        deferred = new this.Promise(function(resolve, reject) {
+          deferredResolve = resolve;
+          deferredReject = reject;
+        });
+      }
+      opts = opts || {};
+      var resolved = false;
+      var timer = null;
+      var occupationTimer = null;
+      var executionTimer = null;
+      var self = this;
+      var done = function(locked, err, ret) {
+        if (occupationTimer) {
+          clearTimeout(occupationTimer);
+          occupationTimer = null;
+        }
+        if (executionTimer) {
+          clearTimeout(executionTimer);
+          executionTimer = null;
+        }
+        if (locked) {
+          if (!!self.queues[key] && self.queues[key].length === 0) {
+            delete self.queues[key];
+          }
+          if (self.domainReentrant) {
+            delete self.domains[key];
+          }
+        }
+        if (!resolved) {
+          if (!deferred) {
+            if (typeof cb === "function") {
+              cb(err, ret);
+            }
+          } else {
+            if (err) {
+              deferredReject(err);
+            } else {
+              deferredResolve(ret);
+            }
+          }
+          resolved = true;
+        }
+        if (locked) {
+          if (!!self.queues[key] && self.queues[key].length > 0) {
+            self.queues[key].shift()();
+          }
+        }
+      };
+      var exec = function(locked) {
+        if (resolved) {
+          return done(locked);
+        }
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        if (self.domainReentrant && locked) {
+          self.domains[key] = process.domain;
+        }
+        var maxExecutionTime = opts.maxExecutionTime || self.maxExecutionTime;
+        if (maxExecutionTime) {
+          executionTimer = setTimeout(function() {
+            if (!!self.queues[key]) {
+              done(locked, new Error("Maximum execution time is exceeded " + key));
+            }
+          }, maxExecutionTime);
+        }
+        if (fn.length === 1) {
+          var called = false;
+          try {
+            fn(function(err, ret) {
+              if (!called) {
+                called = true;
+                done(locked, err, ret);
+              }
+            });
+          } catch (err) {
+            if (!called) {
+              called = true;
+              done(locked, err);
+            }
+          }
+        } else {
+          self._promiseTry(function() {
+            return fn();
+          }).then(function(ret) {
+            done(locked, void 0, ret);
+          }, function(error) {
+            done(locked, error);
+          });
+        }
+      };
+      if (self.domainReentrant && !!process.domain) {
+        exec = process.domain.bind(exec);
+      }
+      var maxPending = opts.maxPending || self.maxPending;
+      if (!self.queues[key]) {
+        self.queues[key] = [];
+        exec(true);
+      } else if (self.domainReentrant && !!process.domain && process.domain === self.domains[key]) {
+        exec(false);
+      } else if (self.queues[key].length >= maxPending) {
+        done(false, new Error("Too many pending tasks in queue " + key));
+      } else {
+        var taskFn = function() {
+          exec(true);
+        };
+        if (opts.skipQueue) {
+          self.queues[key].unshift(taskFn);
+        } else {
+          self.queues[key].push(taskFn);
+        }
+        var timeout = opts.timeout || self.timeout;
+        if (timeout) {
+          timer = setTimeout(function() {
+            timer = null;
+            done(false, new Error("async-lock timed out in queue " + key));
+          }, timeout);
+        }
+      }
+      var maxOccupationTime = opts.maxOccupationTime || self.maxOccupationTime;
+      if (maxOccupationTime) {
+        occupationTimer = setTimeout(function() {
+          if (!!self.queues[key]) {
+            done(false, new Error("Maximum occupation time is exceeded in queue " + key));
+          }
+        }, maxOccupationTime);
+      }
+      if (deferred) {
+        return deferred;
+      }
+    };
+    AsyncLock2.prototype._acquireBatch = function(keys, fn, cb, opts) {
+      if (typeof cb !== "function") {
+        opts = cb;
+        cb = null;
+      }
+      var self = this;
+      var getFn = function(key, fn2) {
+        return function(cb2) {
+          self.acquire(key, fn2, cb2, opts);
+        };
+      };
+      var fnx = keys.reduceRight(function(prev, key) {
+        return getFn(key, prev);
+      }, fn);
+      if (typeof cb === "function") {
+        fnx(cb);
+      } else {
+        return new this.Promise(function(resolve, reject) {
+          if (fnx.length === 1) {
+            fnx(function(err, ret) {
+              if (err) {
+                reject(err);
+              } else {
+                resolve(ret);
+              }
+            });
+          } else {
+            resolve(fnx());
+          }
+        });
+      }
+    };
+    AsyncLock2.prototype.isBusy = function(key) {
+      if (!key) {
+        return Object.keys(this.queues).length > 0;
+      } else {
+        return !!this.queues[key];
+      }
+    };
+    AsyncLock2.prototype._promiseTry = function(fn) {
+      try {
+        return this.Promise.resolve(fn());
+      } catch (e) {
+        return this.Promise.reject(e);
+      }
+    };
+    module.exports = AsyncLock2;
+  }
+});
+
+// node_modules/async-lock/index.js
+var require_async_lock = __commonJS({
+  "node_modules/async-lock/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = require_lib();
+  }
+});
+
+// node_modules/inherits/inherits_browser.js
+var require_inherits_browser = __commonJS({
+  "node_modules/inherits/inherits_browser.js"(exports, module) {
+    init_bufinject();
+    if (typeof Object.create === "function") {
+      module.exports = function inherits(ctor, superCtor) {
+        if (superCtor) {
+          ctor.super_ = superCtor;
+          ctor.prototype = Object.create(superCtor.prototype, {
+            constructor: {
+              value: ctor,
+              enumerable: false,
+              writable: true,
+              configurable: true
+            }
+          });
+        }
+      };
+    } else {
+      module.exports = function inherits(ctor, superCtor) {
+        if (superCtor) {
+          ctor.super_ = superCtor;
+          var TempCtor = function() {
+          };
+          TempCtor.prototype = superCtor.prototype;
+          ctor.prototype = new TempCtor();
+          ctor.prototype.constructor = ctor;
+        }
+      };
+    }
+  }
+});
+
+// node_modules/safe-buffer/index.js
+var require_safe_buffer = __commonJS({
+  "node_modules/safe-buffer/index.js"(exports, module) {
+    init_bufinject();
+    var buffer = require_buffer();
+    var Buffer3 = buffer.Buffer;
+    function copyProps(src, dst) {
+      for (var key in src) {
+        dst[key] = src[key];
+      }
+    }
+    if (Buffer3.from && Buffer3.alloc && Buffer3.allocUnsafe && Buffer3.allocUnsafeSlow) {
+      module.exports = buffer;
+    } else {
+      copyProps(buffer, exports);
+      exports.Buffer = SafeBuffer;
+    }
+    function SafeBuffer(arg, encodingOrOffset, length) {
+      return Buffer3(arg, encodingOrOffset, length);
+    }
+    SafeBuffer.prototype = Object.create(Buffer3.prototype);
+    copyProps(Buffer3, SafeBuffer);
+    SafeBuffer.from = function(arg, encodingOrOffset, length) {
+      if (typeof arg === "number") {
+        throw new TypeError("Argument must not be a number");
+      }
+      return Buffer3(arg, encodingOrOffset, length);
+    };
+    SafeBuffer.alloc = function(size, fill, encoding) {
+      if (typeof size !== "number") {
+        throw new TypeError("Argument must be a number");
+      }
+      var buf = Buffer3(size);
+      if (fill !== void 0) {
+        if (typeof encoding === "string") {
+          buf.fill(fill, encoding);
+        } else {
+          buf.fill(fill);
+        }
+      } else {
+        buf.fill(0);
+      }
+      return buf;
+    };
+    SafeBuffer.allocUnsafe = function(size) {
+      if (typeof size !== "number") {
+        throw new TypeError("Argument must be a number");
+      }
+      return Buffer3(size);
+    };
+    SafeBuffer.allocUnsafeSlow = function(size) {
+      if (typeof size !== "number") {
+        throw new TypeError("Argument must be a number");
+      }
+      return buffer.SlowBuffer(size);
+    };
+  }
+});
+
+// node_modules/isarray/index.js
+var require_isarray = __commonJS({
+  "node_modules/isarray/index.js"(exports, module) {
+    init_bufinject();
+    var toString = {}.toString;
+    module.exports = Array.isArray || function(arr) {
+      return toString.call(arr) == "[object Array]";
+    };
+  }
+});
+
+// node_modules/es-errors/type.js
+var require_type = __commonJS({
+  "node_modules/es-errors/type.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = TypeError;
+  }
+});
+
+// node_modules/es-object-atoms/index.js
+var require_es_object_atoms = __commonJS({
+  "node_modules/es-object-atoms/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Object;
+  }
+});
+
+// node_modules/es-errors/index.js
+var require_es_errors = __commonJS({
+  "node_modules/es-errors/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Error;
+  }
+});
+
+// node_modules/es-errors/eval.js
+var require_eval = __commonJS({
+  "node_modules/es-errors/eval.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = EvalError;
+  }
+});
+
+// node_modules/es-errors/range.js
+var require_range = __commonJS({
+  "node_modules/es-errors/range.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = RangeError;
+  }
+});
+
+// node_modules/es-errors/ref.js
+var require_ref = __commonJS({
+  "node_modules/es-errors/ref.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = ReferenceError;
+  }
+});
+
+// node_modules/es-errors/syntax.js
+var require_syntax = __commonJS({
+  "node_modules/es-errors/syntax.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = SyntaxError;
+  }
+});
+
+// node_modules/es-errors/uri.js
+var require_uri = __commonJS({
+  "node_modules/es-errors/uri.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = URIError;
+  }
+});
+
+// node_modules/math-intrinsics/abs.js
+var require_abs = __commonJS({
+  "node_modules/math-intrinsics/abs.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Math.abs;
+  }
+});
+
+// node_modules/math-intrinsics/floor.js
+var require_floor = __commonJS({
+  "node_modules/math-intrinsics/floor.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Math.floor;
+  }
+});
+
+// node_modules/math-intrinsics/max.js
+var require_max = __commonJS({
+  "node_modules/math-intrinsics/max.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Math.max;
+  }
+});
+
+// node_modules/math-intrinsics/min.js
+var require_min = __commonJS({
+  "node_modules/math-intrinsics/min.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Math.min;
+  }
+});
+
+// node_modules/math-intrinsics/pow.js
+var require_pow = __commonJS({
+  "node_modules/math-intrinsics/pow.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Math.pow;
+  }
+});
+
+// node_modules/math-intrinsics/round.js
+var require_round = __commonJS({
+  "node_modules/math-intrinsics/round.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Math.round;
+  }
+});
+
+// node_modules/math-intrinsics/isNaN.js
+var require_isNaN = __commonJS({
+  "node_modules/math-intrinsics/isNaN.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Number.isNaN || function isNaN2(a) {
+      return a !== a;
+    };
+  }
+});
+
+// node_modules/math-intrinsics/sign.js
+var require_sign = __commonJS({
+  "node_modules/math-intrinsics/sign.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var $isNaN = require_isNaN();
+    module.exports = function sign(number) {
+      if ($isNaN(number) || number === 0) {
+        return number;
+      }
+      return number < 0 ? -1 : 1;
+    };
+  }
+});
+
+// node_modules/gopd/gOPD.js
+var require_gOPD = __commonJS({
+  "node_modules/gopd/gOPD.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Object.getOwnPropertyDescriptor;
+  }
+});
+
+// node_modules/gopd/index.js
+var require_gopd = __commonJS({
+  "node_modules/gopd/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var $gOPD = require_gOPD();
+    if ($gOPD) {
+      try {
+        $gOPD([], "length");
+      } catch (e) {
+        $gOPD = null;
+      }
+    }
+    module.exports = $gOPD;
+  }
+});
+
+// node_modules/es-define-property/index.js
+var require_es_define_property = __commonJS({
+  "node_modules/es-define-property/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var $defineProperty = Object.defineProperty || false;
+    if ($defineProperty) {
+      try {
+        $defineProperty({}, "a", { value: 1 });
+      } catch (e) {
+        $defineProperty = false;
+      }
+    }
+    module.exports = $defineProperty;
+  }
+});
+
+// node_modules/has-symbols/shams.js
+var require_shams = __commonJS({
+  "node_modules/has-symbols/shams.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = function hasSymbols() {
+      if (typeof Symbol !== "function" || typeof Object.getOwnPropertySymbols !== "function") {
+        return false;
+      }
+      if (typeof Symbol.iterator === "symbol") {
+        return true;
+      }
+      var obj = {};
+      var sym = /* @__PURE__ */ Symbol("test");
+      var symObj = Object(sym);
+      if (typeof sym === "string") {
+        return false;
+      }
+      if (Object.prototype.toString.call(sym) !== "[object Symbol]") {
+        return false;
+      }
+      if (Object.prototype.toString.call(symObj) !== "[object Symbol]") {
+        return false;
+      }
+      var symVal = 42;
+      obj[sym] = symVal;
+      for (var _ in obj) {
+        return false;
+      }
+      if (typeof Object.keys === "function" && Object.keys(obj).length !== 0) {
+        return false;
+      }
+      if (typeof Object.getOwnPropertyNames === "function" && Object.getOwnPropertyNames(obj).length !== 0) {
+        return false;
+      }
+      var syms = Object.getOwnPropertySymbols(obj);
+      if (syms.length !== 1 || syms[0] !== sym) {
+        return false;
+      }
+      if (!Object.prototype.propertyIsEnumerable.call(obj, sym)) {
+        return false;
+      }
+      if (typeof Object.getOwnPropertyDescriptor === "function") {
+        var descriptor = (
+          /** @type {PropertyDescriptor} */
+          Object.getOwnPropertyDescriptor(obj, sym)
+        );
+        if (descriptor.value !== symVal || descriptor.enumerable !== true) {
+          return false;
+        }
+      }
+      return true;
+    };
+  }
+});
+
+// node_modules/has-symbols/index.js
+var require_has_symbols = __commonJS({
+  "node_modules/has-symbols/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var origSymbol = typeof Symbol !== "undefined" && Symbol;
+    var hasSymbolSham = require_shams();
+    module.exports = function hasNativeSymbols() {
+      if (typeof origSymbol !== "function") {
+        return false;
+      }
+      if (typeof Symbol !== "function") {
+        return false;
+      }
+      if (typeof origSymbol("foo") !== "symbol") {
+        return false;
+      }
+      if (typeof /* @__PURE__ */ Symbol("bar") !== "symbol") {
+        return false;
+      }
+      return hasSymbolSham();
+    };
+  }
+});
+
+// node_modules/get-proto/Reflect.getPrototypeOf.js
+var require_Reflect_getPrototypeOf = __commonJS({
+  "node_modules/get-proto/Reflect.getPrototypeOf.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = typeof Reflect !== "undefined" && Reflect.getPrototypeOf || null;
+  }
+});
+
+// node_modules/get-proto/Object.getPrototypeOf.js
+var require_Object_getPrototypeOf = __commonJS({
+  "node_modules/get-proto/Object.getPrototypeOf.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var $Object = require_es_object_atoms();
+    module.exports = $Object.getPrototypeOf || null;
+  }
+});
+
+// node_modules/function-bind/implementation.js
+var require_implementation = __commonJS({
+  "node_modules/function-bind/implementation.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var ERROR_MESSAGE = "Function.prototype.bind called on incompatible ";
+    var toStr = Object.prototype.toString;
+    var max = Math.max;
+    var funcType = "[object Function]";
+    var concatty = function concatty2(a, b) {
+      var arr = [];
+      for (var i = 0; i < a.length; i += 1) {
+        arr[i] = a[i];
+      }
+      for (var j = 0; j < b.length; j += 1) {
+        arr[j + a.length] = b[j];
+      }
+      return arr;
+    };
+    var slicy = function slicy2(arrLike, offset) {
+      var arr = [];
+      for (var i = offset || 0, j = 0; i < arrLike.length; i += 1, j += 1) {
+        arr[j] = arrLike[i];
+      }
+      return arr;
+    };
+    var joiny = function(arr, joiner) {
+      var str = "";
+      for (var i = 0; i < arr.length; i += 1) {
+        str += arr[i];
+        if (i + 1 < arr.length) {
+          str += joiner;
+        }
+      }
+      return str;
+    };
+    module.exports = function bind(that) {
+      var target = this;
+      if (typeof target !== "function" || toStr.apply(target) !== funcType) {
+        throw new TypeError(ERROR_MESSAGE + target);
+      }
+      var args = slicy(arguments, 1);
+      var bound;
+      var binder = function() {
+        if (this instanceof bound) {
+          var result = target.apply(
+            this,
+            concatty(args, arguments)
+          );
+          if (Object(result) === result) {
+            return result;
+          }
+          return this;
+        }
+        return target.apply(
+          that,
+          concatty(args, arguments)
+        );
+      };
+      var boundLength = max(0, target.length - args.length);
+      var boundArgs = [];
+      for (var i = 0; i < boundLength; i++) {
+        boundArgs[i] = "$" + i;
+      }
+      bound = Function("binder", "return function (" + joiny(boundArgs, ",") + "){ return binder.apply(this,arguments); }")(binder);
+      if (target.prototype) {
+        var Empty = function Empty2() {
+        };
+        Empty.prototype = target.prototype;
+        bound.prototype = new Empty();
+        Empty.prototype = null;
+      }
+      return bound;
+    };
+  }
+});
+
+// node_modules/function-bind/index.js
+var require_function_bind = __commonJS({
+  "node_modules/function-bind/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var implementation = require_implementation();
+    module.exports = Function.prototype.bind || implementation;
+  }
+});
+
+// node_modules/call-bind-apply-helpers/functionCall.js
+var require_functionCall = __commonJS({
+  "node_modules/call-bind-apply-helpers/functionCall.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Function.prototype.call;
+  }
+});
+
+// node_modules/call-bind-apply-helpers/functionApply.js
+var require_functionApply = __commonJS({
+  "node_modules/call-bind-apply-helpers/functionApply.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = Function.prototype.apply;
+  }
+});
+
+// node_modules/call-bind-apply-helpers/reflectApply.js
+var require_reflectApply = __commonJS({
+  "node_modules/call-bind-apply-helpers/reflectApply.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = typeof Reflect !== "undefined" && Reflect && Reflect.apply;
+  }
+});
+
+// node_modules/call-bind-apply-helpers/actualApply.js
+var require_actualApply = __commonJS({
+  "node_modules/call-bind-apply-helpers/actualApply.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var bind = require_function_bind();
+    var $apply = require_functionApply();
+    var $call = require_functionCall();
+    var $reflectApply = require_reflectApply();
+    module.exports = $reflectApply || bind.call($call, $apply);
+  }
+});
+
+// node_modules/call-bind-apply-helpers/index.js
+var require_call_bind_apply_helpers = __commonJS({
+  "node_modules/call-bind-apply-helpers/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var bind = require_function_bind();
+    var $TypeError = require_type();
+    var $call = require_functionCall();
+    var $actualApply = require_actualApply();
+    module.exports = function callBindBasic(args) {
+      if (args.length < 1 || typeof args[0] !== "function") {
+        throw new $TypeError("a function is required");
+      }
+      return $actualApply(bind, $call, args);
+    };
+  }
+});
+
+// node_modules/dunder-proto/get.js
+var require_get = __commonJS({
+  "node_modules/dunder-proto/get.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var callBind = require_call_bind_apply_helpers();
+    var gOPD = require_gopd();
+    var hasProtoAccessor;
+    try {
+      hasProtoAccessor = /** @type {{ __proto__?: typeof Array.prototype }} */
+      [].__proto__ === Array.prototype;
+    } catch (e) {
+      if (!e || typeof e !== "object" || !("code" in e) || e.code !== "ERR_PROTO_ACCESS") {
+        throw e;
+      }
+    }
+    var desc = !!hasProtoAccessor && gOPD && gOPD(
+      Object.prototype,
+      /** @type {keyof typeof Object.prototype} */
+      "__proto__"
+    );
+    var $Object = Object;
+    var $getPrototypeOf = $Object.getPrototypeOf;
+    module.exports = desc && typeof desc.get === "function" ? callBind([desc.get]) : typeof $getPrototypeOf === "function" ? (
+      /** @type {import('./get')} */
+      function getDunder(value) {
+        return $getPrototypeOf(value == null ? value : $Object(value));
+      }
+    ) : false;
+  }
+});
+
+// node_modules/get-proto/index.js
+var require_get_proto = __commonJS({
+  "node_modules/get-proto/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var reflectGetProto = require_Reflect_getPrototypeOf();
+    var originalGetProto = require_Object_getPrototypeOf();
+    var getDunderProto = require_get();
+    module.exports = reflectGetProto ? function getProto(O) {
+      return reflectGetProto(O);
+    } : originalGetProto ? function getProto(O) {
+      if (!O || typeof O !== "object" && typeof O !== "function") {
+        throw new TypeError("getProto: not an object");
+      }
+      return originalGetProto(O);
+    } : getDunderProto ? function getProto(O) {
+      return getDunderProto(O);
+    } : null;
+  }
+});
+
+// node_modules/hasown/index.js
+var require_hasown = __commonJS({
+  "node_modules/hasown/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var call = Function.prototype.call;
+    var $hasOwn = Object.prototype.hasOwnProperty;
+    var bind = require_function_bind();
+    module.exports = bind.call(call, $hasOwn);
+  }
+});
+
+// node_modules/get-intrinsic/index.js
+var require_get_intrinsic = __commonJS({
+  "node_modules/get-intrinsic/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var undefined2;
+    var $Object = require_es_object_atoms();
+    var $Error = require_es_errors();
+    var $EvalError = require_eval();
+    var $RangeError = require_range();
+    var $ReferenceError = require_ref();
+    var $SyntaxError = require_syntax();
+    var $TypeError = require_type();
+    var $URIError = require_uri();
+    var abs = require_abs();
+    var floor = require_floor();
+    var max = require_max();
+    var min = require_min();
+    var pow = require_pow();
+    var round = require_round();
+    var sign = require_sign();
+    var $Function = Function;
+    var getEvalledConstructor = function(expressionSyntax) {
+      try {
+        return $Function('"use strict"; return (' + expressionSyntax + ").constructor;")();
+      } catch (e) {
+      }
+    };
+    var $gOPD = require_gopd();
+    var $defineProperty = require_es_define_property();
+    var throwTypeError = function() {
+      throw new $TypeError();
+    };
+    var ThrowTypeError = $gOPD ? (function() {
+      try {
+        arguments.callee;
+        return throwTypeError;
+      } catch (calleeThrows) {
+        try {
+          return $gOPD(arguments, "callee").get;
+        } catch (gOPDthrows) {
+          return throwTypeError;
+        }
+      }
+    })() : throwTypeError;
+    var hasSymbols = require_has_symbols()();
+    var getProto = require_get_proto();
+    var $ObjectGPO = require_Object_getPrototypeOf();
+    var $ReflectGPO = require_Reflect_getPrototypeOf();
+    var $apply = require_functionApply();
+    var $call = require_functionCall();
+    var needsEval = {};
+    var TypedArray = typeof Uint8Array === "undefined" || !getProto ? undefined2 : getProto(Uint8Array);
+    var INTRINSICS = {
+      __proto__: null,
+      "%AggregateError%": typeof AggregateError === "undefined" ? undefined2 : AggregateError,
+      "%Array%": Array,
+      "%ArrayBuffer%": typeof ArrayBuffer === "undefined" ? undefined2 : ArrayBuffer,
+      "%ArrayIteratorPrototype%": hasSymbols && getProto ? getProto([][Symbol.iterator]()) : undefined2,
+      "%AsyncFromSyncIteratorPrototype%": undefined2,
+      "%AsyncFunction%": needsEval,
+      "%AsyncGenerator%": needsEval,
+      "%AsyncGeneratorFunction%": needsEval,
+      "%AsyncIteratorPrototype%": needsEval,
+      "%Atomics%": typeof Atomics === "undefined" ? undefined2 : Atomics,
+      "%BigInt%": typeof BigInt === "undefined" ? undefined2 : BigInt,
+      "%BigInt64Array%": typeof BigInt64Array === "undefined" ? undefined2 : BigInt64Array,
+      "%BigUint64Array%": typeof BigUint64Array === "undefined" ? undefined2 : BigUint64Array,
+      "%Boolean%": Boolean,
+      "%DataView%": typeof DataView === "undefined" ? undefined2 : DataView,
+      "%Date%": Date,
+      "%decodeURI%": decodeURI,
+      "%decodeURIComponent%": decodeURIComponent,
+      "%encodeURI%": encodeURI,
+      "%encodeURIComponent%": encodeURIComponent,
+      "%Error%": $Error,
+      "%eval%": eval,
+      // eslint-disable-line no-eval
+      "%EvalError%": $EvalError,
+      "%Float16Array%": typeof Float16Array === "undefined" ? undefined2 : Float16Array,
+      "%Float32Array%": typeof Float32Array === "undefined" ? undefined2 : Float32Array,
+      "%Float64Array%": typeof Float64Array === "undefined" ? undefined2 : Float64Array,
+      "%FinalizationRegistry%": typeof FinalizationRegistry === "undefined" ? undefined2 : FinalizationRegistry,
+      "%Function%": $Function,
+      "%GeneratorFunction%": needsEval,
+      "%Int8Array%": typeof Int8Array === "undefined" ? undefined2 : Int8Array,
+      "%Int16Array%": typeof Int16Array === "undefined" ? undefined2 : Int16Array,
+      "%Int32Array%": typeof Int32Array === "undefined" ? undefined2 : Int32Array,
+      "%isFinite%": isFinite,
+      "%isNaN%": isNaN,
+      "%IteratorPrototype%": hasSymbols && getProto ? getProto(getProto([][Symbol.iterator]())) : undefined2,
+      "%JSON%": typeof JSON === "object" ? JSON : undefined2,
+      "%Map%": typeof Map === "undefined" ? undefined2 : Map,
+      "%MapIteratorPrototype%": typeof Map === "undefined" || !hasSymbols || !getProto ? undefined2 : getProto((/* @__PURE__ */ new Map())[Symbol.iterator]()),
+      "%Math%": Math,
+      "%Number%": Number,
+      "%Object%": $Object,
+      "%Object.getOwnPropertyDescriptor%": $gOPD,
+      "%parseFloat%": parseFloat,
+      "%parseInt%": parseInt,
+      "%Promise%": typeof Promise === "undefined" ? undefined2 : Promise,
+      "%Proxy%": typeof Proxy === "undefined" ? undefined2 : Proxy,
+      "%RangeError%": $RangeError,
+      "%ReferenceError%": $ReferenceError,
+      "%Reflect%": typeof Reflect === "undefined" ? undefined2 : Reflect,
+      "%RegExp%": RegExp,
+      "%Set%": typeof Set === "undefined" ? undefined2 : Set,
+      "%SetIteratorPrototype%": typeof Set === "undefined" || !hasSymbols || !getProto ? undefined2 : getProto((/* @__PURE__ */ new Set())[Symbol.iterator]()),
+      "%SharedArrayBuffer%": typeof SharedArrayBuffer === "undefined" ? undefined2 : SharedArrayBuffer,
+      "%String%": String,
+      "%StringIteratorPrototype%": hasSymbols && getProto ? getProto(""[Symbol.iterator]()) : undefined2,
+      "%Symbol%": hasSymbols ? Symbol : undefined2,
+      "%SyntaxError%": $SyntaxError,
+      "%ThrowTypeError%": ThrowTypeError,
+      "%TypedArray%": TypedArray,
+      "%TypeError%": $TypeError,
+      "%Uint8Array%": typeof Uint8Array === "undefined" ? undefined2 : Uint8Array,
+      "%Uint8ClampedArray%": typeof Uint8ClampedArray === "undefined" ? undefined2 : Uint8ClampedArray,
+      "%Uint16Array%": typeof Uint16Array === "undefined" ? undefined2 : Uint16Array,
+      "%Uint32Array%": typeof Uint32Array === "undefined" ? undefined2 : Uint32Array,
+      "%URIError%": $URIError,
+      "%WeakMap%": typeof WeakMap === "undefined" ? undefined2 : WeakMap,
+      "%WeakRef%": typeof WeakRef === "undefined" ? undefined2 : WeakRef,
+      "%WeakSet%": typeof WeakSet === "undefined" ? undefined2 : WeakSet,
+      "%Function.prototype.call%": $call,
+      "%Function.prototype.apply%": $apply,
+      "%Object.defineProperty%": $defineProperty,
+      "%Object.getPrototypeOf%": $ObjectGPO,
+      "%Math.abs%": abs,
+      "%Math.floor%": floor,
+      "%Math.max%": max,
+      "%Math.min%": min,
+      "%Math.pow%": pow,
+      "%Math.round%": round,
+      "%Math.sign%": sign,
+      "%Reflect.getPrototypeOf%": $ReflectGPO
+    };
+    if (getProto) {
+      try {
+        null.error;
+      } catch (e) {
+        errorProto = getProto(getProto(e));
+        INTRINSICS["%Error.prototype%"] = errorProto;
+      }
+    }
+    var errorProto;
+    var doEval = function doEval2(name) {
+      var value;
+      if (name === "%AsyncFunction%") {
+        value = getEvalledConstructor("async function () {}");
+      } else if (name === "%GeneratorFunction%") {
+        value = getEvalledConstructor("function* () {}");
+      } else if (name === "%AsyncGeneratorFunction%") {
+        value = getEvalledConstructor("async function* () {}");
+      } else if (name === "%AsyncGenerator%") {
+        var fn = doEval2("%AsyncGeneratorFunction%");
+        if (fn) {
+          value = fn.prototype;
+        }
+      } else if (name === "%AsyncIteratorPrototype%") {
+        var gen = doEval2("%AsyncGenerator%");
+        if (gen && getProto) {
+          value = getProto(gen.prototype);
+        }
+      }
+      INTRINSICS[name] = value;
+      return value;
+    };
+    var LEGACY_ALIASES = {
+      __proto__: null,
+      "%ArrayBufferPrototype%": ["ArrayBuffer", "prototype"],
+      "%ArrayPrototype%": ["Array", "prototype"],
+      "%ArrayProto_entries%": ["Array", "prototype", "entries"],
+      "%ArrayProto_forEach%": ["Array", "prototype", "forEach"],
+      "%ArrayProto_keys%": ["Array", "prototype", "keys"],
+      "%ArrayProto_values%": ["Array", "prototype", "values"],
+      "%AsyncFunctionPrototype%": ["AsyncFunction", "prototype"],
+      "%AsyncGenerator%": ["AsyncGeneratorFunction", "prototype"],
+      "%AsyncGeneratorPrototype%": ["AsyncGeneratorFunction", "prototype", "prototype"],
+      "%BooleanPrototype%": ["Boolean", "prototype"],
+      "%DataViewPrototype%": ["DataView", "prototype"],
+      "%DatePrototype%": ["Date", "prototype"],
+      "%ErrorPrototype%": ["Error", "prototype"],
+      "%EvalErrorPrototype%": ["EvalError", "prototype"],
+      "%Float32ArrayPrototype%": ["Float32Array", "prototype"],
+      "%Float64ArrayPrototype%": ["Float64Array", "prototype"],
+      "%FunctionPrototype%": ["Function", "prototype"],
+      "%Generator%": ["GeneratorFunction", "prototype"],
+      "%GeneratorPrototype%": ["GeneratorFunction", "prototype", "prototype"],
+      "%Int8ArrayPrototype%": ["Int8Array", "prototype"],
+      "%Int16ArrayPrototype%": ["Int16Array", "prototype"],
+      "%Int32ArrayPrototype%": ["Int32Array", "prototype"],
+      "%JSONParse%": ["JSON", "parse"],
+      "%JSONStringify%": ["JSON", "stringify"],
+      "%MapPrototype%": ["Map", "prototype"],
+      "%NumberPrototype%": ["Number", "prototype"],
+      "%ObjectPrototype%": ["Object", "prototype"],
+      "%ObjProto_toString%": ["Object", "prototype", "toString"],
+      "%ObjProto_valueOf%": ["Object", "prototype", "valueOf"],
+      "%PromisePrototype%": ["Promise", "prototype"],
+      "%PromiseProto_then%": ["Promise", "prototype", "then"],
+      "%Promise_all%": ["Promise", "all"],
+      "%Promise_reject%": ["Promise", "reject"],
+      "%Promise_resolve%": ["Promise", "resolve"],
+      "%RangeErrorPrototype%": ["RangeError", "prototype"],
+      "%ReferenceErrorPrototype%": ["ReferenceError", "prototype"],
+      "%RegExpPrototype%": ["RegExp", "prototype"],
+      "%SetPrototype%": ["Set", "prototype"],
+      "%SharedArrayBufferPrototype%": ["SharedArrayBuffer", "prototype"],
+      "%StringPrototype%": ["String", "prototype"],
+      "%SymbolPrototype%": ["Symbol", "prototype"],
+      "%SyntaxErrorPrototype%": ["SyntaxError", "prototype"],
+      "%TypedArrayPrototype%": ["TypedArray", "prototype"],
+      "%TypeErrorPrototype%": ["TypeError", "prototype"],
+      "%Uint8ArrayPrototype%": ["Uint8Array", "prototype"],
+      "%Uint8ClampedArrayPrototype%": ["Uint8ClampedArray", "prototype"],
+      "%Uint16ArrayPrototype%": ["Uint16Array", "prototype"],
+      "%Uint32ArrayPrototype%": ["Uint32Array", "prototype"],
+      "%URIErrorPrototype%": ["URIError", "prototype"],
+      "%WeakMapPrototype%": ["WeakMap", "prototype"],
+      "%WeakSetPrototype%": ["WeakSet", "prototype"]
+    };
+    var bind = require_function_bind();
+    var hasOwn = require_hasown();
+    var $concat = bind.call($call, Array.prototype.concat);
+    var $spliceApply = bind.call($apply, Array.prototype.splice);
+    var $replace = bind.call($call, String.prototype.replace);
+    var $strSlice = bind.call($call, String.prototype.slice);
+    var $exec = bind.call($call, RegExp.prototype.exec);
+    var rePropName = /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
+    var reEscapeChar = /\\(\\)?/g;
+    var stringToPath = function stringToPath2(string) {
+      var first = $strSlice(string, 0, 1);
+      var last = $strSlice(string, -1);
+      if (first === "%" && last !== "%") {
+        throw new $SyntaxError("invalid intrinsic syntax, expected closing `%`");
+      } else if (last === "%" && first !== "%") {
+        throw new $SyntaxError("invalid intrinsic syntax, expected opening `%`");
+      }
+      var result = [];
+      $replace(string, rePropName, function(match, number, quote, subString) {
+        result[result.length] = quote ? $replace(subString, reEscapeChar, "$1") : number || match;
+      });
+      return result;
+    };
+    var getBaseIntrinsic = function getBaseIntrinsic2(name, allowMissing) {
+      var intrinsicName = name;
+      var alias;
+      if (hasOwn(LEGACY_ALIASES, intrinsicName)) {
+        alias = LEGACY_ALIASES[intrinsicName];
+        intrinsicName = "%" + alias[0] + "%";
+      }
+      if (hasOwn(INTRINSICS, intrinsicName)) {
+        var value = INTRINSICS[intrinsicName];
+        if (value === needsEval) {
+          value = doEval(intrinsicName);
+        }
+        if (typeof value === "undefined" && !allowMissing) {
+          throw new $TypeError("intrinsic " + name + " exists, but is not available. Please file an issue!");
+        }
+        return {
+          alias,
+          name: intrinsicName,
+          value
+        };
+      }
+      throw new $SyntaxError("intrinsic " + name + " does not exist!");
+    };
+    module.exports = function GetIntrinsic(name, allowMissing) {
+      if (typeof name !== "string" || name.length === 0) {
+        throw new $TypeError("intrinsic name must be a non-empty string");
+      }
+      if (arguments.length > 1 && typeof allowMissing !== "boolean") {
+        throw new $TypeError('"allowMissing" argument must be a boolean');
+      }
+      if ($exec(/^%?[^%]*%?$/, name) === null) {
+        throw new $SyntaxError("`%` may not be present anywhere but at the beginning and end of the intrinsic name");
+      }
+      var parts = stringToPath(name);
+      var intrinsicBaseName = parts.length > 0 ? parts[0] : "";
+      var intrinsic = getBaseIntrinsic("%" + intrinsicBaseName + "%", allowMissing);
+      var intrinsicRealName = intrinsic.name;
+      var value = intrinsic.value;
+      var skipFurtherCaching = false;
+      var alias = intrinsic.alias;
+      if (alias) {
+        intrinsicBaseName = alias[0];
+        $spliceApply(parts, $concat([0, 1], alias));
+      }
+      for (var i = 1, isOwn = true; i < parts.length; i += 1) {
+        var part = parts[i];
+        var first = $strSlice(part, 0, 1);
+        var last = $strSlice(part, -1);
+        if ((first === '"' || first === "'" || first === "`" || (last === '"' || last === "'" || last === "`")) && first !== last) {
+          throw new $SyntaxError("property names with quotes must have matching quotes");
+        }
+        if (part === "constructor" || !isOwn) {
+          skipFurtherCaching = true;
+        }
+        intrinsicBaseName += "." + part;
+        intrinsicRealName = "%" + intrinsicBaseName + "%";
+        if (hasOwn(INTRINSICS, intrinsicRealName)) {
+          value = INTRINSICS[intrinsicRealName];
+        } else if (value != null) {
+          if (!(part in value)) {
+            if (!allowMissing) {
+              throw new $TypeError("base intrinsic for " + name + " exists, but the property is not available.");
+            }
+            return void undefined2;
+          }
+          if ($gOPD && i + 1 >= parts.length) {
+            var desc = $gOPD(value, part);
+            isOwn = !!desc;
+            if (isOwn && "get" in desc && !("originalValue" in desc.get)) {
+              value = desc.get;
+            } else {
+              value = value[part];
+            }
+          } else {
+            isOwn = hasOwn(value, part);
+            value = value[part];
+          }
+          if (isOwn && !skipFurtherCaching) {
+            INTRINSICS[intrinsicRealName] = value;
+          }
+        }
+      }
+      return value;
+    };
+  }
+});
+
+// node_modules/call-bound/index.js
+var require_call_bound = __commonJS({
+  "node_modules/call-bound/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var GetIntrinsic = require_get_intrinsic();
+    var callBindBasic = require_call_bind_apply_helpers();
+    var $indexOf = callBindBasic([GetIntrinsic("%String.prototype.indexOf%")]);
+    module.exports = function callBoundIntrinsic(name, allowMissing) {
+      var intrinsic = (
+        /** @type {(this: unknown, ...args: unknown[]) => unknown} */
+        GetIntrinsic(name, !!allowMissing)
+      );
+      if (typeof intrinsic === "function" && $indexOf(name, ".prototype.") > -1) {
+        return callBindBasic(
+          /** @type {const} */
+          [intrinsic]
+        );
+      }
+      return intrinsic;
+    };
+  }
+});
+
+// node_modules/is-callable/index.js
+var require_is_callable = __commonJS({
+  "node_modules/is-callable/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var fnToStr = Function.prototype.toString;
+    var reflectApply = typeof Reflect === "object" && Reflect !== null && Reflect.apply;
+    var badArrayLike;
+    var isCallableMarker;
+    if (typeof reflectApply === "function" && typeof Object.defineProperty === "function") {
+      try {
+        badArrayLike = Object.defineProperty({}, "length", {
+          get: function() {
+            throw isCallableMarker;
+          }
+        });
+        isCallableMarker = {};
+        reflectApply(function() {
+          throw 42;
+        }, null, badArrayLike);
+      } catch (_) {
+        if (_ !== isCallableMarker) {
+          reflectApply = null;
+        }
+      }
+    } else {
+      reflectApply = null;
+    }
+    var constructorRegex = /^\s*class\b/;
+    var isES6ClassFn = function isES6ClassFunction(value) {
+      try {
+        var fnStr = fnToStr.call(value);
+        return constructorRegex.test(fnStr);
+      } catch (e) {
+        return false;
+      }
+    };
+    var tryFunctionObject = function tryFunctionToStr(value) {
+      try {
+        if (isES6ClassFn(value)) {
+          return false;
+        }
+        fnToStr.call(value);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    };
+    var toStr = Object.prototype.toString;
+    var objectClass = "[object Object]";
+    var fnClass = "[object Function]";
+    var genClass = "[object GeneratorFunction]";
+    var ddaClass = "[object HTMLAllCollection]";
+    var ddaClass2 = "[object HTML document.all class]";
+    var ddaClass3 = "[object HTMLCollection]";
+    var hasToStringTag = typeof Symbol === "function" && !!Symbol.toStringTag;
+    var isIE68 = !(0 in [,]);
+    var isDDA = function isDocumentDotAll() {
+      return false;
+    };
+    if (typeof document === "object") {
+      all = document.all;
+      if (toStr.call(all) === toStr.call(document.all)) {
+        isDDA = function isDocumentDotAll(value) {
+          if ((isIE68 || !value) && (typeof value === "undefined" || typeof value === "object")) {
+            try {
+              var str = toStr.call(value);
+              return (str === ddaClass || str === ddaClass2 || str === ddaClass3 || str === objectClass) && value("") == null;
+            } catch (e) {
+            }
+          }
+          return false;
+        };
+      }
+    }
+    var all;
+    module.exports = reflectApply ? function isCallable(value) {
+      if (isDDA(value)) {
+        return true;
+      }
+      if (!value) {
+        return false;
+      }
+      if (typeof value !== "function" && typeof value !== "object") {
+        return false;
+      }
+      try {
+        reflectApply(value, null, badArrayLike);
+      } catch (e) {
+        if (e !== isCallableMarker) {
+          return false;
+        }
+      }
+      return !isES6ClassFn(value) && tryFunctionObject(value);
+    } : function isCallable(value) {
+      if (isDDA(value)) {
+        return true;
+      }
+      if (!value) {
+        return false;
+      }
+      if (typeof value !== "function" && typeof value !== "object") {
+        return false;
+      }
+      if (hasToStringTag) {
+        return tryFunctionObject(value);
+      }
+      if (isES6ClassFn(value)) {
+        return false;
+      }
+      var strClass = toStr.call(value);
+      if (strClass !== fnClass && strClass !== genClass && !/^\[object HTML/.test(strClass)) {
+        return false;
+      }
+      return tryFunctionObject(value);
+    };
+  }
+});
+
+// node_modules/for-each/index.js
+var require_for_each = __commonJS({
+  "node_modules/for-each/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var isCallable = require_is_callable();
+    var toStr = Object.prototype.toString;
+    var hasOwnProperty = Object.prototype.hasOwnProperty;
+    var forEachArray = function forEachArray2(array, iterator, receiver) {
+      for (var i = 0, len = array.length; i < len; i++) {
+        if (hasOwnProperty.call(array, i)) {
+          if (receiver == null) {
+            iterator(array[i], i, array);
+          } else {
+            iterator.call(receiver, array[i], i, array);
+          }
+        }
+      }
+    };
+    var forEachString = function forEachString2(string, iterator, receiver) {
+      for (var i = 0, len = string.length; i < len; i++) {
+        if (receiver == null) {
+          iterator(string.charAt(i), i, string);
+        } else {
+          iterator.call(receiver, string.charAt(i), i, string);
+        }
+      }
+    };
+    var forEachObject = function forEachObject2(object, iterator, receiver) {
+      for (var k in object) {
+        if (hasOwnProperty.call(object, k)) {
+          if (receiver == null) {
+            iterator(object[k], k, object);
+          } else {
+            iterator.call(receiver, object[k], k, object);
+          }
+        }
+      }
+    };
+    function isArray(x) {
+      return toStr.call(x) === "[object Array]";
+    }
+    module.exports = function forEach(list, iterator, thisArg) {
+      if (!isCallable(iterator)) {
+        throw new TypeError("iterator must be a function");
+      }
+      var receiver;
+      if (arguments.length >= 3) {
+        receiver = thisArg;
+      }
+      if (isArray(list)) {
+        forEachArray(list, iterator, receiver);
+      } else if (typeof list === "string") {
+        forEachString(list, iterator, receiver);
+      } else {
+        forEachObject(list, iterator, receiver);
+      }
+    };
+  }
+});
+
+// node_modules/possible-typed-array-names/index.js
+var require_possible_typed_array_names = __commonJS({
+  "node_modules/possible-typed-array-names/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = [
+      "Float16Array",
+      "Float32Array",
+      "Float64Array",
+      "Int8Array",
+      "Int16Array",
+      "Int32Array",
+      "Uint8Array",
+      "Uint8ClampedArray",
+      "Uint16Array",
+      "Uint32Array",
+      "BigInt64Array",
+      "BigUint64Array"
+    ];
+  }
+});
+
+// node_modules/available-typed-arrays/index.js
+var require_available_typed_arrays = __commonJS({
+  "node_modules/available-typed-arrays/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var possibleNames = require_possible_typed_array_names();
+    var g = typeof globalThis === "undefined" ? global : globalThis;
+    module.exports = function availableTypedArrays() {
+      var out = [];
+      for (var i = 0; i < possibleNames.length; i++) {
+        if (typeof g[possibleNames[i]] === "function") {
+          out[out.length] = possibleNames[i];
+        }
+      }
+      return out;
+    };
+  }
+});
+
+// node_modules/define-data-property/index.js
+var require_define_data_property = __commonJS({
+  "node_modules/define-data-property/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var $defineProperty = require_es_define_property();
+    var $SyntaxError = require_syntax();
+    var $TypeError = require_type();
+    var gopd = require_gopd();
+    module.exports = function defineDataProperty(obj, property, value) {
+      if (!obj || typeof obj !== "object" && typeof obj !== "function") {
+        throw new $TypeError("`obj` must be an object or a function`");
+      }
+      if (typeof property !== "string" && typeof property !== "symbol") {
+        throw new $TypeError("`property` must be a string or a symbol`");
+      }
+      if (arguments.length > 3 && typeof arguments[3] !== "boolean" && arguments[3] !== null) {
+        throw new $TypeError("`nonEnumerable`, if provided, must be a boolean or null");
+      }
+      if (arguments.length > 4 && typeof arguments[4] !== "boolean" && arguments[4] !== null) {
+        throw new $TypeError("`nonWritable`, if provided, must be a boolean or null");
+      }
+      if (arguments.length > 5 && typeof arguments[5] !== "boolean" && arguments[5] !== null) {
+        throw new $TypeError("`nonConfigurable`, if provided, must be a boolean or null");
+      }
+      if (arguments.length > 6 && typeof arguments[6] !== "boolean") {
+        throw new $TypeError("`loose`, if provided, must be a boolean");
+      }
+      var nonEnumerable = arguments.length > 3 ? arguments[3] : null;
+      var nonWritable = arguments.length > 4 ? arguments[4] : null;
+      var nonConfigurable = arguments.length > 5 ? arguments[5] : null;
+      var loose = arguments.length > 6 ? arguments[6] : false;
+      var desc = !!gopd && gopd(obj, property);
+      if ($defineProperty) {
+        $defineProperty(obj, property, {
+          configurable: nonConfigurable === null && desc ? desc.configurable : !nonConfigurable,
+          enumerable: nonEnumerable === null && desc ? desc.enumerable : !nonEnumerable,
+          value,
+          writable: nonWritable === null && desc ? desc.writable : !nonWritable
+        });
+      } else if (loose || !nonEnumerable && !nonWritable && !nonConfigurable) {
+        obj[property] = value;
+      } else {
+        throw new $SyntaxError("This environment does not support defining a property as non-configurable, non-writable, or non-enumerable.");
+      }
+    };
+  }
+});
+
+// node_modules/has-property-descriptors/index.js
+var require_has_property_descriptors = __commonJS({
+  "node_modules/has-property-descriptors/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var $defineProperty = require_es_define_property();
+    var hasPropertyDescriptors = function hasPropertyDescriptors2() {
+      return !!$defineProperty;
+    };
+    hasPropertyDescriptors.hasArrayLengthDefineBug = function hasArrayLengthDefineBug() {
+      if (!$defineProperty) {
+        return null;
+      }
+      try {
+        return $defineProperty([], "length", { value: 1 }).length !== 1;
+      } catch (e) {
+        return true;
+      }
+    };
+    module.exports = hasPropertyDescriptors;
+  }
+});
+
+// node_modules/set-function-length/index.js
+var require_set_function_length = __commonJS({
+  "node_modules/set-function-length/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var GetIntrinsic = require_get_intrinsic();
+    var define2 = require_define_data_property();
+    var hasDescriptors = require_has_property_descriptors()();
+    var gOPD = require_gopd();
+    var $TypeError = require_type();
+    var $floor = GetIntrinsic("%Math.floor%");
+    module.exports = function setFunctionLength(fn, length) {
+      if (typeof fn !== "function") {
+        throw new $TypeError("`fn` is not a function");
+      }
+      if (typeof length !== "number" || length < 0 || length > 4294967295 || $floor(length) !== length) {
+        throw new $TypeError("`length` must be a positive 32-bit integer");
+      }
+      var loose = arguments.length > 2 && !!arguments[2];
+      var functionLengthIsConfigurable = true;
+      var functionLengthIsWritable = true;
+      if ("length" in fn && gOPD) {
+        var desc = gOPD(fn, "length");
+        if (desc && !desc.configurable) {
+          functionLengthIsConfigurable = false;
+        }
+        if (desc && !desc.writable) {
+          functionLengthIsWritable = false;
+        }
+      }
+      if (functionLengthIsConfigurable || functionLengthIsWritable || !loose) {
+        if (hasDescriptors) {
+          define2(
+            /** @type {Parameters<define>[0]} */
+            fn,
+            "length",
+            length,
+            true,
+            true
+          );
+        } else {
+          define2(
+            /** @type {Parameters<define>[0]} */
+            fn,
+            "length",
+            length
+          );
+        }
+      }
+      return fn;
+    };
+  }
+});
+
+// node_modules/call-bind-apply-helpers/applyBind.js
+var require_applyBind = __commonJS({
+  "node_modules/call-bind-apply-helpers/applyBind.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var bind = require_function_bind();
+    var $apply = require_functionApply();
+    var actualApply = require_actualApply();
+    module.exports = function applyBind() {
+      return actualApply(bind, $apply, arguments);
+    };
+  }
+});
+
+// node_modules/call-bind/index.js
+var require_call_bind = __commonJS({
+  "node_modules/call-bind/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var setFunctionLength = require_set_function_length();
+    var $defineProperty = require_es_define_property();
+    var callBindBasic = require_call_bind_apply_helpers();
+    var applyBind = require_applyBind();
+    module.exports = function callBind(originalFunction) {
+      var func = callBindBasic(arguments);
+      var adjustedLength = 1 + originalFunction.length - (arguments.length - 1);
+      return setFunctionLength(
+        func,
+        adjustedLength > 0 ? adjustedLength : 0,
+        true
+      );
+    };
+    if ($defineProperty) {
+      $defineProperty(module.exports, "apply", { value: applyBind });
+    } else {
+      module.exports.apply = applyBind;
+    }
+  }
+});
+
+// node_modules/has-tostringtag/shams.js
+var require_shams2 = __commonJS({
+  "node_modules/has-tostringtag/shams.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var hasSymbols = require_shams();
+    module.exports = function hasToStringTagShams() {
+      return hasSymbols() && !!Symbol.toStringTag;
+    };
+  }
+});
+
+// node_modules/which-typed-array/index.js
+var require_which_typed_array = __commonJS({
+  "node_modules/which-typed-array/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var forEach = require_for_each();
+    var availableTypedArrays = require_available_typed_arrays();
+    var callBind = require_call_bind();
+    var callBound = require_call_bound();
+    var gOPD = require_gopd();
+    var getProto = require_get_proto();
+    var $toString = callBound("Object.prototype.toString");
+    var hasToStringTag = require_shams2()();
+    var g = typeof globalThis === "undefined" ? global : globalThis;
+    var typedArrays = availableTypedArrays();
+    var $slice = callBound("String.prototype.slice");
+    var $indexOf = callBound("Array.prototype.indexOf", true) || function indexOf(array, value) {
+      for (var i = 0; i < array.length; i += 1) {
+        if (array[i] === value) {
+          return i;
+        }
+      }
+      return -1;
+    };
+    var cache = { __proto__: null };
+    if (hasToStringTag && gOPD && getProto) {
+      forEach(typedArrays, function(typedArray) {
+        var arr = new g[typedArray]();
+        if (Symbol.toStringTag in arr && getProto) {
+          var proto = getProto(arr);
+          var descriptor = gOPD(proto, Symbol.toStringTag);
+          if (!descriptor && proto) {
+            var superProto = getProto(proto);
+            descriptor = gOPD(superProto, Symbol.toStringTag);
+          }
+          if (descriptor && descriptor.get) {
+            var bound = callBind(descriptor.get);
+            cache[
+              /** @type {`$${TypedArrayName}`} */
+              "$" + typedArray
+            ] = bound;
+          }
+        }
+      });
+    } else {
+      forEach(typedArrays, function(typedArray) {
+        var arr = new g[typedArray]();
+        var fn = arr.slice || arr.set;
+        if (fn) {
+          var bound = (
+            /** @type {BoundSlice | BoundSet} */
+            // @ts-expect-error TODO FIXME
+            callBind(fn)
+          );
+          cache[
+            /** @type {`$${TypedArrayName}`} */
+            "$" + typedArray
+          ] = bound;
+        }
+      });
+    }
+    function tryTypedArrays(value) {
+      var found = false;
+      forEach(
+        /** @type {Record<`$${TypedArrayName}`, Getter>} */
+        cache,
+        /** @param {Getter} getter @param {`$${TypedArrayName}`} typedArray */
+        function(getter, typedArray) {
+          if (!found) {
+            try {
+              if ("$" + getter(value) === typedArray) {
+                found = /** @type {TypedArrayName} */
+                $slice(typedArray, 1);
+              }
+            } catch (e) {
+            }
+          }
+        }
+      );
+      return found;
+    }
+    function trySlices(value) {
+      var found = false;
+      forEach(
+        /** @type {Record<`$${TypedArrayName}`, Getter>} */
+        cache,
+        /** @param {Getter} getter @param {`$${TypedArrayName}`} name */
+        function(getter, name) {
+          if (!found) {
+            try {
+              getter(value);
+              found = /** @type {TypedArrayName} */
+              $slice(name, 1);
+            } catch (e) {
+            }
+          }
+        }
+      );
+      return found;
+    }
+    function isTATag(tag2) {
+      return $indexOf(typedArrays, tag2) > -1;
+    }
+    module.exports = function whichTypedArray(value) {
+      if (!value || typeof value !== "object") {
+        return false;
+      }
+      if (!hasToStringTag) {
+        var tag2 = $slice($toString(value), 8, -1);
+        if (isTATag(tag2)) {
+          return tag2;
+        }
+        if (tag2 !== "Object") {
+          return false;
+        }
+        return trySlices(value);
+      }
+      if (!gOPD) {
+        return null;
+      }
+      return tryTypedArrays(value);
+    };
+  }
+});
+
+// node_modules/is-typed-array/index.js
+var require_is_typed_array = __commonJS({
+  "node_modules/is-typed-array/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var whichTypedArray = require_which_typed_array();
+    module.exports = function isTypedArray(value) {
+      return !!whichTypedArray(value);
+    };
+  }
+});
+
+// node_modules/typed-array-buffer/index.js
+var require_typed_array_buffer = __commonJS({
+  "node_modules/typed-array-buffer/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var $TypeError = require_type();
+    var callBound = require_call_bound();
+    var $typedArrayBuffer = callBound("TypedArray.prototype.buffer", true);
+    var isTypedArray = require_is_typed_array();
+    module.exports = $typedArrayBuffer || function typedArrayBuffer(x) {
+      if (!isTypedArray(x)) {
+        throw new $TypeError("Not a Typed Array");
+      }
+      return x.buffer;
+    };
+  }
+});
+
+// node_modules/to-buffer/index.js
+var require_to_buffer = __commonJS({
+  "node_modules/to-buffer/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var Buffer3 = require_safe_buffer().Buffer;
+    var isArray = require_isarray();
+    var typedArrayBuffer = require_typed_array_buffer();
+    var isView = ArrayBuffer.isView || function isView2(obj) {
+      try {
+        typedArrayBuffer(obj);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    };
+    var useUint8Array = typeof Uint8Array !== "undefined";
+    var useArrayBuffer = typeof ArrayBuffer !== "undefined" && typeof Uint8Array !== "undefined";
+    var useFromArrayBuffer = useArrayBuffer && (Buffer3.prototype instanceof Uint8Array || Buffer3.TYPED_ARRAY_SUPPORT);
+    module.exports = function toBuffer(data, encoding) {
+      if (Buffer3.isBuffer(data)) {
+        if (data.constructor && !("isBuffer" in data)) {
+          return Buffer3.from(data);
+        }
+        return data;
+      }
+      if (typeof data === "string") {
+        return Buffer3.from(data, encoding);
+      }
+      if (useArrayBuffer && isView(data)) {
+        if (data.byteLength === 0) {
+          return Buffer3.alloc(0);
+        }
+        if (useFromArrayBuffer) {
+          var res = Buffer3.from(data.buffer, data.byteOffset, data.byteLength);
+          if (res.byteLength === data.byteLength) {
+            return res;
+          }
+        }
+        var uint8 = data instanceof Uint8Array ? data : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+        var result = Buffer3.from(uint8);
+        if (result.length === data.byteLength) {
+          return result;
+        }
+      }
+      if (useUint8Array && data instanceof Uint8Array) {
+        return Buffer3.from(data);
+      }
+      var isArr = isArray(data);
+      if (isArr) {
+        for (var i = 0; i < data.length; i += 1) {
+          var x = data[i];
+          if (typeof x !== "number" || x < 0 || x > 255 || ~~x !== x) {
+            throw new RangeError("Array items must be numbers in the range 0-255.");
+          }
+        }
+      }
+      if (isArr || Buffer3.isBuffer(data) && data.constructor && typeof data.constructor.isBuffer === "function" && data.constructor.isBuffer(data)) {
+        return Buffer3.from(data);
+      }
+      throw new TypeError('The "data" argument must be a string, an Array, a Buffer, a Uint8Array, or a DataView.');
+    };
+  }
+});
+
+// node_modules/sha.js/hash.js
+var require_hash = __commonJS({
+  "node_modules/sha.js/hash.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var Buffer3 = require_safe_buffer().Buffer;
+    var toBuffer = require_to_buffer();
+    function Hash2(blockSize, finalSize) {
+      this._block = Buffer3.alloc(blockSize);
+      this._finalSize = finalSize;
+      this._blockSize = blockSize;
+      this._len = 0;
+    }
+    Hash2.prototype.update = function(data, enc) {
+      data = toBuffer(data, enc || "utf8");
+      var block = this._block;
+      var blockSize = this._blockSize;
+      var length = data.length;
+      var accum = this._len;
+      for (var offset = 0; offset < length; ) {
+        var assigned = accum % blockSize;
+        var remainder = Math.min(length - offset, blockSize - assigned);
+        for (var i = 0; i < remainder; i++) {
+          block[assigned + i] = data[offset + i];
+        }
+        accum += remainder;
+        offset += remainder;
+        if (accum % blockSize === 0) {
+          this._update(block);
+        }
+      }
+      this._len += length;
+      return this;
+    };
+    Hash2.prototype.digest = function(enc) {
+      var rem = this._len % this._blockSize;
+      this._block[rem] = 128;
+      this._block.fill(0, rem + 1);
+      if (rem >= this._finalSize) {
+        this._update(this._block);
+        this._block.fill(0);
+      }
+      var bits = this._len * 8;
+      if (bits <= 4294967295) {
+        this._block.writeUInt32BE(bits, this._blockSize - 4);
+      } else {
+        var lowBits = (bits & 4294967295) >>> 0;
+        var highBits = (bits - lowBits) / 4294967296;
+        this._block.writeUInt32BE(highBits, this._blockSize - 8);
+        this._block.writeUInt32BE(lowBits, this._blockSize - 4);
+      }
+      this._update(this._block);
+      var hash = this._hash();
+      return enc ? hash.toString(enc) : hash;
+    };
+    Hash2.prototype._update = function() {
+      throw new Error("_update must be implemented by subclass");
+    };
+    module.exports = Hash2;
+  }
+});
+
+// node_modules/sha.js/sha1.js
+var require_sha1 = __commonJS({
+  "node_modules/sha.js/sha1.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var inherits = require_inherits_browser();
+    var Hash2 = require_hash();
+    var Buffer3 = require_safe_buffer().Buffer;
+    var K = [
+      1518500249,
+      1859775393,
+      2400959708 | 0,
+      3395469782 | 0
+    ];
+    var W = new Array(80);
+    function Sha1() {
+      this.init();
+      this._w = W;
+      Hash2.call(this, 64, 56);
+    }
+    inherits(Sha1, Hash2);
+    Sha1.prototype.init = function() {
+      this._a = 1732584193;
+      this._b = 4023233417;
+      this._c = 2562383102;
+      this._d = 271733878;
+      this._e = 3285377520;
+      return this;
+    };
+    function rotl1(num2) {
+      return num2 << 1 | num2 >>> 31;
+    }
+    function rotl5(num2) {
+      return num2 << 5 | num2 >>> 27;
+    }
+    function rotl30(num2) {
+      return num2 << 30 | num2 >>> 2;
+    }
+    function ft(s, b, c, d) {
+      if (s === 0) {
+        return b & c | ~b & d;
+      }
+      if (s === 2) {
+        return b & c | b & d | c & d;
+      }
+      return b ^ c ^ d;
+    }
+    Sha1.prototype._update = function(M) {
+      var w = this._w;
+      var a = this._a | 0;
+      var b = this._b | 0;
+      var c = this._c | 0;
+      var d = this._d | 0;
+      var e = this._e | 0;
+      for (var i = 0; i < 16; ++i) {
+        w[i] = M.readInt32BE(i * 4);
+      }
+      for (; i < 80; ++i) {
+        w[i] = rotl1(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
+      }
+      for (var j = 0; j < 80; ++j) {
+        var s = ~~(j / 20);
+        var t = rotl5(a) + ft(s, b, c, d) + e + w[j] + K[s] | 0;
+        e = d;
+        d = c;
+        c = rotl30(b);
+        b = a;
+        a = t;
+      }
+      this._a = a + this._a | 0;
+      this._b = b + this._b | 0;
+      this._c = c + this._c | 0;
+      this._d = d + this._d | 0;
+      this._e = e + this._e | 0;
+    };
+    Sha1.prototype._hash = function() {
+      var H = Buffer3.allocUnsafe(20);
+      H.writeInt32BE(this._a | 0, 0);
+      H.writeInt32BE(this._b | 0, 4);
+      H.writeInt32BE(this._c | 0, 8);
+      H.writeInt32BE(this._d | 0, 12);
+      H.writeInt32BE(this._e | 0, 16);
+      return H;
+    };
+    module.exports = Sha1;
+  }
+});
+
+// node_modules/crc-32/crc32.js
+var require_crc32 = __commonJS({
+  "node_modules/crc-32/crc32.js"(exports) {
+    init_bufinject();
+    var CRC32;
+    (function(factory) {
+      if (typeof DO_NOT_EXPORT_CRC === "undefined") {
+        if ("object" === typeof exports) {
+          factory(exports);
+        } else if ("function" === typeof define && define.amd) {
+          define(function() {
+            var module2 = {};
+            factory(module2);
+            return module2;
+          });
+        } else {
+          factory(CRC32 = {});
+        }
+      } else {
+        factory(CRC32 = {});
+      }
+    })(function(CRC322) {
+      CRC322.version = "1.2.2";
+      function signed_crc_table() {
+        var c = 0, table = new Array(256);
+        for (var n = 0; n != 256; ++n) {
+          c = n;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          c = c & 1 ? -306674912 ^ c >>> 1 : c >>> 1;
+          table[n] = c;
+        }
+        return typeof Int32Array !== "undefined" ? new Int32Array(table) : table;
+      }
+      var T0 = signed_crc_table();
+      function slice_by_16_tables(T) {
+        var c = 0, v = 0, n = 0, table = typeof Int32Array !== "undefined" ? new Int32Array(4096) : new Array(4096);
+        for (n = 0; n != 256; ++n) table[n] = T[n];
+        for (n = 0; n != 256; ++n) {
+          v = T[n];
+          for (c = 256 + n; c < 4096; c += 256) v = table[c] = v >>> 8 ^ T[v & 255];
+        }
+        var out = [];
+        for (n = 1; n != 16; ++n) out[n - 1] = typeof Int32Array !== "undefined" ? table.subarray(n * 256, n * 256 + 256) : table.slice(n * 256, n * 256 + 256);
+        return out;
+      }
+      var TT = slice_by_16_tables(T0);
+      var T1 = TT[0], T2 = TT[1], T3 = TT[2], T4 = TT[3], T5 = TT[4];
+      var T6 = TT[5], T7 = TT[6], T8 = TT[7], T9 = TT[8], Ta = TT[9];
+      var Tb = TT[10], Tc = TT[11], Td = TT[12], Te = TT[13], Tf = TT[14];
+      function crc32_bstr(bstr, seed) {
+        var C = seed ^ -1;
+        for (var i = 0, L = bstr.length; i < L; ) C = C >>> 8 ^ T0[(C ^ bstr.charCodeAt(i++)) & 255];
+        return ~C;
+      }
+      function crc32_buf(B, seed) {
+        var C = seed ^ -1, L = B.length - 15, i = 0;
+        for (; i < L; ) C = Tf[B[i++] ^ C & 255] ^ Te[B[i++] ^ C >> 8 & 255] ^ Td[B[i++] ^ C >> 16 & 255] ^ Tc[B[i++] ^ C >>> 24] ^ Tb[B[i++]] ^ Ta[B[i++]] ^ T9[B[i++]] ^ T8[B[i++]] ^ T7[B[i++]] ^ T6[B[i++]] ^ T5[B[i++]] ^ T4[B[i++]] ^ T3[B[i++]] ^ T2[B[i++]] ^ T1[B[i++]] ^ T0[B[i++]];
+        L += 15;
+        while (i < L) C = C >>> 8 ^ T0[(C ^ B[i++]) & 255];
+        return ~C;
+      }
+      function crc32_str(str, seed) {
+        var C = seed ^ -1;
+        for (var i = 0, L = str.length, c = 0, d = 0; i < L; ) {
+          c = str.charCodeAt(i++);
+          if (c < 128) {
+            C = C >>> 8 ^ T0[(C ^ c) & 255];
+          } else if (c < 2048) {
+            C = C >>> 8 ^ T0[(C ^ (192 | c >> 6 & 31)) & 255];
+            C = C >>> 8 ^ T0[(C ^ (128 | c & 63)) & 255];
+          } else if (c >= 55296 && c < 57344) {
+            c = (c & 1023) + 64;
+            d = str.charCodeAt(i++) & 1023;
+            C = C >>> 8 ^ T0[(C ^ (240 | c >> 8 & 7)) & 255];
+            C = C >>> 8 ^ T0[(C ^ (128 | c >> 2 & 63)) & 255];
+            C = C >>> 8 ^ T0[(C ^ (128 | d >> 6 & 15 | (c & 3) << 4)) & 255];
+            C = C >>> 8 ^ T0[(C ^ (128 | d & 63)) & 255];
+          } else {
+            C = C >>> 8 ^ T0[(C ^ (224 | c >> 12 & 15)) & 255];
+            C = C >>> 8 ^ T0[(C ^ (128 | c >> 6 & 63)) & 255];
+            C = C >>> 8 ^ T0[(C ^ (128 | c & 63)) & 255];
+          }
+        }
+        return ~C;
+      }
+      CRC322.table = T0;
+      CRC322.bstr = crc32_bstr;
+      CRC322.buf = crc32_buf;
+      CRC322.str = crc32_str;
+    });
+  }
+});
+
+// node_modules/pako/lib/utils/common.js
+var require_common = __commonJS({
+  "node_modules/pako/lib/utils/common.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var TYPED_OK = typeof Uint8Array !== "undefined" && typeof Uint16Array !== "undefined" && typeof Int32Array !== "undefined";
+    function _has(obj, key) {
+      return Object.prototype.hasOwnProperty.call(obj, key);
+    }
+    exports.assign = function(obj) {
+      var sources = Array.prototype.slice.call(arguments, 1);
+      while (sources.length) {
+        var source = sources.shift();
+        if (!source) {
+          continue;
+        }
+        if (typeof source !== "object") {
+          throw new TypeError(source + "must be non-object");
+        }
+        for (var p in source) {
+          if (_has(source, p)) {
+            obj[p] = source[p];
+          }
+        }
+      }
+      return obj;
+    };
+    exports.shrinkBuf = function(buf, size) {
+      if (buf.length === size) {
+        return buf;
+      }
+      if (buf.subarray) {
+        return buf.subarray(0, size);
+      }
+      buf.length = size;
+      return buf;
+    };
+    var fnTyped = {
+      arraySet: function(dest, src, src_offs, len, dest_offs) {
+        if (src.subarray && dest.subarray) {
+          dest.set(src.subarray(src_offs, src_offs + len), dest_offs);
+          return;
+        }
+        for (var i = 0; i < len; i++) {
+          dest[dest_offs + i] = src[src_offs + i];
+        }
+      },
+      // Join array of chunks to single array.
+      flattenChunks: function(chunks) {
+        var i, l, len, pos, chunk, result;
+        len = 0;
+        for (i = 0, l = chunks.length; i < l; i++) {
+          len += chunks[i].length;
+        }
+        result = new Uint8Array(len);
+        pos = 0;
+        for (i = 0, l = chunks.length; i < l; i++) {
+          chunk = chunks[i];
+          result.set(chunk, pos);
+          pos += chunk.length;
+        }
+        return result;
+      }
+    };
+    var fnUntyped = {
+      arraySet: function(dest, src, src_offs, len, dest_offs) {
+        for (var i = 0; i < len; i++) {
+          dest[dest_offs + i] = src[src_offs + i];
+        }
+      },
+      // Join array of chunks to single array.
+      flattenChunks: function(chunks) {
+        return [].concat.apply([], chunks);
+      }
+    };
+    exports.setTyped = function(on) {
+      if (on) {
+        exports.Buf8 = Uint8Array;
+        exports.Buf16 = Uint16Array;
+        exports.Buf32 = Int32Array;
+        exports.assign(exports, fnTyped);
+      } else {
+        exports.Buf8 = Array;
+        exports.Buf16 = Array;
+        exports.Buf32 = Array;
+        exports.assign(exports, fnUntyped);
+      }
+    };
+    exports.setTyped(TYPED_OK);
+  }
+});
+
+// node_modules/pako/lib/zlib/trees.js
+var require_trees = __commonJS({
+  "node_modules/pako/lib/zlib/trees.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var utils = require_common();
+    var Z_FIXED = 4;
+    var Z_BINARY = 0;
+    var Z_TEXT = 1;
+    var Z_UNKNOWN = 2;
+    function zero(buf) {
+      var len = buf.length;
+      while (--len >= 0) {
+        buf[len] = 0;
+      }
+    }
+    var STORED_BLOCK = 0;
+    var STATIC_TREES = 1;
+    var DYN_TREES = 2;
+    var MIN_MATCH = 3;
+    var MAX_MATCH = 258;
+    var LENGTH_CODES = 29;
+    var LITERALS = 256;
+    var L_CODES = LITERALS + 1 + LENGTH_CODES;
+    var D_CODES = 30;
+    var BL_CODES = 19;
+    var HEAP_SIZE = 2 * L_CODES + 1;
+    var MAX_BITS = 15;
+    var Buf_size = 16;
+    var MAX_BL_BITS = 7;
+    var END_BLOCK = 256;
+    var REP_3_6 = 16;
+    var REPZ_3_10 = 17;
+    var REPZ_11_138 = 18;
+    var extra_lbits = (
+      /* extra bits for each length code */
+      [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0]
+    );
+    var extra_dbits = (
+      /* extra bits for each distance code */
+      [0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13]
+    );
+    var extra_blbits = (
+      /* extra bits for each bit length code */
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 7]
+    );
+    var bl_order = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15];
+    var DIST_CODE_LEN = 512;
+    var static_ltree = new Array((L_CODES + 2) * 2);
+    zero(static_ltree);
+    var static_dtree = new Array(D_CODES * 2);
+    zero(static_dtree);
+    var _dist_code = new Array(DIST_CODE_LEN);
+    zero(_dist_code);
+    var _length_code = new Array(MAX_MATCH - MIN_MATCH + 1);
+    zero(_length_code);
+    var base_length = new Array(LENGTH_CODES);
+    zero(base_length);
+    var base_dist = new Array(D_CODES);
+    zero(base_dist);
+    function StaticTreeDesc(static_tree, extra_bits, extra_base, elems, max_length) {
+      this.static_tree = static_tree;
+      this.extra_bits = extra_bits;
+      this.extra_base = extra_base;
+      this.elems = elems;
+      this.max_length = max_length;
+      this.has_stree = static_tree && static_tree.length;
+    }
+    var static_l_desc;
+    var static_d_desc;
+    var static_bl_desc;
+    function TreeDesc(dyn_tree, stat_desc) {
+      this.dyn_tree = dyn_tree;
+      this.max_code = 0;
+      this.stat_desc = stat_desc;
+    }
+    function d_code(dist) {
+      return dist < 256 ? _dist_code[dist] : _dist_code[256 + (dist >>> 7)];
+    }
+    function put_short(s, w) {
+      s.pending_buf[s.pending++] = w & 255;
+      s.pending_buf[s.pending++] = w >>> 8 & 255;
+    }
+    function send_bits(s, value, length) {
+      if (s.bi_valid > Buf_size - length) {
+        s.bi_buf |= value << s.bi_valid & 65535;
+        put_short(s, s.bi_buf);
+        s.bi_buf = value >> Buf_size - s.bi_valid;
+        s.bi_valid += length - Buf_size;
+      } else {
+        s.bi_buf |= value << s.bi_valid & 65535;
+        s.bi_valid += length;
+      }
+    }
+    function send_code(s, c, tree) {
+      send_bits(
+        s,
+        tree[c * 2],
+        tree[c * 2 + 1]
+        /*.Len*/
+      );
+    }
+    function bi_reverse(code, len) {
+      var res = 0;
+      do {
+        res |= code & 1;
+        code >>>= 1;
+        res <<= 1;
+      } while (--len > 0);
+      return res >>> 1;
+    }
+    function bi_flush(s) {
+      if (s.bi_valid === 16) {
+        put_short(s, s.bi_buf);
+        s.bi_buf = 0;
+        s.bi_valid = 0;
+      } else if (s.bi_valid >= 8) {
+        s.pending_buf[s.pending++] = s.bi_buf & 255;
+        s.bi_buf >>= 8;
+        s.bi_valid -= 8;
+      }
+    }
+    function gen_bitlen(s, desc) {
+      var tree = desc.dyn_tree;
+      var max_code = desc.max_code;
+      var stree = desc.stat_desc.static_tree;
+      var has_stree = desc.stat_desc.has_stree;
+      var extra = desc.stat_desc.extra_bits;
+      var base = desc.stat_desc.extra_base;
+      var max_length = desc.stat_desc.max_length;
+      var h;
+      var n, m;
+      var bits;
+      var xbits;
+      var f;
+      var overflow = 0;
+      for (bits = 0; bits <= MAX_BITS; bits++) {
+        s.bl_count[bits] = 0;
+      }
+      tree[s.heap[s.heap_max] * 2 + 1] = 0;
+      for (h = s.heap_max + 1; h < HEAP_SIZE; h++) {
+        n = s.heap[h];
+        bits = tree[tree[n * 2 + 1] * 2 + 1] + 1;
+        if (bits > max_length) {
+          bits = max_length;
+          overflow++;
+        }
+        tree[n * 2 + 1] = bits;
+        if (n > max_code) {
+          continue;
+        }
+        s.bl_count[bits]++;
+        xbits = 0;
+        if (n >= base) {
+          xbits = extra[n - base];
+        }
+        f = tree[n * 2];
+        s.opt_len += f * (bits + xbits);
+        if (has_stree) {
+          s.static_len += f * (stree[n * 2 + 1] + xbits);
+        }
+      }
+      if (overflow === 0) {
+        return;
+      }
+      do {
+        bits = max_length - 1;
+        while (s.bl_count[bits] === 0) {
+          bits--;
+        }
+        s.bl_count[bits]--;
+        s.bl_count[bits + 1] += 2;
+        s.bl_count[max_length]--;
+        overflow -= 2;
+      } while (overflow > 0);
+      for (bits = max_length; bits !== 0; bits--) {
+        n = s.bl_count[bits];
+        while (n !== 0) {
+          m = s.heap[--h];
+          if (m > max_code) {
+            continue;
+          }
+          if (tree[m * 2 + 1] !== bits) {
+            s.opt_len += (bits - tree[m * 2 + 1]) * tree[m * 2];
+            tree[m * 2 + 1] = bits;
+          }
+          n--;
+        }
+      }
+    }
+    function gen_codes(tree, max_code, bl_count) {
+      var next_code = new Array(MAX_BITS + 1);
+      var code = 0;
+      var bits;
+      var n;
+      for (bits = 1; bits <= MAX_BITS; bits++) {
+        next_code[bits] = code = code + bl_count[bits - 1] << 1;
+      }
+      for (n = 0; n <= max_code; n++) {
+        var len = tree[n * 2 + 1];
+        if (len === 0) {
+          continue;
+        }
+        tree[n * 2] = bi_reverse(next_code[len]++, len);
+      }
+    }
+    function tr_static_init() {
+      var n;
+      var bits;
+      var length;
+      var code;
+      var dist;
+      var bl_count = new Array(MAX_BITS + 1);
+      length = 0;
+      for (code = 0; code < LENGTH_CODES - 1; code++) {
+        base_length[code] = length;
+        for (n = 0; n < 1 << extra_lbits[code]; n++) {
+          _length_code[length++] = code;
+        }
+      }
+      _length_code[length - 1] = code;
+      dist = 0;
+      for (code = 0; code < 16; code++) {
+        base_dist[code] = dist;
+        for (n = 0; n < 1 << extra_dbits[code]; n++) {
+          _dist_code[dist++] = code;
+        }
+      }
+      dist >>= 7;
+      for (; code < D_CODES; code++) {
+        base_dist[code] = dist << 7;
+        for (n = 0; n < 1 << extra_dbits[code] - 7; n++) {
+          _dist_code[256 + dist++] = code;
+        }
+      }
+      for (bits = 0; bits <= MAX_BITS; bits++) {
+        bl_count[bits] = 0;
+      }
+      n = 0;
+      while (n <= 143) {
+        static_ltree[n * 2 + 1] = 8;
+        n++;
+        bl_count[8]++;
+      }
+      while (n <= 255) {
+        static_ltree[n * 2 + 1] = 9;
+        n++;
+        bl_count[9]++;
+      }
+      while (n <= 279) {
+        static_ltree[n * 2 + 1] = 7;
+        n++;
+        bl_count[7]++;
+      }
+      while (n <= 287) {
+        static_ltree[n * 2 + 1] = 8;
+        n++;
+        bl_count[8]++;
+      }
+      gen_codes(static_ltree, L_CODES + 1, bl_count);
+      for (n = 0; n < D_CODES; n++) {
+        static_dtree[n * 2 + 1] = 5;
+        static_dtree[n * 2] = bi_reverse(n, 5);
+      }
+      static_l_desc = new StaticTreeDesc(static_ltree, extra_lbits, LITERALS + 1, L_CODES, MAX_BITS);
+      static_d_desc = new StaticTreeDesc(static_dtree, extra_dbits, 0, D_CODES, MAX_BITS);
+      static_bl_desc = new StaticTreeDesc(new Array(0), extra_blbits, 0, BL_CODES, MAX_BL_BITS);
+    }
+    function init_block(s) {
+      var n;
+      for (n = 0; n < L_CODES; n++) {
+        s.dyn_ltree[n * 2] = 0;
+      }
+      for (n = 0; n < D_CODES; n++) {
+        s.dyn_dtree[n * 2] = 0;
+      }
+      for (n = 0; n < BL_CODES; n++) {
+        s.bl_tree[n * 2] = 0;
+      }
+      s.dyn_ltree[END_BLOCK * 2] = 1;
+      s.opt_len = s.static_len = 0;
+      s.last_lit = s.matches = 0;
+    }
+    function bi_windup(s) {
+      if (s.bi_valid > 8) {
+        put_short(s, s.bi_buf);
+      } else if (s.bi_valid > 0) {
+        s.pending_buf[s.pending++] = s.bi_buf;
+      }
+      s.bi_buf = 0;
+      s.bi_valid = 0;
+    }
+    function copy_block(s, buf, len, header) {
+      bi_windup(s);
+      if (header) {
+        put_short(s, len);
+        put_short(s, ~len);
+      }
+      utils.arraySet(s.pending_buf, s.window, buf, len, s.pending);
+      s.pending += len;
+    }
+    function smaller(tree, n, m, depth) {
+      var _n2 = n * 2;
+      var _m2 = m * 2;
+      return tree[_n2] < tree[_m2] || tree[_n2] === tree[_m2] && depth[n] <= depth[m];
+    }
+    function pqdownheap(s, tree, k) {
+      var v = s.heap[k];
+      var j = k << 1;
+      while (j <= s.heap_len) {
+        if (j < s.heap_len && smaller(tree, s.heap[j + 1], s.heap[j], s.depth)) {
+          j++;
+        }
+        if (smaller(tree, v, s.heap[j], s.depth)) {
+          break;
+        }
+        s.heap[k] = s.heap[j];
+        k = j;
+        j <<= 1;
+      }
+      s.heap[k] = v;
+    }
+    function compress_block(s, ltree, dtree) {
+      var dist;
+      var lc;
+      var lx = 0;
+      var code;
+      var extra;
+      if (s.last_lit !== 0) {
+        do {
+          dist = s.pending_buf[s.d_buf + lx * 2] << 8 | s.pending_buf[s.d_buf + lx * 2 + 1];
+          lc = s.pending_buf[s.l_buf + lx];
+          lx++;
+          if (dist === 0) {
+            send_code(s, lc, ltree);
+          } else {
+            code = _length_code[lc];
+            send_code(s, code + LITERALS + 1, ltree);
+            extra = extra_lbits[code];
+            if (extra !== 0) {
+              lc -= base_length[code];
+              send_bits(s, lc, extra);
+            }
+            dist--;
+            code = d_code(dist);
+            send_code(s, code, dtree);
+            extra = extra_dbits[code];
+            if (extra !== 0) {
+              dist -= base_dist[code];
+              send_bits(s, dist, extra);
+            }
+          }
+        } while (lx < s.last_lit);
+      }
+      send_code(s, END_BLOCK, ltree);
+    }
+    function build_tree(s, desc) {
+      var tree = desc.dyn_tree;
+      var stree = desc.stat_desc.static_tree;
+      var has_stree = desc.stat_desc.has_stree;
+      var elems = desc.stat_desc.elems;
+      var n, m;
+      var max_code = -1;
+      var node;
+      s.heap_len = 0;
+      s.heap_max = HEAP_SIZE;
+      for (n = 0; n < elems; n++) {
+        if (tree[n * 2] !== 0) {
+          s.heap[++s.heap_len] = max_code = n;
+          s.depth[n] = 0;
+        } else {
+          tree[n * 2 + 1] = 0;
+        }
+      }
+      while (s.heap_len < 2) {
+        node = s.heap[++s.heap_len] = max_code < 2 ? ++max_code : 0;
+        tree[node * 2] = 1;
+        s.depth[node] = 0;
+        s.opt_len--;
+        if (has_stree) {
+          s.static_len -= stree[node * 2 + 1];
+        }
+      }
+      desc.max_code = max_code;
+      for (n = s.heap_len >> 1; n >= 1; n--) {
+        pqdownheap(s, tree, n);
+      }
+      node = elems;
+      do {
+        n = s.heap[
+          1
+          /*SMALLEST*/
+        ];
+        s.heap[
+          1
+          /*SMALLEST*/
+        ] = s.heap[s.heap_len--];
+        pqdownheap(
+          s,
+          tree,
+          1
+          /*SMALLEST*/
+        );
+        m = s.heap[
+          1
+          /*SMALLEST*/
+        ];
+        s.heap[--s.heap_max] = n;
+        s.heap[--s.heap_max] = m;
+        tree[node * 2] = tree[n * 2] + tree[m * 2];
+        s.depth[node] = (s.depth[n] >= s.depth[m] ? s.depth[n] : s.depth[m]) + 1;
+        tree[n * 2 + 1] = tree[m * 2 + 1] = node;
+        s.heap[
+          1
+          /*SMALLEST*/
+        ] = node++;
+        pqdownheap(
+          s,
+          tree,
+          1
+          /*SMALLEST*/
+        );
+      } while (s.heap_len >= 2);
+      s.heap[--s.heap_max] = s.heap[
+        1
+        /*SMALLEST*/
+      ];
+      gen_bitlen(s, desc);
+      gen_codes(tree, max_code, s.bl_count);
+    }
+    function scan_tree(s, tree, max_code) {
+      var n;
+      var prevlen = -1;
+      var curlen;
+      var nextlen = tree[0 * 2 + 1];
+      var count = 0;
+      var max_count = 7;
+      var min_count = 4;
+      if (nextlen === 0) {
+        max_count = 138;
+        min_count = 3;
+      }
+      tree[(max_code + 1) * 2 + 1] = 65535;
+      for (n = 0; n <= max_code; n++) {
+        curlen = nextlen;
+        nextlen = tree[(n + 1) * 2 + 1];
+        if (++count < max_count && curlen === nextlen) {
+          continue;
+        } else if (count < min_count) {
+          s.bl_tree[curlen * 2] += count;
+        } else if (curlen !== 0) {
+          if (curlen !== prevlen) {
+            s.bl_tree[curlen * 2]++;
+          }
+          s.bl_tree[REP_3_6 * 2]++;
+        } else if (count <= 10) {
+          s.bl_tree[REPZ_3_10 * 2]++;
+        } else {
+          s.bl_tree[REPZ_11_138 * 2]++;
+        }
+        count = 0;
+        prevlen = curlen;
+        if (nextlen === 0) {
+          max_count = 138;
+          min_count = 3;
+        } else if (curlen === nextlen) {
+          max_count = 6;
+          min_count = 3;
+        } else {
+          max_count = 7;
+          min_count = 4;
+        }
+      }
+    }
+    function send_tree(s, tree, max_code) {
+      var n;
+      var prevlen = -1;
+      var curlen;
+      var nextlen = tree[0 * 2 + 1];
+      var count = 0;
+      var max_count = 7;
+      var min_count = 4;
+      if (nextlen === 0) {
+        max_count = 138;
+        min_count = 3;
+      }
+      for (n = 0; n <= max_code; n++) {
+        curlen = nextlen;
+        nextlen = tree[(n + 1) * 2 + 1];
+        if (++count < max_count && curlen === nextlen) {
+          continue;
+        } else if (count < min_count) {
+          do {
+            send_code(s, curlen, s.bl_tree);
+          } while (--count !== 0);
+        } else if (curlen !== 0) {
+          if (curlen !== prevlen) {
+            send_code(s, curlen, s.bl_tree);
+            count--;
+          }
+          send_code(s, REP_3_6, s.bl_tree);
+          send_bits(s, count - 3, 2);
+        } else if (count <= 10) {
+          send_code(s, REPZ_3_10, s.bl_tree);
+          send_bits(s, count - 3, 3);
+        } else {
+          send_code(s, REPZ_11_138, s.bl_tree);
+          send_bits(s, count - 11, 7);
+        }
+        count = 0;
+        prevlen = curlen;
+        if (nextlen === 0) {
+          max_count = 138;
+          min_count = 3;
+        } else if (curlen === nextlen) {
+          max_count = 6;
+          min_count = 3;
+        } else {
+          max_count = 7;
+          min_count = 4;
+        }
+      }
+    }
+    function build_bl_tree(s) {
+      var max_blindex;
+      scan_tree(s, s.dyn_ltree, s.l_desc.max_code);
+      scan_tree(s, s.dyn_dtree, s.d_desc.max_code);
+      build_tree(s, s.bl_desc);
+      for (max_blindex = BL_CODES - 1; max_blindex >= 3; max_blindex--) {
+        if (s.bl_tree[bl_order[max_blindex] * 2 + 1] !== 0) {
+          break;
+        }
+      }
+      s.opt_len += 3 * (max_blindex + 1) + 5 + 5 + 4;
+      return max_blindex;
+    }
+    function send_all_trees(s, lcodes, dcodes, blcodes) {
+      var rank;
+      send_bits(s, lcodes - 257, 5);
+      send_bits(s, dcodes - 1, 5);
+      send_bits(s, blcodes - 4, 4);
+      for (rank = 0; rank < blcodes; rank++) {
+        send_bits(s, s.bl_tree[bl_order[rank] * 2 + 1], 3);
+      }
+      send_tree(s, s.dyn_ltree, lcodes - 1);
+      send_tree(s, s.dyn_dtree, dcodes - 1);
+    }
+    function detect_data_type(s) {
+      var black_mask = 4093624447;
+      var n;
+      for (n = 0; n <= 31; n++, black_mask >>>= 1) {
+        if (black_mask & 1 && s.dyn_ltree[n * 2] !== 0) {
+          return Z_BINARY;
+        }
+      }
+      if (s.dyn_ltree[9 * 2] !== 0 || s.dyn_ltree[10 * 2] !== 0 || s.dyn_ltree[13 * 2] !== 0) {
+        return Z_TEXT;
+      }
+      for (n = 32; n < LITERALS; n++) {
+        if (s.dyn_ltree[n * 2] !== 0) {
+          return Z_TEXT;
+        }
+      }
+      return Z_BINARY;
+    }
+    var static_init_done = false;
+    function _tr_init(s) {
+      if (!static_init_done) {
+        tr_static_init();
+        static_init_done = true;
+      }
+      s.l_desc = new TreeDesc(s.dyn_ltree, static_l_desc);
+      s.d_desc = new TreeDesc(s.dyn_dtree, static_d_desc);
+      s.bl_desc = new TreeDesc(s.bl_tree, static_bl_desc);
+      s.bi_buf = 0;
+      s.bi_valid = 0;
+      init_block(s);
+    }
+    function _tr_stored_block(s, buf, stored_len, last) {
+      send_bits(s, (STORED_BLOCK << 1) + (last ? 1 : 0), 3);
+      copy_block(s, buf, stored_len, true);
+    }
+    function _tr_align(s) {
+      send_bits(s, STATIC_TREES << 1, 3);
+      send_code(s, END_BLOCK, static_ltree);
+      bi_flush(s);
+    }
+    function _tr_flush_block(s, buf, stored_len, last) {
+      var opt_lenb, static_lenb;
+      var max_blindex = 0;
+      if (s.level > 0) {
+        if (s.strm.data_type === Z_UNKNOWN) {
+          s.strm.data_type = detect_data_type(s);
+        }
+        build_tree(s, s.l_desc);
+        build_tree(s, s.d_desc);
+        max_blindex = build_bl_tree(s);
+        opt_lenb = s.opt_len + 3 + 7 >>> 3;
+        static_lenb = s.static_len + 3 + 7 >>> 3;
+        if (static_lenb <= opt_lenb) {
+          opt_lenb = static_lenb;
+        }
+      } else {
+        opt_lenb = static_lenb = stored_len + 5;
+      }
+      if (stored_len + 4 <= opt_lenb && buf !== -1) {
+        _tr_stored_block(s, buf, stored_len, last);
+      } else if (s.strategy === Z_FIXED || static_lenb === opt_lenb) {
+        send_bits(s, (STATIC_TREES << 1) + (last ? 1 : 0), 3);
+        compress_block(s, static_ltree, static_dtree);
+      } else {
+        send_bits(s, (DYN_TREES << 1) + (last ? 1 : 0), 3);
+        send_all_trees(s, s.l_desc.max_code + 1, s.d_desc.max_code + 1, max_blindex + 1);
+        compress_block(s, s.dyn_ltree, s.dyn_dtree);
+      }
+      init_block(s);
+      if (last) {
+        bi_windup(s);
+      }
+    }
+    function _tr_tally(s, dist, lc) {
+      s.pending_buf[s.d_buf + s.last_lit * 2] = dist >>> 8 & 255;
+      s.pending_buf[s.d_buf + s.last_lit * 2 + 1] = dist & 255;
+      s.pending_buf[s.l_buf + s.last_lit] = lc & 255;
+      s.last_lit++;
+      if (dist === 0) {
+        s.dyn_ltree[lc * 2]++;
+      } else {
+        s.matches++;
+        dist--;
+        s.dyn_ltree[(_length_code[lc] + LITERALS + 1) * 2]++;
+        s.dyn_dtree[d_code(dist) * 2]++;
+      }
+      return s.last_lit === s.lit_bufsize - 1;
+    }
+    exports._tr_init = _tr_init;
+    exports._tr_stored_block = _tr_stored_block;
+    exports._tr_flush_block = _tr_flush_block;
+    exports._tr_tally = _tr_tally;
+    exports._tr_align = _tr_align;
+  }
+});
+
+// node_modules/pako/lib/zlib/adler32.js
+var require_adler32 = __commonJS({
+  "node_modules/pako/lib/zlib/adler32.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    function adler32(adler, buf, len, pos) {
+      var s1 = adler & 65535 | 0, s2 = adler >>> 16 & 65535 | 0, n = 0;
+      while (len !== 0) {
+        n = len > 2e3 ? 2e3 : len;
+        len -= n;
+        do {
+          s1 = s1 + buf[pos++] | 0;
+          s2 = s2 + s1 | 0;
+        } while (--n);
+        s1 %= 65521;
+        s2 %= 65521;
+      }
+      return s1 | s2 << 16 | 0;
+    }
+    module.exports = adler32;
+  }
+});
+
+// node_modules/pako/lib/zlib/crc32.js
+var require_crc322 = __commonJS({
+  "node_modules/pako/lib/zlib/crc32.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    function makeTable() {
+      var c, table = [];
+      for (var n = 0; n < 256; n++) {
+        c = n;
+        for (var k = 0; k < 8; k++) {
+          c = c & 1 ? 3988292384 ^ c >>> 1 : c >>> 1;
+        }
+        table[n] = c;
+      }
+      return table;
+    }
+    var crcTable = makeTable();
+    function crc322(crc, buf, len, pos) {
+      var t = crcTable, end = pos + len;
+      crc ^= -1;
+      for (var i = pos; i < end; i++) {
+        crc = crc >>> 8 ^ t[(crc ^ buf[i]) & 255];
+      }
+      return crc ^ -1;
+    }
+    module.exports = crc322;
+  }
+});
+
+// node_modules/pako/lib/zlib/messages.js
+var require_messages = __commonJS({
+  "node_modules/pako/lib/zlib/messages.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = {
+      2: "need dictionary",
+      /* Z_NEED_DICT       2  */
+      1: "stream end",
+      /* Z_STREAM_END      1  */
+      0: "",
+      /* Z_OK              0  */
+      "-1": "file error",
+      /* Z_ERRNO         (-1) */
+      "-2": "stream error",
+      /* Z_STREAM_ERROR  (-2) */
+      "-3": "data error",
+      /* Z_DATA_ERROR    (-3) */
+      "-4": "insufficient memory",
+      /* Z_MEM_ERROR     (-4) */
+      "-5": "buffer error",
+      /* Z_BUF_ERROR     (-5) */
+      "-6": "incompatible version"
+      /* Z_VERSION_ERROR (-6) */
+    };
+  }
+});
+
+// node_modules/pako/lib/zlib/deflate.js
+var require_deflate = __commonJS({
+  "node_modules/pako/lib/zlib/deflate.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var utils = require_common();
+    var trees = require_trees();
+    var adler32 = require_adler32();
+    var crc322 = require_crc322();
+    var msg = require_messages();
+    var Z_NO_FLUSH = 0;
+    var Z_PARTIAL_FLUSH = 1;
+    var Z_FULL_FLUSH = 3;
+    var Z_FINISH = 4;
+    var Z_BLOCK = 5;
+    var Z_OK = 0;
+    var Z_STREAM_END = 1;
+    var Z_STREAM_ERROR = -2;
+    var Z_DATA_ERROR = -3;
+    var Z_BUF_ERROR = -5;
+    var Z_DEFAULT_COMPRESSION = -1;
+    var Z_FILTERED = 1;
+    var Z_HUFFMAN_ONLY = 2;
+    var Z_RLE = 3;
+    var Z_FIXED = 4;
+    var Z_DEFAULT_STRATEGY = 0;
+    var Z_UNKNOWN = 2;
+    var Z_DEFLATED = 8;
+    var MAX_MEM_LEVEL = 9;
+    var MAX_WBITS = 15;
+    var DEF_MEM_LEVEL = 8;
+    var LENGTH_CODES = 29;
+    var LITERALS = 256;
+    var L_CODES = LITERALS + 1 + LENGTH_CODES;
+    var D_CODES = 30;
+    var BL_CODES = 19;
+    var HEAP_SIZE = 2 * L_CODES + 1;
+    var MAX_BITS = 15;
+    var MIN_MATCH = 3;
+    var MAX_MATCH = 258;
+    var MIN_LOOKAHEAD = MAX_MATCH + MIN_MATCH + 1;
+    var PRESET_DICT = 32;
+    var INIT_STATE = 42;
+    var EXTRA_STATE = 69;
+    var NAME_STATE = 73;
+    var COMMENT_STATE = 91;
+    var HCRC_STATE = 103;
+    var BUSY_STATE = 113;
+    var FINISH_STATE = 666;
+    var BS_NEED_MORE = 1;
+    var BS_BLOCK_DONE = 2;
+    var BS_FINISH_STARTED = 3;
+    var BS_FINISH_DONE = 4;
+    var OS_CODE = 3;
+    function err(strm, errorCode) {
+      strm.msg = msg[errorCode];
+      return errorCode;
+    }
+    function rank(f) {
+      return (f << 1) - (f > 4 ? 9 : 0);
+    }
+    function zero(buf) {
+      var len = buf.length;
+      while (--len >= 0) {
+        buf[len] = 0;
+      }
+    }
+    function flush_pending(strm) {
+      var s = strm.state;
+      var len = s.pending;
+      if (len > strm.avail_out) {
+        len = strm.avail_out;
+      }
+      if (len === 0) {
+        return;
+      }
+      utils.arraySet(strm.output, s.pending_buf, s.pending_out, len, strm.next_out);
+      strm.next_out += len;
+      s.pending_out += len;
+      strm.total_out += len;
+      strm.avail_out -= len;
+      s.pending -= len;
+      if (s.pending === 0) {
+        s.pending_out = 0;
+      }
+    }
+    function flush_block_only(s, last) {
+      trees._tr_flush_block(s, s.block_start >= 0 ? s.block_start : -1, s.strstart - s.block_start, last);
+      s.block_start = s.strstart;
+      flush_pending(s.strm);
+    }
+    function put_byte(s, b) {
+      s.pending_buf[s.pending++] = b;
+    }
+    function putShortMSB(s, b) {
+      s.pending_buf[s.pending++] = b >>> 8 & 255;
+      s.pending_buf[s.pending++] = b & 255;
+    }
+    function read_buf(strm, buf, start, size) {
+      var len = strm.avail_in;
+      if (len > size) {
+        len = size;
+      }
+      if (len === 0) {
+        return 0;
+      }
+      strm.avail_in -= len;
+      utils.arraySet(buf, strm.input, strm.next_in, len, start);
+      if (strm.state.wrap === 1) {
+        strm.adler = adler32(strm.adler, buf, len, start);
+      } else if (strm.state.wrap === 2) {
+        strm.adler = crc322(strm.adler, buf, len, start);
+      }
+      strm.next_in += len;
+      strm.total_in += len;
+      return len;
+    }
+    function longest_match(s, cur_match) {
+      var chain_length = s.max_chain_length;
+      var scan = s.strstart;
+      var match;
+      var len;
+      var best_len = s.prev_length;
+      var nice_match = s.nice_match;
+      var limit = s.strstart > s.w_size - MIN_LOOKAHEAD ? s.strstart - (s.w_size - MIN_LOOKAHEAD) : 0;
+      var _win = s.window;
+      var wmask = s.w_mask;
+      var prev = s.prev;
+      var strend = s.strstart + MAX_MATCH;
+      var scan_end1 = _win[scan + best_len - 1];
+      var scan_end = _win[scan + best_len];
+      if (s.prev_length >= s.good_match) {
+        chain_length >>= 2;
+      }
+      if (nice_match > s.lookahead) {
+        nice_match = s.lookahead;
+      }
+      do {
+        match = cur_match;
+        if (_win[match + best_len] !== scan_end || _win[match + best_len - 1] !== scan_end1 || _win[match] !== _win[scan] || _win[++match] !== _win[scan + 1]) {
+          continue;
+        }
+        scan += 2;
+        match++;
+        do {
+        } while (_win[++scan] === _win[++match] && _win[++scan] === _win[++match] && _win[++scan] === _win[++match] && _win[++scan] === _win[++match] && _win[++scan] === _win[++match] && _win[++scan] === _win[++match] && _win[++scan] === _win[++match] && _win[++scan] === _win[++match] && scan < strend);
+        len = MAX_MATCH - (strend - scan);
+        scan = strend - MAX_MATCH;
+        if (len > best_len) {
+          s.match_start = cur_match;
+          best_len = len;
+          if (len >= nice_match) {
+            break;
+          }
+          scan_end1 = _win[scan + best_len - 1];
+          scan_end = _win[scan + best_len];
+        }
+      } while ((cur_match = prev[cur_match & wmask]) > limit && --chain_length !== 0);
+      if (best_len <= s.lookahead) {
+        return best_len;
+      }
+      return s.lookahead;
+    }
+    function fill_window(s) {
+      var _w_size = s.w_size;
+      var p, n, m, more, str;
+      do {
+        more = s.window_size - s.lookahead - s.strstart;
+        if (s.strstart >= _w_size + (_w_size - MIN_LOOKAHEAD)) {
+          utils.arraySet(s.window, s.window, _w_size, _w_size, 0);
+          s.match_start -= _w_size;
+          s.strstart -= _w_size;
+          s.block_start -= _w_size;
+          n = s.hash_size;
+          p = n;
+          do {
+            m = s.head[--p];
+            s.head[p] = m >= _w_size ? m - _w_size : 0;
+          } while (--n);
+          n = _w_size;
+          p = n;
+          do {
+            m = s.prev[--p];
+            s.prev[p] = m >= _w_size ? m - _w_size : 0;
+          } while (--n);
+          more += _w_size;
+        }
+        if (s.strm.avail_in === 0) {
+          break;
+        }
+        n = read_buf(s.strm, s.window, s.strstart + s.lookahead, more);
+        s.lookahead += n;
+        if (s.lookahead + s.insert >= MIN_MATCH) {
+          str = s.strstart - s.insert;
+          s.ins_h = s.window[str];
+          s.ins_h = (s.ins_h << s.hash_shift ^ s.window[str + 1]) & s.hash_mask;
+          while (s.insert) {
+            s.ins_h = (s.ins_h << s.hash_shift ^ s.window[str + MIN_MATCH - 1]) & s.hash_mask;
+            s.prev[str & s.w_mask] = s.head[s.ins_h];
+            s.head[s.ins_h] = str;
+            str++;
+            s.insert--;
+            if (s.lookahead + s.insert < MIN_MATCH) {
+              break;
+            }
+          }
+        }
+      } while (s.lookahead < MIN_LOOKAHEAD && s.strm.avail_in !== 0);
+    }
+    function deflate_stored(s, flush) {
+      var max_block_size = 65535;
+      if (max_block_size > s.pending_buf_size - 5) {
+        max_block_size = s.pending_buf_size - 5;
+      }
+      for (; ; ) {
+        if (s.lookahead <= 1) {
+          fill_window(s);
+          if (s.lookahead === 0 && flush === Z_NO_FLUSH) {
+            return BS_NEED_MORE;
+          }
+          if (s.lookahead === 0) {
+            break;
+          }
+        }
+        s.strstart += s.lookahead;
+        s.lookahead = 0;
+        var max_start = s.block_start + max_block_size;
+        if (s.strstart === 0 || s.strstart >= max_start) {
+          s.lookahead = s.strstart - max_start;
+          s.strstart = max_start;
+          flush_block_only(s, false);
+          if (s.strm.avail_out === 0) {
+            return BS_NEED_MORE;
+          }
+        }
+        if (s.strstart - s.block_start >= s.w_size - MIN_LOOKAHEAD) {
+          flush_block_only(s, false);
+          if (s.strm.avail_out === 0) {
+            return BS_NEED_MORE;
+          }
+        }
+      }
+      s.insert = 0;
+      if (flush === Z_FINISH) {
+        flush_block_only(s, true);
+        if (s.strm.avail_out === 0) {
+          return BS_FINISH_STARTED;
+        }
+        return BS_FINISH_DONE;
+      }
+      if (s.strstart > s.block_start) {
+        flush_block_only(s, false);
+        if (s.strm.avail_out === 0) {
+          return BS_NEED_MORE;
+        }
+      }
+      return BS_NEED_MORE;
+    }
+    function deflate_fast(s, flush) {
+      var hash_head;
+      var bflush;
+      for (; ; ) {
+        if (s.lookahead < MIN_LOOKAHEAD) {
+          fill_window(s);
+          if (s.lookahead < MIN_LOOKAHEAD && flush === Z_NO_FLUSH) {
+            return BS_NEED_MORE;
+          }
+          if (s.lookahead === 0) {
+            break;
+          }
+        }
+        hash_head = 0;
+        if (s.lookahead >= MIN_MATCH) {
+          s.ins_h = (s.ins_h << s.hash_shift ^ s.window[s.strstart + MIN_MATCH - 1]) & s.hash_mask;
+          hash_head = s.prev[s.strstart & s.w_mask] = s.head[s.ins_h];
+          s.head[s.ins_h] = s.strstart;
+        }
+        if (hash_head !== 0 && s.strstart - hash_head <= s.w_size - MIN_LOOKAHEAD) {
+          s.match_length = longest_match(s, hash_head);
+        }
+        if (s.match_length >= MIN_MATCH) {
+          bflush = trees._tr_tally(s, s.strstart - s.match_start, s.match_length - MIN_MATCH);
+          s.lookahead -= s.match_length;
+          if (s.match_length <= s.max_lazy_match && s.lookahead >= MIN_MATCH) {
+            s.match_length--;
+            do {
+              s.strstart++;
+              s.ins_h = (s.ins_h << s.hash_shift ^ s.window[s.strstart + MIN_MATCH - 1]) & s.hash_mask;
+              hash_head = s.prev[s.strstart & s.w_mask] = s.head[s.ins_h];
+              s.head[s.ins_h] = s.strstart;
+            } while (--s.match_length !== 0);
+            s.strstart++;
+          } else {
+            s.strstart += s.match_length;
+            s.match_length = 0;
+            s.ins_h = s.window[s.strstart];
+            s.ins_h = (s.ins_h << s.hash_shift ^ s.window[s.strstart + 1]) & s.hash_mask;
+          }
+        } else {
+          bflush = trees._tr_tally(s, 0, s.window[s.strstart]);
+          s.lookahead--;
+          s.strstart++;
+        }
+        if (bflush) {
+          flush_block_only(s, false);
+          if (s.strm.avail_out === 0) {
+            return BS_NEED_MORE;
+          }
+        }
+      }
+      s.insert = s.strstart < MIN_MATCH - 1 ? s.strstart : MIN_MATCH - 1;
+      if (flush === Z_FINISH) {
+        flush_block_only(s, true);
+        if (s.strm.avail_out === 0) {
+          return BS_FINISH_STARTED;
+        }
+        return BS_FINISH_DONE;
+      }
+      if (s.last_lit) {
+        flush_block_only(s, false);
+        if (s.strm.avail_out === 0) {
+          return BS_NEED_MORE;
+        }
+      }
+      return BS_BLOCK_DONE;
+    }
+    function deflate_slow(s, flush) {
+      var hash_head;
+      var bflush;
+      var max_insert;
+      for (; ; ) {
+        if (s.lookahead < MIN_LOOKAHEAD) {
+          fill_window(s);
+          if (s.lookahead < MIN_LOOKAHEAD && flush === Z_NO_FLUSH) {
+            return BS_NEED_MORE;
+          }
+          if (s.lookahead === 0) {
+            break;
+          }
+        }
+        hash_head = 0;
+        if (s.lookahead >= MIN_MATCH) {
+          s.ins_h = (s.ins_h << s.hash_shift ^ s.window[s.strstart + MIN_MATCH - 1]) & s.hash_mask;
+          hash_head = s.prev[s.strstart & s.w_mask] = s.head[s.ins_h];
+          s.head[s.ins_h] = s.strstart;
+        }
+        s.prev_length = s.match_length;
+        s.prev_match = s.match_start;
+        s.match_length = MIN_MATCH - 1;
+        if (hash_head !== 0 && s.prev_length < s.max_lazy_match && s.strstart - hash_head <= s.w_size - MIN_LOOKAHEAD) {
+          s.match_length = longest_match(s, hash_head);
+          if (s.match_length <= 5 && (s.strategy === Z_FILTERED || s.match_length === MIN_MATCH && s.strstart - s.match_start > 4096)) {
+            s.match_length = MIN_MATCH - 1;
+          }
+        }
+        if (s.prev_length >= MIN_MATCH && s.match_length <= s.prev_length) {
+          max_insert = s.strstart + s.lookahead - MIN_MATCH;
+          bflush = trees._tr_tally(s, s.strstart - 1 - s.prev_match, s.prev_length - MIN_MATCH);
+          s.lookahead -= s.prev_length - 1;
+          s.prev_length -= 2;
+          do {
+            if (++s.strstart <= max_insert) {
+              s.ins_h = (s.ins_h << s.hash_shift ^ s.window[s.strstart + MIN_MATCH - 1]) & s.hash_mask;
+              hash_head = s.prev[s.strstart & s.w_mask] = s.head[s.ins_h];
+              s.head[s.ins_h] = s.strstart;
+            }
+          } while (--s.prev_length !== 0);
+          s.match_available = 0;
+          s.match_length = MIN_MATCH - 1;
+          s.strstart++;
+          if (bflush) {
+            flush_block_only(s, false);
+            if (s.strm.avail_out === 0) {
+              return BS_NEED_MORE;
+            }
+          }
+        } else if (s.match_available) {
+          bflush = trees._tr_tally(s, 0, s.window[s.strstart - 1]);
+          if (bflush) {
+            flush_block_only(s, false);
+          }
+          s.strstart++;
+          s.lookahead--;
+          if (s.strm.avail_out === 0) {
+            return BS_NEED_MORE;
+          }
+        } else {
+          s.match_available = 1;
+          s.strstart++;
+          s.lookahead--;
+        }
+      }
+      if (s.match_available) {
+        bflush = trees._tr_tally(s, 0, s.window[s.strstart - 1]);
+        s.match_available = 0;
+      }
+      s.insert = s.strstart < MIN_MATCH - 1 ? s.strstart : MIN_MATCH - 1;
+      if (flush === Z_FINISH) {
+        flush_block_only(s, true);
+        if (s.strm.avail_out === 0) {
+          return BS_FINISH_STARTED;
+        }
+        return BS_FINISH_DONE;
+      }
+      if (s.last_lit) {
+        flush_block_only(s, false);
+        if (s.strm.avail_out === 0) {
+          return BS_NEED_MORE;
+        }
+      }
+      return BS_BLOCK_DONE;
+    }
+    function deflate_rle(s, flush) {
+      var bflush;
+      var prev;
+      var scan, strend;
+      var _win = s.window;
+      for (; ; ) {
+        if (s.lookahead <= MAX_MATCH) {
+          fill_window(s);
+          if (s.lookahead <= MAX_MATCH && flush === Z_NO_FLUSH) {
+            return BS_NEED_MORE;
+          }
+          if (s.lookahead === 0) {
+            break;
+          }
+        }
+        s.match_length = 0;
+        if (s.lookahead >= MIN_MATCH && s.strstart > 0) {
+          scan = s.strstart - 1;
+          prev = _win[scan];
+          if (prev === _win[++scan] && prev === _win[++scan] && prev === _win[++scan]) {
+            strend = s.strstart + MAX_MATCH;
+            do {
+            } while (prev === _win[++scan] && prev === _win[++scan] && prev === _win[++scan] && prev === _win[++scan] && prev === _win[++scan] && prev === _win[++scan] && prev === _win[++scan] && prev === _win[++scan] && scan < strend);
+            s.match_length = MAX_MATCH - (strend - scan);
+            if (s.match_length > s.lookahead) {
+              s.match_length = s.lookahead;
+            }
+          }
+        }
+        if (s.match_length >= MIN_MATCH) {
+          bflush = trees._tr_tally(s, 1, s.match_length - MIN_MATCH);
+          s.lookahead -= s.match_length;
+          s.strstart += s.match_length;
+          s.match_length = 0;
+        } else {
+          bflush = trees._tr_tally(s, 0, s.window[s.strstart]);
+          s.lookahead--;
+          s.strstart++;
+        }
+        if (bflush) {
+          flush_block_only(s, false);
+          if (s.strm.avail_out === 0) {
+            return BS_NEED_MORE;
+          }
+        }
+      }
+      s.insert = 0;
+      if (flush === Z_FINISH) {
+        flush_block_only(s, true);
+        if (s.strm.avail_out === 0) {
+          return BS_FINISH_STARTED;
+        }
+        return BS_FINISH_DONE;
+      }
+      if (s.last_lit) {
+        flush_block_only(s, false);
+        if (s.strm.avail_out === 0) {
+          return BS_NEED_MORE;
+        }
+      }
+      return BS_BLOCK_DONE;
+    }
+    function deflate_huff(s, flush) {
+      var bflush;
+      for (; ; ) {
+        if (s.lookahead === 0) {
+          fill_window(s);
+          if (s.lookahead === 0) {
+            if (flush === Z_NO_FLUSH) {
+              return BS_NEED_MORE;
+            }
+            break;
+          }
+        }
+        s.match_length = 0;
+        bflush = trees._tr_tally(s, 0, s.window[s.strstart]);
+        s.lookahead--;
+        s.strstart++;
+        if (bflush) {
+          flush_block_only(s, false);
+          if (s.strm.avail_out === 0) {
+            return BS_NEED_MORE;
+          }
+        }
+      }
+      s.insert = 0;
+      if (flush === Z_FINISH) {
+        flush_block_only(s, true);
+        if (s.strm.avail_out === 0) {
+          return BS_FINISH_STARTED;
+        }
+        return BS_FINISH_DONE;
+      }
+      if (s.last_lit) {
+        flush_block_only(s, false);
+        if (s.strm.avail_out === 0) {
+          return BS_NEED_MORE;
+        }
+      }
+      return BS_BLOCK_DONE;
+    }
+    function Config(good_length, max_lazy, nice_length, max_chain, func) {
+      this.good_length = good_length;
+      this.max_lazy = max_lazy;
+      this.nice_length = nice_length;
+      this.max_chain = max_chain;
+      this.func = func;
+    }
+    var configuration_table;
+    configuration_table = [
+      /*      good lazy nice chain */
+      new Config(0, 0, 0, 0, deflate_stored),
+      /* 0 store only */
+      new Config(4, 4, 8, 4, deflate_fast),
+      /* 1 max speed, no lazy matches */
+      new Config(4, 5, 16, 8, deflate_fast),
+      /* 2 */
+      new Config(4, 6, 32, 32, deflate_fast),
+      /* 3 */
+      new Config(4, 4, 16, 16, deflate_slow),
+      /* 4 lazy matches */
+      new Config(8, 16, 32, 32, deflate_slow),
+      /* 5 */
+      new Config(8, 16, 128, 128, deflate_slow),
+      /* 6 */
+      new Config(8, 32, 128, 256, deflate_slow),
+      /* 7 */
+      new Config(32, 128, 258, 1024, deflate_slow),
+      /* 8 */
+      new Config(32, 258, 258, 4096, deflate_slow)
+      /* 9 max compression */
+    ];
+    function lm_init(s) {
+      s.window_size = 2 * s.w_size;
+      zero(s.head);
+      s.max_lazy_match = configuration_table[s.level].max_lazy;
+      s.good_match = configuration_table[s.level].good_length;
+      s.nice_match = configuration_table[s.level].nice_length;
+      s.max_chain_length = configuration_table[s.level].max_chain;
+      s.strstart = 0;
+      s.block_start = 0;
+      s.lookahead = 0;
+      s.insert = 0;
+      s.match_length = s.prev_length = MIN_MATCH - 1;
+      s.match_available = 0;
+      s.ins_h = 0;
+    }
+    function DeflateState() {
+      this.strm = null;
+      this.status = 0;
+      this.pending_buf = null;
+      this.pending_buf_size = 0;
+      this.pending_out = 0;
+      this.pending = 0;
+      this.wrap = 0;
+      this.gzhead = null;
+      this.gzindex = 0;
+      this.method = Z_DEFLATED;
+      this.last_flush = -1;
+      this.w_size = 0;
+      this.w_bits = 0;
+      this.w_mask = 0;
+      this.window = null;
+      this.window_size = 0;
+      this.prev = null;
+      this.head = null;
+      this.ins_h = 0;
+      this.hash_size = 0;
+      this.hash_bits = 0;
+      this.hash_mask = 0;
+      this.hash_shift = 0;
+      this.block_start = 0;
+      this.match_length = 0;
+      this.prev_match = 0;
+      this.match_available = 0;
+      this.strstart = 0;
+      this.match_start = 0;
+      this.lookahead = 0;
+      this.prev_length = 0;
+      this.max_chain_length = 0;
+      this.max_lazy_match = 0;
+      this.level = 0;
+      this.strategy = 0;
+      this.good_match = 0;
+      this.nice_match = 0;
+      this.dyn_ltree = new utils.Buf16(HEAP_SIZE * 2);
+      this.dyn_dtree = new utils.Buf16((2 * D_CODES + 1) * 2);
+      this.bl_tree = new utils.Buf16((2 * BL_CODES + 1) * 2);
+      zero(this.dyn_ltree);
+      zero(this.dyn_dtree);
+      zero(this.bl_tree);
+      this.l_desc = null;
+      this.d_desc = null;
+      this.bl_desc = null;
+      this.bl_count = new utils.Buf16(MAX_BITS + 1);
+      this.heap = new utils.Buf16(2 * L_CODES + 1);
+      zero(this.heap);
+      this.heap_len = 0;
+      this.heap_max = 0;
+      this.depth = new utils.Buf16(2 * L_CODES + 1);
+      zero(this.depth);
+      this.l_buf = 0;
+      this.lit_bufsize = 0;
+      this.last_lit = 0;
+      this.d_buf = 0;
+      this.opt_len = 0;
+      this.static_len = 0;
+      this.matches = 0;
+      this.insert = 0;
+      this.bi_buf = 0;
+      this.bi_valid = 0;
+    }
+    function deflateResetKeep(strm) {
+      var s;
+      if (!strm || !strm.state) {
+        return err(strm, Z_STREAM_ERROR);
+      }
+      strm.total_in = strm.total_out = 0;
+      strm.data_type = Z_UNKNOWN;
+      s = strm.state;
+      s.pending = 0;
+      s.pending_out = 0;
+      if (s.wrap < 0) {
+        s.wrap = -s.wrap;
+      }
+      s.status = s.wrap ? INIT_STATE : BUSY_STATE;
+      strm.adler = s.wrap === 2 ? 0 : 1;
+      s.last_flush = Z_NO_FLUSH;
+      trees._tr_init(s);
+      return Z_OK;
+    }
+    function deflateReset(strm) {
+      var ret = deflateResetKeep(strm);
+      if (ret === Z_OK) {
+        lm_init(strm.state);
+      }
+      return ret;
+    }
+    function deflateSetHeader(strm, head) {
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      if (strm.state.wrap !== 2) {
+        return Z_STREAM_ERROR;
+      }
+      strm.state.gzhead = head;
+      return Z_OK;
+    }
+    function deflateInit2(strm, level, method, windowBits, memLevel, strategy) {
+      if (!strm) {
+        return Z_STREAM_ERROR;
+      }
+      var wrap = 1;
+      if (level === Z_DEFAULT_COMPRESSION) {
+        level = 6;
+      }
+      if (windowBits < 0) {
+        wrap = 0;
+        windowBits = -windowBits;
+      } else if (windowBits > 15) {
+        wrap = 2;
+        windowBits -= 16;
+      }
+      if (memLevel < 1 || memLevel > MAX_MEM_LEVEL || method !== Z_DEFLATED || windowBits < 8 || windowBits > 15 || level < 0 || level > 9 || strategy < 0 || strategy > Z_FIXED) {
+        return err(strm, Z_STREAM_ERROR);
+      }
+      if (windowBits === 8) {
+        windowBits = 9;
+      }
+      var s = new DeflateState();
+      strm.state = s;
+      s.strm = strm;
+      s.wrap = wrap;
+      s.gzhead = null;
+      s.w_bits = windowBits;
+      s.w_size = 1 << s.w_bits;
+      s.w_mask = s.w_size - 1;
+      s.hash_bits = memLevel + 7;
+      s.hash_size = 1 << s.hash_bits;
+      s.hash_mask = s.hash_size - 1;
+      s.hash_shift = ~~((s.hash_bits + MIN_MATCH - 1) / MIN_MATCH);
+      s.window = new utils.Buf8(s.w_size * 2);
+      s.head = new utils.Buf16(s.hash_size);
+      s.prev = new utils.Buf16(s.w_size);
+      s.lit_bufsize = 1 << memLevel + 6;
+      s.pending_buf_size = s.lit_bufsize * 4;
+      s.pending_buf = new utils.Buf8(s.pending_buf_size);
+      s.d_buf = 1 * s.lit_bufsize;
+      s.l_buf = (1 + 2) * s.lit_bufsize;
+      s.level = level;
+      s.strategy = strategy;
+      s.method = method;
+      return deflateReset(strm);
+    }
+    function deflateInit(strm, level) {
+      return deflateInit2(strm, level, Z_DEFLATED, MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+    }
+    function deflate2(strm, flush) {
+      var old_flush, s;
+      var beg, val;
+      if (!strm || !strm.state || flush > Z_BLOCK || flush < 0) {
+        return strm ? err(strm, Z_STREAM_ERROR) : Z_STREAM_ERROR;
+      }
+      s = strm.state;
+      if (!strm.output || !strm.input && strm.avail_in !== 0 || s.status === FINISH_STATE && flush !== Z_FINISH) {
+        return err(strm, strm.avail_out === 0 ? Z_BUF_ERROR : Z_STREAM_ERROR);
+      }
+      s.strm = strm;
+      old_flush = s.last_flush;
+      s.last_flush = flush;
+      if (s.status === INIT_STATE) {
+        if (s.wrap === 2) {
+          strm.adler = 0;
+          put_byte(s, 31);
+          put_byte(s, 139);
+          put_byte(s, 8);
+          if (!s.gzhead) {
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, s.level === 9 ? 2 : s.strategy >= Z_HUFFMAN_ONLY || s.level < 2 ? 4 : 0);
+            put_byte(s, OS_CODE);
+            s.status = BUSY_STATE;
+          } else {
+            put_byte(
+              s,
+              (s.gzhead.text ? 1 : 0) + (s.gzhead.hcrc ? 2 : 0) + (!s.gzhead.extra ? 0 : 4) + (!s.gzhead.name ? 0 : 8) + (!s.gzhead.comment ? 0 : 16)
+            );
+            put_byte(s, s.gzhead.time & 255);
+            put_byte(s, s.gzhead.time >> 8 & 255);
+            put_byte(s, s.gzhead.time >> 16 & 255);
+            put_byte(s, s.gzhead.time >> 24 & 255);
+            put_byte(s, s.level === 9 ? 2 : s.strategy >= Z_HUFFMAN_ONLY || s.level < 2 ? 4 : 0);
+            put_byte(s, s.gzhead.os & 255);
+            if (s.gzhead.extra && s.gzhead.extra.length) {
+              put_byte(s, s.gzhead.extra.length & 255);
+              put_byte(s, s.gzhead.extra.length >> 8 & 255);
+            }
+            if (s.gzhead.hcrc) {
+              strm.adler = crc322(strm.adler, s.pending_buf, s.pending, 0);
+            }
+            s.gzindex = 0;
+            s.status = EXTRA_STATE;
+          }
+        } else {
+          var header = Z_DEFLATED + (s.w_bits - 8 << 4) << 8;
+          var level_flags = -1;
+          if (s.strategy >= Z_HUFFMAN_ONLY || s.level < 2) {
+            level_flags = 0;
+          } else if (s.level < 6) {
+            level_flags = 1;
+          } else if (s.level === 6) {
+            level_flags = 2;
+          } else {
+            level_flags = 3;
+          }
+          header |= level_flags << 6;
+          if (s.strstart !== 0) {
+            header |= PRESET_DICT;
+          }
+          header += 31 - header % 31;
+          s.status = BUSY_STATE;
+          putShortMSB(s, header);
+          if (s.strstart !== 0) {
+            putShortMSB(s, strm.adler >>> 16);
+            putShortMSB(s, strm.adler & 65535);
+          }
+          strm.adler = 1;
+        }
+      }
+      if (s.status === EXTRA_STATE) {
+        if (s.gzhead.extra) {
+          beg = s.pending;
+          while (s.gzindex < (s.gzhead.extra.length & 65535)) {
+            if (s.pending === s.pending_buf_size) {
+              if (s.gzhead.hcrc && s.pending > beg) {
+                strm.adler = crc322(strm.adler, s.pending_buf, s.pending - beg, beg);
+              }
+              flush_pending(strm);
+              beg = s.pending;
+              if (s.pending === s.pending_buf_size) {
+                break;
+              }
+            }
+            put_byte(s, s.gzhead.extra[s.gzindex] & 255);
+            s.gzindex++;
+          }
+          if (s.gzhead.hcrc && s.pending > beg) {
+            strm.adler = crc322(strm.adler, s.pending_buf, s.pending - beg, beg);
+          }
+          if (s.gzindex === s.gzhead.extra.length) {
+            s.gzindex = 0;
+            s.status = NAME_STATE;
+          }
+        } else {
+          s.status = NAME_STATE;
+        }
+      }
+      if (s.status === NAME_STATE) {
+        if (s.gzhead.name) {
+          beg = s.pending;
+          do {
+            if (s.pending === s.pending_buf_size) {
+              if (s.gzhead.hcrc && s.pending > beg) {
+                strm.adler = crc322(strm.adler, s.pending_buf, s.pending - beg, beg);
+              }
+              flush_pending(strm);
+              beg = s.pending;
+              if (s.pending === s.pending_buf_size) {
+                val = 1;
+                break;
+              }
+            }
+            if (s.gzindex < s.gzhead.name.length) {
+              val = s.gzhead.name.charCodeAt(s.gzindex++) & 255;
+            } else {
+              val = 0;
+            }
+            put_byte(s, val);
+          } while (val !== 0);
+          if (s.gzhead.hcrc && s.pending > beg) {
+            strm.adler = crc322(strm.adler, s.pending_buf, s.pending - beg, beg);
+          }
+          if (val === 0) {
+            s.gzindex = 0;
+            s.status = COMMENT_STATE;
+          }
+        } else {
+          s.status = COMMENT_STATE;
+        }
+      }
+      if (s.status === COMMENT_STATE) {
+        if (s.gzhead.comment) {
+          beg = s.pending;
+          do {
+            if (s.pending === s.pending_buf_size) {
+              if (s.gzhead.hcrc && s.pending > beg) {
+                strm.adler = crc322(strm.adler, s.pending_buf, s.pending - beg, beg);
+              }
+              flush_pending(strm);
+              beg = s.pending;
+              if (s.pending === s.pending_buf_size) {
+                val = 1;
+                break;
+              }
+            }
+            if (s.gzindex < s.gzhead.comment.length) {
+              val = s.gzhead.comment.charCodeAt(s.gzindex++) & 255;
+            } else {
+              val = 0;
+            }
+            put_byte(s, val);
+          } while (val !== 0);
+          if (s.gzhead.hcrc && s.pending > beg) {
+            strm.adler = crc322(strm.adler, s.pending_buf, s.pending - beg, beg);
+          }
+          if (val === 0) {
+            s.status = HCRC_STATE;
+          }
+        } else {
+          s.status = HCRC_STATE;
+        }
+      }
+      if (s.status === HCRC_STATE) {
+        if (s.gzhead.hcrc) {
+          if (s.pending + 2 > s.pending_buf_size) {
+            flush_pending(strm);
+          }
+          if (s.pending + 2 <= s.pending_buf_size) {
+            put_byte(s, strm.adler & 255);
+            put_byte(s, strm.adler >> 8 & 255);
+            strm.adler = 0;
+            s.status = BUSY_STATE;
+          }
+        } else {
+          s.status = BUSY_STATE;
+        }
+      }
+      if (s.pending !== 0) {
+        flush_pending(strm);
+        if (strm.avail_out === 0) {
+          s.last_flush = -1;
+          return Z_OK;
+        }
+      } else if (strm.avail_in === 0 && rank(flush) <= rank(old_flush) && flush !== Z_FINISH) {
+        return err(strm, Z_BUF_ERROR);
+      }
+      if (s.status === FINISH_STATE && strm.avail_in !== 0) {
+        return err(strm, Z_BUF_ERROR);
+      }
+      if (strm.avail_in !== 0 || s.lookahead !== 0 || flush !== Z_NO_FLUSH && s.status !== FINISH_STATE) {
+        var bstate = s.strategy === Z_HUFFMAN_ONLY ? deflate_huff(s, flush) : s.strategy === Z_RLE ? deflate_rle(s, flush) : configuration_table[s.level].func(s, flush);
+        if (bstate === BS_FINISH_STARTED || bstate === BS_FINISH_DONE) {
+          s.status = FINISH_STATE;
+        }
+        if (bstate === BS_NEED_MORE || bstate === BS_FINISH_STARTED) {
+          if (strm.avail_out === 0) {
+            s.last_flush = -1;
+          }
+          return Z_OK;
+        }
+        if (bstate === BS_BLOCK_DONE) {
+          if (flush === Z_PARTIAL_FLUSH) {
+            trees._tr_align(s);
+          } else if (flush !== Z_BLOCK) {
+            trees._tr_stored_block(s, 0, 0, false);
+            if (flush === Z_FULL_FLUSH) {
+              zero(s.head);
+              if (s.lookahead === 0) {
+                s.strstart = 0;
+                s.block_start = 0;
+                s.insert = 0;
+              }
+            }
+          }
+          flush_pending(strm);
+          if (strm.avail_out === 0) {
+            s.last_flush = -1;
+            return Z_OK;
+          }
+        }
+      }
+      if (flush !== Z_FINISH) {
+        return Z_OK;
+      }
+      if (s.wrap <= 0) {
+        return Z_STREAM_END;
+      }
+      if (s.wrap === 2) {
+        put_byte(s, strm.adler & 255);
+        put_byte(s, strm.adler >> 8 & 255);
+        put_byte(s, strm.adler >> 16 & 255);
+        put_byte(s, strm.adler >> 24 & 255);
+        put_byte(s, strm.total_in & 255);
+        put_byte(s, strm.total_in >> 8 & 255);
+        put_byte(s, strm.total_in >> 16 & 255);
+        put_byte(s, strm.total_in >> 24 & 255);
+      } else {
+        putShortMSB(s, strm.adler >>> 16);
+        putShortMSB(s, strm.adler & 65535);
+      }
+      flush_pending(strm);
+      if (s.wrap > 0) {
+        s.wrap = -s.wrap;
+      }
+      return s.pending !== 0 ? Z_OK : Z_STREAM_END;
+    }
+    function deflateEnd(strm) {
+      var status2;
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      status2 = strm.state.status;
+      if (status2 !== INIT_STATE && status2 !== EXTRA_STATE && status2 !== NAME_STATE && status2 !== COMMENT_STATE && status2 !== HCRC_STATE && status2 !== BUSY_STATE && status2 !== FINISH_STATE) {
+        return err(strm, Z_STREAM_ERROR);
+      }
+      strm.state = null;
+      return status2 === BUSY_STATE ? err(strm, Z_DATA_ERROR) : Z_OK;
+    }
+    function deflateSetDictionary(strm, dictionary) {
+      var dictLength = dictionary.length;
+      var s;
+      var str, n;
+      var wrap;
+      var avail;
+      var next;
+      var input;
+      var tmpDict;
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      s = strm.state;
+      wrap = s.wrap;
+      if (wrap === 2 || wrap === 1 && s.status !== INIT_STATE || s.lookahead) {
+        return Z_STREAM_ERROR;
+      }
+      if (wrap === 1) {
+        strm.adler = adler32(strm.adler, dictionary, dictLength, 0);
+      }
+      s.wrap = 0;
+      if (dictLength >= s.w_size) {
+        if (wrap === 0) {
+          zero(s.head);
+          s.strstart = 0;
+          s.block_start = 0;
+          s.insert = 0;
+        }
+        tmpDict = new utils.Buf8(s.w_size);
+        utils.arraySet(tmpDict, dictionary, dictLength - s.w_size, s.w_size, 0);
+        dictionary = tmpDict;
+        dictLength = s.w_size;
+      }
+      avail = strm.avail_in;
+      next = strm.next_in;
+      input = strm.input;
+      strm.avail_in = dictLength;
+      strm.next_in = 0;
+      strm.input = dictionary;
+      fill_window(s);
+      while (s.lookahead >= MIN_MATCH) {
+        str = s.strstart;
+        n = s.lookahead - (MIN_MATCH - 1);
+        do {
+          s.ins_h = (s.ins_h << s.hash_shift ^ s.window[str + MIN_MATCH - 1]) & s.hash_mask;
+          s.prev[str & s.w_mask] = s.head[s.ins_h];
+          s.head[s.ins_h] = str;
+          str++;
+        } while (--n);
+        s.strstart = str;
+        s.lookahead = MIN_MATCH - 1;
+        fill_window(s);
+      }
+      s.strstart += s.lookahead;
+      s.block_start = s.strstart;
+      s.insert = s.lookahead;
+      s.lookahead = 0;
+      s.match_length = s.prev_length = MIN_MATCH - 1;
+      s.match_available = 0;
+      strm.next_in = next;
+      strm.input = input;
+      strm.avail_in = avail;
+      s.wrap = wrap;
+      return Z_OK;
+    }
+    exports.deflateInit = deflateInit;
+    exports.deflateInit2 = deflateInit2;
+    exports.deflateReset = deflateReset;
+    exports.deflateResetKeep = deflateResetKeep;
+    exports.deflateSetHeader = deflateSetHeader;
+    exports.deflate = deflate2;
+    exports.deflateEnd = deflateEnd;
+    exports.deflateSetDictionary = deflateSetDictionary;
+    exports.deflateInfo = "pako deflate (from Nodeca project)";
+  }
+});
+
+// node_modules/pako/lib/utils/strings.js
+var require_strings = __commonJS({
+  "node_modules/pako/lib/utils/strings.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var utils = require_common();
+    var STR_APPLY_OK = true;
+    var STR_APPLY_UIA_OK = true;
+    try {
+      String.fromCharCode.apply(null, [0]);
+    } catch (__) {
+      STR_APPLY_OK = false;
+    }
+    try {
+      String.fromCharCode.apply(null, new Uint8Array(1));
+    } catch (__) {
+      STR_APPLY_UIA_OK = false;
+    }
+    var _utf8len = new utils.Buf8(256);
+    for (q = 0; q < 256; q++) {
+      _utf8len[q] = q >= 252 ? 6 : q >= 248 ? 5 : q >= 240 ? 4 : q >= 224 ? 3 : q >= 192 ? 2 : 1;
+    }
+    var q;
+    _utf8len[254] = _utf8len[254] = 1;
+    exports.string2buf = function(str) {
+      var buf, c, c2, m_pos, i, str_len = str.length, buf_len = 0;
+      for (m_pos = 0; m_pos < str_len; m_pos++) {
+        c = str.charCodeAt(m_pos);
+        if ((c & 64512) === 55296 && m_pos + 1 < str_len) {
+          c2 = str.charCodeAt(m_pos + 1);
+          if ((c2 & 64512) === 56320) {
+            c = 65536 + (c - 55296 << 10) + (c2 - 56320);
+            m_pos++;
+          }
+        }
+        buf_len += c < 128 ? 1 : c < 2048 ? 2 : c < 65536 ? 3 : 4;
+      }
+      buf = new utils.Buf8(buf_len);
+      for (i = 0, m_pos = 0; i < buf_len; m_pos++) {
+        c = str.charCodeAt(m_pos);
+        if ((c & 64512) === 55296 && m_pos + 1 < str_len) {
+          c2 = str.charCodeAt(m_pos + 1);
+          if ((c2 & 64512) === 56320) {
+            c = 65536 + (c - 55296 << 10) + (c2 - 56320);
+            m_pos++;
+          }
+        }
+        if (c < 128) {
+          buf[i++] = c;
+        } else if (c < 2048) {
+          buf[i++] = 192 | c >>> 6;
+          buf[i++] = 128 | c & 63;
+        } else if (c < 65536) {
+          buf[i++] = 224 | c >>> 12;
+          buf[i++] = 128 | c >>> 6 & 63;
+          buf[i++] = 128 | c & 63;
+        } else {
+          buf[i++] = 240 | c >>> 18;
+          buf[i++] = 128 | c >>> 12 & 63;
+          buf[i++] = 128 | c >>> 6 & 63;
+          buf[i++] = 128 | c & 63;
+        }
+      }
+      return buf;
+    };
+    function buf2binstring(buf, len) {
+      if (len < 65534) {
+        if (buf.subarray && STR_APPLY_UIA_OK || !buf.subarray && STR_APPLY_OK) {
+          return String.fromCharCode.apply(null, utils.shrinkBuf(buf, len));
+        }
+      }
+      var result = "";
+      for (var i = 0; i < len; i++) {
+        result += String.fromCharCode(buf[i]);
+      }
+      return result;
+    }
+    exports.buf2binstring = function(buf) {
+      return buf2binstring(buf, buf.length);
+    };
+    exports.binstring2buf = function(str) {
+      var buf = new utils.Buf8(str.length);
+      for (var i = 0, len = buf.length; i < len; i++) {
+        buf[i] = str.charCodeAt(i);
+      }
+      return buf;
+    };
+    exports.buf2string = function(buf, max) {
+      var i, out, c, c_len;
+      var len = max || buf.length;
+      var utf16buf = new Array(len * 2);
+      for (out = 0, i = 0; i < len; ) {
+        c = buf[i++];
+        if (c < 128) {
+          utf16buf[out++] = c;
+          continue;
+        }
+        c_len = _utf8len[c];
+        if (c_len > 4) {
+          utf16buf[out++] = 65533;
+          i += c_len - 1;
+          continue;
+        }
+        c &= c_len === 2 ? 31 : c_len === 3 ? 15 : 7;
+        while (c_len > 1 && i < len) {
+          c = c << 6 | buf[i++] & 63;
+          c_len--;
+        }
+        if (c_len > 1) {
+          utf16buf[out++] = 65533;
+          continue;
+        }
+        if (c < 65536) {
+          utf16buf[out++] = c;
+        } else {
+          c -= 65536;
+          utf16buf[out++] = 55296 | c >> 10 & 1023;
+          utf16buf[out++] = 56320 | c & 1023;
+        }
+      }
+      return buf2binstring(utf16buf, out);
+    };
+    exports.utf8border = function(buf, max) {
+      var pos;
+      max = max || buf.length;
+      if (max > buf.length) {
+        max = buf.length;
+      }
+      pos = max - 1;
+      while (pos >= 0 && (buf[pos] & 192) === 128) {
+        pos--;
+      }
+      if (pos < 0) {
+        return max;
+      }
+      if (pos === 0) {
+        return max;
+      }
+      return pos + _utf8len[buf[pos]] > max ? pos : max;
+    };
+  }
+});
+
+// node_modules/pako/lib/zlib/zstream.js
+var require_zstream = __commonJS({
+  "node_modules/pako/lib/zlib/zstream.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    function ZStream() {
+      this.input = null;
+      this.next_in = 0;
+      this.avail_in = 0;
+      this.total_in = 0;
+      this.output = null;
+      this.next_out = 0;
+      this.avail_out = 0;
+      this.total_out = 0;
+      this.msg = "";
+      this.state = null;
+      this.data_type = 2;
+      this.adler = 0;
+    }
+    module.exports = ZStream;
+  }
+});
+
+// node_modules/pako/lib/deflate.js
+var require_deflate2 = __commonJS({
+  "node_modules/pako/lib/deflate.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var zlib_deflate = require_deflate();
+    var utils = require_common();
+    var strings = require_strings();
+    var msg = require_messages();
+    var ZStream = require_zstream();
+    var toString = Object.prototype.toString;
+    var Z_NO_FLUSH = 0;
+    var Z_FINISH = 4;
+    var Z_OK = 0;
+    var Z_STREAM_END = 1;
+    var Z_SYNC_FLUSH = 2;
+    var Z_DEFAULT_COMPRESSION = -1;
+    var Z_DEFAULT_STRATEGY = 0;
+    var Z_DEFLATED = 8;
+    function Deflate(options) {
+      if (!(this instanceof Deflate)) return new Deflate(options);
+      this.options = utils.assign({
+        level: Z_DEFAULT_COMPRESSION,
+        method: Z_DEFLATED,
+        chunkSize: 16384,
+        windowBits: 15,
+        memLevel: 8,
+        strategy: Z_DEFAULT_STRATEGY,
+        to: ""
+      }, options || {});
+      var opt = this.options;
+      if (opt.raw && opt.windowBits > 0) {
+        opt.windowBits = -opt.windowBits;
+      } else if (opt.gzip && opt.windowBits > 0 && opt.windowBits < 16) {
+        opt.windowBits += 16;
+      }
+      this.err = 0;
+      this.msg = "";
+      this.ended = false;
+      this.chunks = [];
+      this.strm = new ZStream();
+      this.strm.avail_out = 0;
+      var status2 = zlib_deflate.deflateInit2(
+        this.strm,
+        opt.level,
+        opt.method,
+        opt.windowBits,
+        opt.memLevel,
+        opt.strategy
+      );
+      if (status2 !== Z_OK) {
+        throw new Error(msg[status2]);
+      }
+      if (opt.header) {
+        zlib_deflate.deflateSetHeader(this.strm, opt.header);
+      }
+      if (opt.dictionary) {
+        var dict;
+        if (typeof opt.dictionary === "string") {
+          dict = strings.string2buf(opt.dictionary);
+        } else if (toString.call(opt.dictionary) === "[object ArrayBuffer]") {
+          dict = new Uint8Array(opt.dictionary);
+        } else {
+          dict = opt.dictionary;
+        }
+        status2 = zlib_deflate.deflateSetDictionary(this.strm, dict);
+        if (status2 !== Z_OK) {
+          throw new Error(msg[status2]);
+        }
+        this._dict_set = true;
+      }
+    }
+    Deflate.prototype.push = function(data, mode) {
+      var strm = this.strm;
+      var chunkSize = this.options.chunkSize;
+      var status2, _mode;
+      if (this.ended) {
+        return false;
+      }
+      _mode = mode === ~~mode ? mode : mode === true ? Z_FINISH : Z_NO_FLUSH;
+      if (typeof data === "string") {
+        strm.input = strings.string2buf(data);
+      } else if (toString.call(data) === "[object ArrayBuffer]") {
+        strm.input = new Uint8Array(data);
+      } else {
+        strm.input = data;
+      }
+      strm.next_in = 0;
+      strm.avail_in = strm.input.length;
+      do {
+        if (strm.avail_out === 0) {
+          strm.output = new utils.Buf8(chunkSize);
+          strm.next_out = 0;
+          strm.avail_out = chunkSize;
+        }
+        status2 = zlib_deflate.deflate(strm, _mode);
+        if (status2 !== Z_STREAM_END && status2 !== Z_OK) {
+          this.onEnd(status2);
+          this.ended = true;
+          return false;
+        }
+        if (strm.avail_out === 0 || strm.avail_in === 0 && (_mode === Z_FINISH || _mode === Z_SYNC_FLUSH)) {
+          if (this.options.to === "string") {
+            this.onData(strings.buf2binstring(utils.shrinkBuf(strm.output, strm.next_out)));
+          } else {
+            this.onData(utils.shrinkBuf(strm.output, strm.next_out));
+          }
+        }
+      } while ((strm.avail_in > 0 || strm.avail_out === 0) && status2 !== Z_STREAM_END);
+      if (_mode === Z_FINISH) {
+        status2 = zlib_deflate.deflateEnd(this.strm);
+        this.onEnd(status2);
+        this.ended = true;
+        return status2 === Z_OK;
+      }
+      if (_mode === Z_SYNC_FLUSH) {
+        this.onEnd(Z_OK);
+        strm.avail_out = 0;
+        return true;
+      }
+      return true;
+    };
+    Deflate.prototype.onData = function(chunk) {
+      this.chunks.push(chunk);
+    };
+    Deflate.prototype.onEnd = function(status2) {
+      if (status2 === Z_OK) {
+        if (this.options.to === "string") {
+          this.result = this.chunks.join("");
+        } else {
+          this.result = utils.flattenChunks(this.chunks);
+        }
+      }
+      this.chunks = [];
+      this.err = status2;
+      this.msg = this.strm.msg;
+    };
+    function deflate2(input, options) {
+      var deflator = new Deflate(options);
+      deflator.push(input, true);
+      if (deflator.err) {
+        throw deflator.msg || msg[deflator.err];
+      }
+      return deflator.result;
+    }
+    function deflateRaw(input, options) {
+      options = options || {};
+      options.raw = true;
+      return deflate2(input, options);
+    }
+    function gzip(input, options) {
+      options = options || {};
+      options.gzip = true;
+      return deflate2(input, options);
+    }
+    exports.Deflate = Deflate;
+    exports.deflate = deflate2;
+    exports.deflateRaw = deflateRaw;
+    exports.gzip = gzip;
+  }
+});
+
+// node_modules/pako/lib/zlib/inffast.js
+var require_inffast = __commonJS({
+  "node_modules/pako/lib/zlib/inffast.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var BAD = 30;
+    var TYPE = 12;
+    module.exports = function inflate_fast(strm, start) {
+      var state;
+      var _in;
+      var last;
+      var _out;
+      var beg;
+      var end;
+      var dmax;
+      var wsize;
+      var whave;
+      var wnext;
+      var s_window;
+      var hold;
+      var bits;
+      var lcode;
+      var dcode;
+      var lmask;
+      var dmask;
+      var here;
+      var op;
+      var len;
+      var dist;
+      var from;
+      var from_source;
+      var input, output;
+      state = strm.state;
+      _in = strm.next_in;
+      input = strm.input;
+      last = _in + (strm.avail_in - 5);
+      _out = strm.next_out;
+      output = strm.output;
+      beg = _out - (start - strm.avail_out);
+      end = _out + (strm.avail_out - 257);
+      dmax = state.dmax;
+      wsize = state.wsize;
+      whave = state.whave;
+      wnext = state.wnext;
+      s_window = state.window;
+      hold = state.hold;
+      bits = state.bits;
+      lcode = state.lencode;
+      dcode = state.distcode;
+      lmask = (1 << state.lenbits) - 1;
+      dmask = (1 << state.distbits) - 1;
+      top:
+        do {
+          if (bits < 15) {
+            hold += input[_in++] << bits;
+            bits += 8;
+            hold += input[_in++] << bits;
+            bits += 8;
+          }
+          here = lcode[hold & lmask];
+          dolen:
+            for (; ; ) {
+              op = here >>> 24;
+              hold >>>= op;
+              bits -= op;
+              op = here >>> 16 & 255;
+              if (op === 0) {
+                output[_out++] = here & 65535;
+              } else if (op & 16) {
+                len = here & 65535;
+                op &= 15;
+                if (op) {
+                  if (bits < op) {
+                    hold += input[_in++] << bits;
+                    bits += 8;
+                  }
+                  len += hold & (1 << op) - 1;
+                  hold >>>= op;
+                  bits -= op;
+                }
+                if (bits < 15) {
+                  hold += input[_in++] << bits;
+                  bits += 8;
+                  hold += input[_in++] << bits;
+                  bits += 8;
+                }
+                here = dcode[hold & dmask];
+                dodist:
+                  for (; ; ) {
+                    op = here >>> 24;
+                    hold >>>= op;
+                    bits -= op;
+                    op = here >>> 16 & 255;
+                    if (op & 16) {
+                      dist = here & 65535;
+                      op &= 15;
+                      if (bits < op) {
+                        hold += input[_in++] << bits;
+                        bits += 8;
+                        if (bits < op) {
+                          hold += input[_in++] << bits;
+                          bits += 8;
+                        }
+                      }
+                      dist += hold & (1 << op) - 1;
+                      if (dist > dmax) {
+                        strm.msg = "invalid distance too far back";
+                        state.mode = BAD;
+                        break top;
+                      }
+                      hold >>>= op;
+                      bits -= op;
+                      op = _out - beg;
+                      if (dist > op) {
+                        op = dist - op;
+                        if (op > whave) {
+                          if (state.sane) {
+                            strm.msg = "invalid distance too far back";
+                            state.mode = BAD;
+                            break top;
+                          }
+                        }
+                        from = 0;
+                        from_source = s_window;
+                        if (wnext === 0) {
+                          from += wsize - op;
+                          if (op < len) {
+                            len -= op;
+                            do {
+                              output[_out++] = s_window[from++];
+                            } while (--op);
+                            from = _out - dist;
+                            from_source = output;
+                          }
+                        } else if (wnext < op) {
+                          from += wsize + wnext - op;
+                          op -= wnext;
+                          if (op < len) {
+                            len -= op;
+                            do {
+                              output[_out++] = s_window[from++];
+                            } while (--op);
+                            from = 0;
+                            if (wnext < len) {
+                              op = wnext;
+                              len -= op;
+                              do {
+                                output[_out++] = s_window[from++];
+                              } while (--op);
+                              from = _out - dist;
+                              from_source = output;
+                            }
+                          }
+                        } else {
+                          from += wnext - op;
+                          if (op < len) {
+                            len -= op;
+                            do {
+                              output[_out++] = s_window[from++];
+                            } while (--op);
+                            from = _out - dist;
+                            from_source = output;
+                          }
+                        }
+                        while (len > 2) {
+                          output[_out++] = from_source[from++];
+                          output[_out++] = from_source[from++];
+                          output[_out++] = from_source[from++];
+                          len -= 3;
+                        }
+                        if (len) {
+                          output[_out++] = from_source[from++];
+                          if (len > 1) {
+                            output[_out++] = from_source[from++];
+                          }
+                        }
+                      } else {
+                        from = _out - dist;
+                        do {
+                          output[_out++] = output[from++];
+                          output[_out++] = output[from++];
+                          output[_out++] = output[from++];
+                          len -= 3;
+                        } while (len > 2);
+                        if (len) {
+                          output[_out++] = output[from++];
+                          if (len > 1) {
+                            output[_out++] = output[from++];
+                          }
+                        }
+                      }
+                    } else if ((op & 64) === 0) {
+                      here = dcode[(here & 65535) + (hold & (1 << op) - 1)];
+                      continue dodist;
+                    } else {
+                      strm.msg = "invalid distance code";
+                      state.mode = BAD;
+                      break top;
+                    }
+                    break;
+                  }
+              } else if ((op & 64) === 0) {
+                here = lcode[(here & 65535) + (hold & (1 << op) - 1)];
+                continue dolen;
+              } else if (op & 32) {
+                state.mode = TYPE;
+                break top;
+              } else {
+                strm.msg = "invalid literal/length code";
+                state.mode = BAD;
+                break top;
+              }
+              break;
+            }
+        } while (_in < last && _out < end);
+      len = bits >> 3;
+      _in -= len;
+      bits -= len << 3;
+      hold &= (1 << bits) - 1;
+      strm.next_in = _in;
+      strm.next_out = _out;
+      strm.avail_in = _in < last ? 5 + (last - _in) : 5 - (_in - last);
+      strm.avail_out = _out < end ? 257 + (end - _out) : 257 - (_out - end);
+      state.hold = hold;
+      state.bits = bits;
+      return;
+    };
+  }
+});
+
+// node_modules/pako/lib/zlib/inftrees.js
+var require_inftrees = __commonJS({
+  "node_modules/pako/lib/zlib/inftrees.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var utils = require_common();
+    var MAXBITS = 15;
+    var ENOUGH_LENS = 852;
+    var ENOUGH_DISTS = 592;
+    var CODES = 0;
+    var LENS = 1;
+    var DISTS = 2;
+    var lbase = [
+      /* Length codes 257..285 base */
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      13,
+      15,
+      17,
+      19,
+      23,
+      27,
+      31,
+      35,
+      43,
+      51,
+      59,
+      67,
+      83,
+      99,
+      115,
+      131,
+      163,
+      195,
+      227,
+      258,
+      0,
+      0
+    ];
+    var lext = [
+      /* Length codes 257..285 extra */
+      16,
+      16,
+      16,
+      16,
+      16,
+      16,
+      16,
+      16,
+      17,
+      17,
+      17,
+      17,
+      18,
+      18,
+      18,
+      18,
+      19,
+      19,
+      19,
+      19,
+      20,
+      20,
+      20,
+      20,
+      21,
+      21,
+      21,
+      21,
+      16,
+      72,
+      78
+    ];
+    var dbase = [
+      /* Distance codes 0..29 base */
+      1,
+      2,
+      3,
+      4,
+      5,
+      7,
+      9,
+      13,
+      17,
+      25,
+      33,
+      49,
+      65,
+      97,
+      129,
+      193,
+      257,
+      385,
+      513,
+      769,
+      1025,
+      1537,
+      2049,
+      3073,
+      4097,
+      6145,
+      8193,
+      12289,
+      16385,
+      24577,
+      0,
+      0
+    ];
+    var dext = [
+      /* Distance codes 0..29 extra */
+      16,
+      16,
+      16,
+      16,
+      17,
+      17,
+      18,
+      18,
+      19,
+      19,
+      20,
+      20,
+      21,
+      21,
+      22,
+      22,
+      23,
+      23,
+      24,
+      24,
+      25,
+      25,
+      26,
+      26,
+      27,
+      27,
+      28,
+      28,
+      29,
+      29,
+      64,
+      64
+    ];
+    module.exports = function inflate_table(type, lens, lens_index, codes, table, table_index, work, opts) {
+      var bits = opts.bits;
+      var len = 0;
+      var sym = 0;
+      var min = 0, max = 0;
+      var root = 0;
+      var curr = 0;
+      var drop = 0;
+      var left = 0;
+      var used = 0;
+      var huff = 0;
+      var incr;
+      var fill;
+      var low;
+      var mask;
+      var next;
+      var base = null;
+      var base_index = 0;
+      var end;
+      var count = new utils.Buf16(MAXBITS + 1);
+      var offs = new utils.Buf16(MAXBITS + 1);
+      var extra = null;
+      var extra_index = 0;
+      var here_bits, here_op, here_val;
+      for (len = 0; len <= MAXBITS; len++) {
+        count[len] = 0;
+      }
+      for (sym = 0; sym < codes; sym++) {
+        count[lens[lens_index + sym]]++;
+      }
+      root = bits;
+      for (max = MAXBITS; max >= 1; max--) {
+        if (count[max] !== 0) {
+          break;
+        }
+      }
+      if (root > max) {
+        root = max;
+      }
+      if (max === 0) {
+        table[table_index++] = 1 << 24 | 64 << 16 | 0;
+        table[table_index++] = 1 << 24 | 64 << 16 | 0;
+        opts.bits = 1;
+        return 0;
+      }
+      for (min = 1; min < max; min++) {
+        if (count[min] !== 0) {
+          break;
+        }
+      }
+      if (root < min) {
+        root = min;
+      }
+      left = 1;
+      for (len = 1; len <= MAXBITS; len++) {
+        left <<= 1;
+        left -= count[len];
+        if (left < 0) {
+          return -1;
+        }
+      }
+      if (left > 0 && (type === CODES || max !== 1)) {
+        return -1;
+      }
+      offs[1] = 0;
+      for (len = 1; len < MAXBITS; len++) {
+        offs[len + 1] = offs[len] + count[len];
+      }
+      for (sym = 0; sym < codes; sym++) {
+        if (lens[lens_index + sym] !== 0) {
+          work[offs[lens[lens_index + sym]]++] = sym;
+        }
+      }
+      if (type === CODES) {
+        base = extra = work;
+        end = 19;
+      } else if (type === LENS) {
+        base = lbase;
+        base_index -= 257;
+        extra = lext;
+        extra_index -= 257;
+        end = 256;
+      } else {
+        base = dbase;
+        extra = dext;
+        end = -1;
+      }
+      huff = 0;
+      sym = 0;
+      len = min;
+      next = table_index;
+      curr = root;
+      drop = 0;
+      low = -1;
+      used = 1 << root;
+      mask = used - 1;
+      if (type === LENS && used > ENOUGH_LENS || type === DISTS && used > ENOUGH_DISTS) {
+        return 1;
+      }
+      for (; ; ) {
+        here_bits = len - drop;
+        if (work[sym] < end) {
+          here_op = 0;
+          here_val = work[sym];
+        } else if (work[sym] > end) {
+          here_op = extra[extra_index + work[sym]];
+          here_val = base[base_index + work[sym]];
+        } else {
+          here_op = 32 + 64;
+          here_val = 0;
+        }
+        incr = 1 << len - drop;
+        fill = 1 << curr;
+        min = fill;
+        do {
+          fill -= incr;
+          table[next + (huff >> drop) + fill] = here_bits << 24 | here_op << 16 | here_val | 0;
+        } while (fill !== 0);
+        incr = 1 << len - 1;
+        while (huff & incr) {
+          incr >>= 1;
+        }
+        if (incr !== 0) {
+          huff &= incr - 1;
+          huff += incr;
+        } else {
+          huff = 0;
+        }
+        sym++;
+        if (--count[len] === 0) {
+          if (len === max) {
+            break;
+          }
+          len = lens[lens_index + work[sym]];
+        }
+        if (len > root && (huff & mask) !== low) {
+          if (drop === 0) {
+            drop = root;
+          }
+          next += min;
+          curr = len - drop;
+          left = 1 << curr;
+          while (curr + drop < max) {
+            left -= count[curr + drop];
+            if (left <= 0) {
+              break;
+            }
+            curr++;
+            left <<= 1;
+          }
+          used += 1 << curr;
+          if (type === LENS && used > ENOUGH_LENS || type === DISTS && used > ENOUGH_DISTS) {
+            return 1;
+          }
+          low = huff & mask;
+          table[low] = root << 24 | curr << 16 | next - table_index | 0;
+        }
+      }
+      if (huff !== 0) {
+        table[next + huff] = len - drop << 24 | 64 << 16 | 0;
+      }
+      opts.bits = root;
+      return 0;
+    };
+  }
+});
+
+// node_modules/pako/lib/zlib/inflate.js
+var require_inflate = __commonJS({
+  "node_modules/pako/lib/zlib/inflate.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var utils = require_common();
+    var adler32 = require_adler32();
+    var crc322 = require_crc322();
+    var inflate_fast = require_inffast();
+    var inflate_table = require_inftrees();
+    var CODES = 0;
+    var LENS = 1;
+    var DISTS = 2;
+    var Z_FINISH = 4;
+    var Z_BLOCK = 5;
+    var Z_TREES = 6;
+    var Z_OK = 0;
+    var Z_STREAM_END = 1;
+    var Z_NEED_DICT = 2;
+    var Z_STREAM_ERROR = -2;
+    var Z_DATA_ERROR = -3;
+    var Z_MEM_ERROR = -4;
+    var Z_BUF_ERROR = -5;
+    var Z_DEFLATED = 8;
+    var HEAD = 1;
+    var FLAGS = 2;
+    var TIME = 3;
+    var OS = 4;
+    var EXLEN = 5;
+    var EXTRA = 6;
+    var NAME = 7;
+    var COMMENT = 8;
+    var HCRC = 9;
+    var DICTID = 10;
+    var DICT = 11;
+    var TYPE = 12;
+    var TYPEDO = 13;
+    var STORED = 14;
+    var COPY_ = 15;
+    var COPY = 16;
+    var TABLE = 17;
+    var LENLENS = 18;
+    var CODELENS = 19;
+    var LEN_ = 20;
+    var LEN = 21;
+    var LENEXT = 22;
+    var DIST = 23;
+    var DISTEXT = 24;
+    var MATCH = 25;
+    var LIT = 26;
+    var CHECK = 27;
+    var LENGTH = 28;
+    var DONE = 29;
+    var BAD = 30;
+    var MEM = 31;
+    var SYNC = 32;
+    var ENOUGH_LENS = 852;
+    var ENOUGH_DISTS = 592;
+    var MAX_WBITS = 15;
+    var DEF_WBITS = MAX_WBITS;
+    function zswap32(q) {
+      return (q >>> 24 & 255) + (q >>> 8 & 65280) + ((q & 65280) << 8) + ((q & 255) << 24);
+    }
+    function InflateState() {
+      this.mode = 0;
+      this.last = false;
+      this.wrap = 0;
+      this.havedict = false;
+      this.flags = 0;
+      this.dmax = 0;
+      this.check = 0;
+      this.total = 0;
+      this.head = null;
+      this.wbits = 0;
+      this.wsize = 0;
+      this.whave = 0;
+      this.wnext = 0;
+      this.window = null;
+      this.hold = 0;
+      this.bits = 0;
+      this.length = 0;
+      this.offset = 0;
+      this.extra = 0;
+      this.lencode = null;
+      this.distcode = null;
+      this.lenbits = 0;
+      this.distbits = 0;
+      this.ncode = 0;
+      this.nlen = 0;
+      this.ndist = 0;
+      this.have = 0;
+      this.next = null;
+      this.lens = new utils.Buf16(320);
+      this.work = new utils.Buf16(288);
+      this.lendyn = null;
+      this.distdyn = null;
+      this.sane = 0;
+      this.back = 0;
+      this.was = 0;
+    }
+    function inflateResetKeep(strm) {
+      var state;
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      state = strm.state;
+      strm.total_in = strm.total_out = state.total = 0;
+      strm.msg = "";
+      if (state.wrap) {
+        strm.adler = state.wrap & 1;
+      }
+      state.mode = HEAD;
+      state.last = 0;
+      state.havedict = 0;
+      state.dmax = 32768;
+      state.head = null;
+      state.hold = 0;
+      state.bits = 0;
+      state.lencode = state.lendyn = new utils.Buf32(ENOUGH_LENS);
+      state.distcode = state.distdyn = new utils.Buf32(ENOUGH_DISTS);
+      state.sane = 1;
+      state.back = -1;
+      return Z_OK;
+    }
+    function inflateReset(strm) {
+      var state;
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      state = strm.state;
+      state.wsize = 0;
+      state.whave = 0;
+      state.wnext = 0;
+      return inflateResetKeep(strm);
+    }
+    function inflateReset2(strm, windowBits) {
+      var wrap;
+      var state;
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      state = strm.state;
+      if (windowBits < 0) {
+        wrap = 0;
+        windowBits = -windowBits;
+      } else {
+        wrap = (windowBits >> 4) + 1;
+        if (windowBits < 48) {
+          windowBits &= 15;
+        }
+      }
+      if (windowBits && (windowBits < 8 || windowBits > 15)) {
+        return Z_STREAM_ERROR;
+      }
+      if (state.window !== null && state.wbits !== windowBits) {
+        state.window = null;
+      }
+      state.wrap = wrap;
+      state.wbits = windowBits;
+      return inflateReset(strm);
+    }
+    function inflateInit2(strm, windowBits) {
+      var ret;
+      var state;
+      if (!strm) {
+        return Z_STREAM_ERROR;
+      }
+      state = new InflateState();
+      strm.state = state;
+      state.window = null;
+      ret = inflateReset2(strm, windowBits);
+      if (ret !== Z_OK) {
+        strm.state = null;
+      }
+      return ret;
+    }
+    function inflateInit(strm) {
+      return inflateInit2(strm, DEF_WBITS);
+    }
+    var virgin = true;
+    var lenfix;
+    var distfix;
+    function fixedtables(state) {
+      if (virgin) {
+        var sym;
+        lenfix = new utils.Buf32(512);
+        distfix = new utils.Buf32(32);
+        sym = 0;
+        while (sym < 144) {
+          state.lens[sym++] = 8;
+        }
+        while (sym < 256) {
+          state.lens[sym++] = 9;
+        }
+        while (sym < 280) {
+          state.lens[sym++] = 7;
+        }
+        while (sym < 288) {
+          state.lens[sym++] = 8;
+        }
+        inflate_table(LENS, state.lens, 0, 288, lenfix, 0, state.work, { bits: 9 });
+        sym = 0;
+        while (sym < 32) {
+          state.lens[sym++] = 5;
+        }
+        inflate_table(DISTS, state.lens, 0, 32, distfix, 0, state.work, { bits: 5 });
+        virgin = false;
+      }
+      state.lencode = lenfix;
+      state.lenbits = 9;
+      state.distcode = distfix;
+      state.distbits = 5;
+    }
+    function updatewindow(strm, src, end, copy) {
+      var dist;
+      var state = strm.state;
+      if (state.window === null) {
+        state.wsize = 1 << state.wbits;
+        state.wnext = 0;
+        state.whave = 0;
+        state.window = new utils.Buf8(state.wsize);
+      }
+      if (copy >= state.wsize) {
+        utils.arraySet(state.window, src, end - state.wsize, state.wsize, 0);
+        state.wnext = 0;
+        state.whave = state.wsize;
+      } else {
+        dist = state.wsize - state.wnext;
+        if (dist > copy) {
+          dist = copy;
+        }
+        utils.arraySet(state.window, src, end - copy, dist, state.wnext);
+        copy -= dist;
+        if (copy) {
+          utils.arraySet(state.window, src, end - copy, copy, 0);
+          state.wnext = copy;
+          state.whave = state.wsize;
+        } else {
+          state.wnext += dist;
+          if (state.wnext === state.wsize) {
+            state.wnext = 0;
+          }
+          if (state.whave < state.wsize) {
+            state.whave += dist;
+          }
+        }
+      }
+      return 0;
+    }
+    function inflate2(strm, flush) {
+      var state;
+      var input, output;
+      var next;
+      var put;
+      var have, left;
+      var hold;
+      var bits;
+      var _in, _out;
+      var copy;
+      var from;
+      var from_source;
+      var here = 0;
+      var here_bits, here_op, here_val;
+      var last_bits, last_op, last_val;
+      var len;
+      var ret;
+      var hbuf = new utils.Buf8(4);
+      var opts;
+      var n;
+      var order = (
+        /* permutation of code lengths */
+        [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]
+      );
+      if (!strm || !strm.state || !strm.output || !strm.input && strm.avail_in !== 0) {
+        return Z_STREAM_ERROR;
+      }
+      state = strm.state;
+      if (state.mode === TYPE) {
+        state.mode = TYPEDO;
+      }
+      put = strm.next_out;
+      output = strm.output;
+      left = strm.avail_out;
+      next = strm.next_in;
+      input = strm.input;
+      have = strm.avail_in;
+      hold = state.hold;
+      bits = state.bits;
+      _in = have;
+      _out = left;
+      ret = Z_OK;
+      inf_leave:
+        for (; ; ) {
+          switch (state.mode) {
+            case HEAD:
+              if (state.wrap === 0) {
+                state.mode = TYPEDO;
+                break;
+              }
+              while (bits < 16) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              if (state.wrap & 2 && hold === 35615) {
+                state.check = 0;
+                hbuf[0] = hold & 255;
+                hbuf[1] = hold >>> 8 & 255;
+                state.check = crc322(state.check, hbuf, 2, 0);
+                hold = 0;
+                bits = 0;
+                state.mode = FLAGS;
+                break;
+              }
+              state.flags = 0;
+              if (state.head) {
+                state.head.done = false;
+              }
+              if (!(state.wrap & 1) || /* check if zlib header allowed */
+              (((hold & 255) << 8) + (hold >> 8)) % 31) {
+                strm.msg = "incorrect header check";
+                state.mode = BAD;
+                break;
+              }
+              if ((hold & 15) !== Z_DEFLATED) {
+                strm.msg = "unknown compression method";
+                state.mode = BAD;
+                break;
+              }
+              hold >>>= 4;
+              bits -= 4;
+              len = (hold & 15) + 8;
+              if (state.wbits === 0) {
+                state.wbits = len;
+              } else if (len > state.wbits) {
+                strm.msg = "invalid window size";
+                state.mode = BAD;
+                break;
+              }
+              state.dmax = 1 << len;
+              strm.adler = state.check = 1;
+              state.mode = hold & 512 ? DICTID : TYPE;
+              hold = 0;
+              bits = 0;
+              break;
+            case FLAGS:
+              while (bits < 16) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              state.flags = hold;
+              if ((state.flags & 255) !== Z_DEFLATED) {
+                strm.msg = "unknown compression method";
+                state.mode = BAD;
+                break;
+              }
+              if (state.flags & 57344) {
+                strm.msg = "unknown header flags set";
+                state.mode = BAD;
+                break;
+              }
+              if (state.head) {
+                state.head.text = hold >> 8 & 1;
+              }
+              if (state.flags & 512) {
+                hbuf[0] = hold & 255;
+                hbuf[1] = hold >>> 8 & 255;
+                state.check = crc322(state.check, hbuf, 2, 0);
+              }
+              hold = 0;
+              bits = 0;
+              state.mode = TIME;
+            /* falls through */
+            case TIME:
+              while (bits < 32) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              if (state.head) {
+                state.head.time = hold;
+              }
+              if (state.flags & 512) {
+                hbuf[0] = hold & 255;
+                hbuf[1] = hold >>> 8 & 255;
+                hbuf[2] = hold >>> 16 & 255;
+                hbuf[3] = hold >>> 24 & 255;
+                state.check = crc322(state.check, hbuf, 4, 0);
+              }
+              hold = 0;
+              bits = 0;
+              state.mode = OS;
+            /* falls through */
+            case OS:
+              while (bits < 16) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              if (state.head) {
+                state.head.xflags = hold & 255;
+                state.head.os = hold >> 8;
+              }
+              if (state.flags & 512) {
+                hbuf[0] = hold & 255;
+                hbuf[1] = hold >>> 8 & 255;
+                state.check = crc322(state.check, hbuf, 2, 0);
+              }
+              hold = 0;
+              bits = 0;
+              state.mode = EXLEN;
+            /* falls through */
+            case EXLEN:
+              if (state.flags & 1024) {
+                while (bits < 16) {
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                state.length = hold;
+                if (state.head) {
+                  state.head.extra_len = hold;
+                }
+                if (state.flags & 512) {
+                  hbuf[0] = hold & 255;
+                  hbuf[1] = hold >>> 8 & 255;
+                  state.check = crc322(state.check, hbuf, 2, 0);
+                }
+                hold = 0;
+                bits = 0;
+              } else if (state.head) {
+                state.head.extra = null;
+              }
+              state.mode = EXTRA;
+            /* falls through */
+            case EXTRA:
+              if (state.flags & 1024) {
+                copy = state.length;
+                if (copy > have) {
+                  copy = have;
+                }
+                if (copy) {
+                  if (state.head) {
+                    len = state.head.extra_len - state.length;
+                    if (!state.head.extra) {
+                      state.head.extra = new Array(state.head.extra_len);
+                    }
+                    utils.arraySet(
+                      state.head.extra,
+                      input,
+                      next,
+                      // extra field is limited to 65536 bytes
+                      // - no need for additional size check
+                      copy,
+                      /*len + copy > state.head.extra_max - len ? state.head.extra_max : copy,*/
+                      len
+                    );
+                  }
+                  if (state.flags & 512) {
+                    state.check = crc322(state.check, input, copy, next);
+                  }
+                  have -= copy;
+                  next += copy;
+                  state.length -= copy;
+                }
+                if (state.length) {
+                  break inf_leave;
+                }
+              }
+              state.length = 0;
+              state.mode = NAME;
+            /* falls through */
+            case NAME:
+              if (state.flags & 2048) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                copy = 0;
+                do {
+                  len = input[next + copy++];
+                  if (state.head && len && state.length < 65536) {
+                    state.head.name += String.fromCharCode(len);
+                  }
+                } while (len && copy < have);
+                if (state.flags & 512) {
+                  state.check = crc322(state.check, input, copy, next);
+                }
+                have -= copy;
+                next += copy;
+                if (len) {
+                  break inf_leave;
+                }
+              } else if (state.head) {
+                state.head.name = null;
+              }
+              state.length = 0;
+              state.mode = COMMENT;
+            /* falls through */
+            case COMMENT:
+              if (state.flags & 4096) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                copy = 0;
+                do {
+                  len = input[next + copy++];
+                  if (state.head && len && state.length < 65536) {
+                    state.head.comment += String.fromCharCode(len);
+                  }
+                } while (len && copy < have);
+                if (state.flags & 512) {
+                  state.check = crc322(state.check, input, copy, next);
+                }
+                have -= copy;
+                next += copy;
+                if (len) {
+                  break inf_leave;
+                }
+              } else if (state.head) {
+                state.head.comment = null;
+              }
+              state.mode = HCRC;
+            /* falls through */
+            case HCRC:
+              if (state.flags & 512) {
+                while (bits < 16) {
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                if (hold !== (state.check & 65535)) {
+                  strm.msg = "header crc mismatch";
+                  state.mode = BAD;
+                  break;
+                }
+                hold = 0;
+                bits = 0;
+              }
+              if (state.head) {
+                state.head.hcrc = state.flags >> 9 & 1;
+                state.head.done = true;
+              }
+              strm.adler = state.check = 0;
+              state.mode = TYPE;
+              break;
+            case DICTID:
+              while (bits < 32) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              strm.adler = state.check = zswap32(hold);
+              hold = 0;
+              bits = 0;
+              state.mode = DICT;
+            /* falls through */
+            case DICT:
+              if (state.havedict === 0) {
+                strm.next_out = put;
+                strm.avail_out = left;
+                strm.next_in = next;
+                strm.avail_in = have;
+                state.hold = hold;
+                state.bits = bits;
+                return Z_NEED_DICT;
+              }
+              strm.adler = state.check = 1;
+              state.mode = TYPE;
+            /* falls through */
+            case TYPE:
+              if (flush === Z_BLOCK || flush === Z_TREES) {
+                break inf_leave;
+              }
+            /* falls through */
+            case TYPEDO:
+              if (state.last) {
+                hold >>>= bits & 7;
+                bits -= bits & 7;
+                state.mode = CHECK;
+                break;
+              }
+              while (bits < 3) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              state.last = hold & 1;
+              hold >>>= 1;
+              bits -= 1;
+              switch (hold & 3) {
+                case 0:
+                  state.mode = STORED;
+                  break;
+                case 1:
+                  fixedtables(state);
+                  state.mode = LEN_;
+                  if (flush === Z_TREES) {
+                    hold >>>= 2;
+                    bits -= 2;
+                    break inf_leave;
+                  }
+                  break;
+                case 2:
+                  state.mode = TABLE;
+                  break;
+                case 3:
+                  strm.msg = "invalid block type";
+                  state.mode = BAD;
+              }
+              hold >>>= 2;
+              bits -= 2;
+              break;
+            case STORED:
+              hold >>>= bits & 7;
+              bits -= bits & 7;
+              while (bits < 32) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              if ((hold & 65535) !== (hold >>> 16 ^ 65535)) {
+                strm.msg = "invalid stored block lengths";
+                state.mode = BAD;
+                break;
+              }
+              state.length = hold & 65535;
+              hold = 0;
+              bits = 0;
+              state.mode = COPY_;
+              if (flush === Z_TREES) {
+                break inf_leave;
+              }
+            /* falls through */
+            case COPY_:
+              state.mode = COPY;
+            /* falls through */
+            case COPY:
+              copy = state.length;
+              if (copy) {
+                if (copy > have) {
+                  copy = have;
+                }
+                if (copy > left) {
+                  copy = left;
+                }
+                if (copy === 0) {
+                  break inf_leave;
+                }
+                utils.arraySet(output, input, next, copy, put);
+                have -= copy;
+                next += copy;
+                left -= copy;
+                put += copy;
+                state.length -= copy;
+                break;
+              }
+              state.mode = TYPE;
+              break;
+            case TABLE:
+              while (bits < 14) {
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              state.nlen = (hold & 31) + 257;
+              hold >>>= 5;
+              bits -= 5;
+              state.ndist = (hold & 31) + 1;
+              hold >>>= 5;
+              bits -= 5;
+              state.ncode = (hold & 15) + 4;
+              hold >>>= 4;
+              bits -= 4;
+              if (state.nlen > 286 || state.ndist > 30) {
+                strm.msg = "too many length or distance symbols";
+                state.mode = BAD;
+                break;
+              }
+              state.have = 0;
+              state.mode = LENLENS;
+            /* falls through */
+            case LENLENS:
+              while (state.have < state.ncode) {
+                while (bits < 3) {
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                state.lens[order[state.have++]] = hold & 7;
+                hold >>>= 3;
+                bits -= 3;
+              }
+              while (state.have < 19) {
+                state.lens[order[state.have++]] = 0;
+              }
+              state.lencode = state.lendyn;
+              state.lenbits = 7;
+              opts = { bits: state.lenbits };
+              ret = inflate_table(CODES, state.lens, 0, 19, state.lencode, 0, state.work, opts);
+              state.lenbits = opts.bits;
+              if (ret) {
+                strm.msg = "invalid code lengths set";
+                state.mode = BAD;
+                break;
+              }
+              state.have = 0;
+              state.mode = CODELENS;
+            /* falls through */
+            case CODELENS:
+              while (state.have < state.nlen + state.ndist) {
+                for (; ; ) {
+                  here = state.lencode[hold & (1 << state.lenbits) - 1];
+                  here_bits = here >>> 24;
+                  here_op = here >>> 16 & 255;
+                  here_val = here & 65535;
+                  if (here_bits <= bits) {
+                    break;
+                  }
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                if (here_val < 16) {
+                  hold >>>= here_bits;
+                  bits -= here_bits;
+                  state.lens[state.have++] = here_val;
+                } else {
+                  if (here_val === 16) {
+                    n = here_bits + 2;
+                    while (bits < n) {
+                      if (have === 0) {
+                        break inf_leave;
+                      }
+                      have--;
+                      hold += input[next++] << bits;
+                      bits += 8;
+                    }
+                    hold >>>= here_bits;
+                    bits -= here_bits;
+                    if (state.have === 0) {
+                      strm.msg = "invalid bit length repeat";
+                      state.mode = BAD;
+                      break;
+                    }
+                    len = state.lens[state.have - 1];
+                    copy = 3 + (hold & 3);
+                    hold >>>= 2;
+                    bits -= 2;
+                  } else if (here_val === 17) {
+                    n = here_bits + 3;
+                    while (bits < n) {
+                      if (have === 0) {
+                        break inf_leave;
+                      }
+                      have--;
+                      hold += input[next++] << bits;
+                      bits += 8;
+                    }
+                    hold >>>= here_bits;
+                    bits -= here_bits;
+                    len = 0;
+                    copy = 3 + (hold & 7);
+                    hold >>>= 3;
+                    bits -= 3;
+                  } else {
+                    n = here_bits + 7;
+                    while (bits < n) {
+                      if (have === 0) {
+                        break inf_leave;
+                      }
+                      have--;
+                      hold += input[next++] << bits;
+                      bits += 8;
+                    }
+                    hold >>>= here_bits;
+                    bits -= here_bits;
+                    len = 0;
+                    copy = 11 + (hold & 127);
+                    hold >>>= 7;
+                    bits -= 7;
+                  }
+                  if (state.have + copy > state.nlen + state.ndist) {
+                    strm.msg = "invalid bit length repeat";
+                    state.mode = BAD;
+                    break;
+                  }
+                  while (copy--) {
+                    state.lens[state.have++] = len;
+                  }
+                }
+              }
+              if (state.mode === BAD) {
+                break;
+              }
+              if (state.lens[256] === 0) {
+                strm.msg = "invalid code -- missing end-of-block";
+                state.mode = BAD;
+                break;
+              }
+              state.lenbits = 9;
+              opts = { bits: state.lenbits };
+              ret = inflate_table(LENS, state.lens, 0, state.nlen, state.lencode, 0, state.work, opts);
+              state.lenbits = opts.bits;
+              if (ret) {
+                strm.msg = "invalid literal/lengths set";
+                state.mode = BAD;
+                break;
+              }
+              state.distbits = 6;
+              state.distcode = state.distdyn;
+              opts = { bits: state.distbits };
+              ret = inflate_table(DISTS, state.lens, state.nlen, state.ndist, state.distcode, 0, state.work, opts);
+              state.distbits = opts.bits;
+              if (ret) {
+                strm.msg = "invalid distances set";
+                state.mode = BAD;
+                break;
+              }
+              state.mode = LEN_;
+              if (flush === Z_TREES) {
+                break inf_leave;
+              }
+            /* falls through */
+            case LEN_:
+              state.mode = LEN;
+            /* falls through */
+            case LEN:
+              if (have >= 6 && left >= 258) {
+                strm.next_out = put;
+                strm.avail_out = left;
+                strm.next_in = next;
+                strm.avail_in = have;
+                state.hold = hold;
+                state.bits = bits;
+                inflate_fast(strm, _out);
+                put = strm.next_out;
+                output = strm.output;
+                left = strm.avail_out;
+                next = strm.next_in;
+                input = strm.input;
+                have = strm.avail_in;
+                hold = state.hold;
+                bits = state.bits;
+                if (state.mode === TYPE) {
+                  state.back = -1;
+                }
+                break;
+              }
+              state.back = 0;
+              for (; ; ) {
+                here = state.lencode[hold & (1 << state.lenbits) - 1];
+                here_bits = here >>> 24;
+                here_op = here >>> 16 & 255;
+                here_val = here & 65535;
+                if (here_bits <= bits) {
+                  break;
+                }
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              if (here_op && (here_op & 240) === 0) {
+                last_bits = here_bits;
+                last_op = here_op;
+                last_val = here_val;
+                for (; ; ) {
+                  here = state.lencode[last_val + ((hold & (1 << last_bits + last_op) - 1) >> last_bits)];
+                  here_bits = here >>> 24;
+                  here_op = here >>> 16 & 255;
+                  here_val = here & 65535;
+                  if (last_bits + here_bits <= bits) {
+                    break;
+                  }
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                hold >>>= last_bits;
+                bits -= last_bits;
+                state.back += last_bits;
+              }
+              hold >>>= here_bits;
+              bits -= here_bits;
+              state.back += here_bits;
+              state.length = here_val;
+              if (here_op === 0) {
+                state.mode = LIT;
+                break;
+              }
+              if (here_op & 32) {
+                state.back = -1;
+                state.mode = TYPE;
+                break;
+              }
+              if (here_op & 64) {
+                strm.msg = "invalid literal/length code";
+                state.mode = BAD;
+                break;
+              }
+              state.extra = here_op & 15;
+              state.mode = LENEXT;
+            /* falls through */
+            case LENEXT:
+              if (state.extra) {
+                n = state.extra;
+                while (bits < n) {
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                state.length += hold & (1 << state.extra) - 1;
+                hold >>>= state.extra;
+                bits -= state.extra;
+                state.back += state.extra;
+              }
+              state.was = state.length;
+              state.mode = DIST;
+            /* falls through */
+            case DIST:
+              for (; ; ) {
+                here = state.distcode[hold & (1 << state.distbits) - 1];
+                here_bits = here >>> 24;
+                here_op = here >>> 16 & 255;
+                here_val = here & 65535;
+                if (here_bits <= bits) {
+                  break;
+                }
+                if (have === 0) {
+                  break inf_leave;
+                }
+                have--;
+                hold += input[next++] << bits;
+                bits += 8;
+              }
+              if ((here_op & 240) === 0) {
+                last_bits = here_bits;
+                last_op = here_op;
+                last_val = here_val;
+                for (; ; ) {
+                  here = state.distcode[last_val + ((hold & (1 << last_bits + last_op) - 1) >> last_bits)];
+                  here_bits = here >>> 24;
+                  here_op = here >>> 16 & 255;
+                  here_val = here & 65535;
+                  if (last_bits + here_bits <= bits) {
+                    break;
+                  }
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                hold >>>= last_bits;
+                bits -= last_bits;
+                state.back += last_bits;
+              }
+              hold >>>= here_bits;
+              bits -= here_bits;
+              state.back += here_bits;
+              if (here_op & 64) {
+                strm.msg = "invalid distance code";
+                state.mode = BAD;
+                break;
+              }
+              state.offset = here_val;
+              state.extra = here_op & 15;
+              state.mode = DISTEXT;
+            /* falls through */
+            case DISTEXT:
+              if (state.extra) {
+                n = state.extra;
+                while (bits < n) {
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                state.offset += hold & (1 << state.extra) - 1;
+                hold >>>= state.extra;
+                bits -= state.extra;
+                state.back += state.extra;
+              }
+              if (state.offset > state.dmax) {
+                strm.msg = "invalid distance too far back";
+                state.mode = BAD;
+                break;
+              }
+              state.mode = MATCH;
+            /* falls through */
+            case MATCH:
+              if (left === 0) {
+                break inf_leave;
+              }
+              copy = _out - left;
+              if (state.offset > copy) {
+                copy = state.offset - copy;
+                if (copy > state.whave) {
+                  if (state.sane) {
+                    strm.msg = "invalid distance too far back";
+                    state.mode = BAD;
+                    break;
+                  }
+                }
+                if (copy > state.wnext) {
+                  copy -= state.wnext;
+                  from = state.wsize - copy;
+                } else {
+                  from = state.wnext - copy;
+                }
+                if (copy > state.length) {
+                  copy = state.length;
+                }
+                from_source = state.window;
+              } else {
+                from_source = output;
+                from = put - state.offset;
+                copy = state.length;
+              }
+              if (copy > left) {
+                copy = left;
+              }
+              left -= copy;
+              state.length -= copy;
+              do {
+                output[put++] = from_source[from++];
+              } while (--copy);
+              if (state.length === 0) {
+                state.mode = LEN;
+              }
+              break;
+            case LIT:
+              if (left === 0) {
+                break inf_leave;
+              }
+              output[put++] = state.length;
+              left--;
+              state.mode = LEN;
+              break;
+            case CHECK:
+              if (state.wrap) {
+                while (bits < 32) {
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold |= input[next++] << bits;
+                  bits += 8;
+                }
+                _out -= left;
+                strm.total_out += _out;
+                state.total += _out;
+                if (_out) {
+                  strm.adler = state.check = /*UPDATE(state.check, put - _out, _out);*/
+                  state.flags ? crc322(state.check, output, _out, put - _out) : adler32(state.check, output, _out, put - _out);
+                }
+                _out = left;
+                if ((state.flags ? hold : zswap32(hold)) !== state.check) {
+                  strm.msg = "incorrect data check";
+                  state.mode = BAD;
+                  break;
+                }
+                hold = 0;
+                bits = 0;
+              }
+              state.mode = LENGTH;
+            /* falls through */
+            case LENGTH:
+              if (state.wrap && state.flags) {
+                while (bits < 32) {
+                  if (have === 0) {
+                    break inf_leave;
+                  }
+                  have--;
+                  hold += input[next++] << bits;
+                  bits += 8;
+                }
+                if (hold !== (state.total & 4294967295)) {
+                  strm.msg = "incorrect length check";
+                  state.mode = BAD;
+                  break;
+                }
+                hold = 0;
+                bits = 0;
+              }
+              state.mode = DONE;
+            /* falls through */
+            case DONE:
+              ret = Z_STREAM_END;
+              break inf_leave;
+            case BAD:
+              ret = Z_DATA_ERROR;
+              break inf_leave;
+            case MEM:
+              return Z_MEM_ERROR;
+            case SYNC:
+            /* falls through */
+            default:
+              return Z_STREAM_ERROR;
+          }
+        }
+      strm.next_out = put;
+      strm.avail_out = left;
+      strm.next_in = next;
+      strm.avail_in = have;
+      state.hold = hold;
+      state.bits = bits;
+      if (state.wsize || _out !== strm.avail_out && state.mode < BAD && (state.mode < CHECK || flush !== Z_FINISH)) {
+        if (updatewindow(strm, strm.output, strm.next_out, _out - strm.avail_out)) {
+          state.mode = MEM;
+          return Z_MEM_ERROR;
+        }
+      }
+      _in -= strm.avail_in;
+      _out -= strm.avail_out;
+      strm.total_in += _in;
+      strm.total_out += _out;
+      state.total += _out;
+      if (state.wrap && _out) {
+        strm.adler = state.check = /*UPDATE(state.check, strm.next_out - _out, _out);*/
+        state.flags ? crc322(state.check, output, _out, strm.next_out - _out) : adler32(state.check, output, _out, strm.next_out - _out);
+      }
+      strm.data_type = state.bits + (state.last ? 64 : 0) + (state.mode === TYPE ? 128 : 0) + (state.mode === LEN_ || state.mode === COPY_ ? 256 : 0);
+      if ((_in === 0 && _out === 0 || flush === Z_FINISH) && ret === Z_OK) {
+        ret = Z_BUF_ERROR;
+      }
+      return ret;
+    }
+    function inflateEnd(strm) {
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      var state = strm.state;
+      if (state.window) {
+        state.window = null;
+      }
+      strm.state = null;
+      return Z_OK;
+    }
+    function inflateGetHeader(strm, head) {
+      var state;
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      state = strm.state;
+      if ((state.wrap & 2) === 0) {
+        return Z_STREAM_ERROR;
+      }
+      state.head = head;
+      head.done = false;
+      return Z_OK;
+    }
+    function inflateSetDictionary(strm, dictionary) {
+      var dictLength = dictionary.length;
+      var state;
+      var dictid;
+      var ret;
+      if (!strm || !strm.state) {
+        return Z_STREAM_ERROR;
+      }
+      state = strm.state;
+      if (state.wrap !== 0 && state.mode !== DICT) {
+        return Z_STREAM_ERROR;
+      }
+      if (state.mode === DICT) {
+        dictid = 1;
+        dictid = adler32(dictid, dictionary, dictLength, 0);
+        if (dictid !== state.check) {
+          return Z_DATA_ERROR;
+        }
+      }
+      ret = updatewindow(strm, dictionary, dictLength, dictLength);
+      if (ret) {
+        state.mode = MEM;
+        return Z_MEM_ERROR;
+      }
+      state.havedict = 1;
+      return Z_OK;
+    }
+    exports.inflateReset = inflateReset;
+    exports.inflateReset2 = inflateReset2;
+    exports.inflateResetKeep = inflateResetKeep;
+    exports.inflateInit = inflateInit;
+    exports.inflateInit2 = inflateInit2;
+    exports.inflate = inflate2;
+    exports.inflateEnd = inflateEnd;
+    exports.inflateGetHeader = inflateGetHeader;
+    exports.inflateSetDictionary = inflateSetDictionary;
+    exports.inflateInfo = "pako inflate (from Nodeca project)";
+  }
+});
+
+// node_modules/pako/lib/zlib/constants.js
+var require_constants = __commonJS({
+  "node_modules/pako/lib/zlib/constants.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    module.exports = {
+      /* Allowed flush values; see deflate() and inflate() below for details */
+      Z_NO_FLUSH: 0,
+      Z_PARTIAL_FLUSH: 1,
+      Z_SYNC_FLUSH: 2,
+      Z_FULL_FLUSH: 3,
+      Z_FINISH: 4,
+      Z_BLOCK: 5,
+      Z_TREES: 6,
+      /* Return codes for the compression/decompression functions. Negative values
+      * are errors, positive values are used for special but normal events.
+      */
+      Z_OK: 0,
+      Z_STREAM_END: 1,
+      Z_NEED_DICT: 2,
+      Z_ERRNO: -1,
+      Z_STREAM_ERROR: -2,
+      Z_DATA_ERROR: -3,
+      //Z_MEM_ERROR:     -4,
+      Z_BUF_ERROR: -5,
+      //Z_VERSION_ERROR: -6,
+      /* compression levels */
+      Z_NO_COMPRESSION: 0,
+      Z_BEST_SPEED: 1,
+      Z_BEST_COMPRESSION: 9,
+      Z_DEFAULT_COMPRESSION: -1,
+      Z_FILTERED: 1,
+      Z_HUFFMAN_ONLY: 2,
+      Z_RLE: 3,
+      Z_FIXED: 4,
+      Z_DEFAULT_STRATEGY: 0,
+      /* Possible values of the data_type field (though see inflate()) */
+      Z_BINARY: 0,
+      Z_TEXT: 1,
+      //Z_ASCII:                1, // = Z_TEXT (deprecated)
+      Z_UNKNOWN: 2,
+      /* The deflate compression method */
+      Z_DEFLATED: 8
+      //Z_NULL:                 null // Use -1 or null inline, depending on var type
+    };
+  }
+});
+
+// node_modules/pako/lib/zlib/gzheader.js
+var require_gzheader = __commonJS({
+  "node_modules/pako/lib/zlib/gzheader.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    function GZheader() {
+      this.text = 0;
+      this.time = 0;
+      this.xflags = 0;
+      this.os = 0;
+      this.extra = null;
+      this.extra_len = 0;
+      this.name = "";
+      this.comment = "";
+      this.hcrc = 0;
+      this.done = false;
+    }
+    module.exports = GZheader;
+  }
+});
+
+// node_modules/pako/lib/inflate.js
+var require_inflate2 = __commonJS({
+  "node_modules/pako/lib/inflate.js"(exports) {
+    "use strict";
+    init_bufinject();
+    var zlib_inflate = require_inflate();
+    var utils = require_common();
+    var strings = require_strings();
+    var c = require_constants();
+    var msg = require_messages();
+    var ZStream = require_zstream();
+    var GZheader = require_gzheader();
+    var toString = Object.prototype.toString;
+    function Inflate(options) {
+      if (!(this instanceof Inflate)) return new Inflate(options);
+      this.options = utils.assign({
+        chunkSize: 16384,
+        windowBits: 0,
+        to: ""
+      }, options || {});
+      var opt = this.options;
+      if (opt.raw && opt.windowBits >= 0 && opt.windowBits < 16) {
+        opt.windowBits = -opt.windowBits;
+        if (opt.windowBits === 0) {
+          opt.windowBits = -15;
+        }
+      }
+      if (opt.windowBits >= 0 && opt.windowBits < 16 && !(options && options.windowBits)) {
+        opt.windowBits += 32;
+      }
+      if (opt.windowBits > 15 && opt.windowBits < 48) {
+        if ((opt.windowBits & 15) === 0) {
+          opt.windowBits |= 15;
+        }
+      }
+      this.err = 0;
+      this.msg = "";
+      this.ended = false;
+      this.chunks = [];
+      this.strm = new ZStream();
+      this.strm.avail_out = 0;
+      var status2 = zlib_inflate.inflateInit2(
+        this.strm,
+        opt.windowBits
+      );
+      if (status2 !== c.Z_OK) {
+        throw new Error(msg[status2]);
+      }
+      this.header = new GZheader();
+      zlib_inflate.inflateGetHeader(this.strm, this.header);
+      if (opt.dictionary) {
+        if (typeof opt.dictionary === "string") {
+          opt.dictionary = strings.string2buf(opt.dictionary);
+        } else if (toString.call(opt.dictionary) === "[object ArrayBuffer]") {
+          opt.dictionary = new Uint8Array(opt.dictionary);
+        }
+        if (opt.raw) {
+          status2 = zlib_inflate.inflateSetDictionary(this.strm, opt.dictionary);
+          if (status2 !== c.Z_OK) {
+            throw new Error(msg[status2]);
+          }
+        }
+      }
+    }
+    Inflate.prototype.push = function(data, mode) {
+      var strm = this.strm;
+      var chunkSize = this.options.chunkSize;
+      var dictionary = this.options.dictionary;
+      var status2, _mode;
+      var next_out_utf8, tail, utf8str;
+      var allowBufError = false;
+      if (this.ended) {
+        return false;
+      }
+      _mode = mode === ~~mode ? mode : mode === true ? c.Z_FINISH : c.Z_NO_FLUSH;
+      if (typeof data === "string") {
+        strm.input = strings.binstring2buf(data);
+      } else if (toString.call(data) === "[object ArrayBuffer]") {
+        strm.input = new Uint8Array(data);
+      } else {
+        strm.input = data;
+      }
+      strm.next_in = 0;
+      strm.avail_in = strm.input.length;
+      do {
+        if (strm.avail_out === 0) {
+          strm.output = new utils.Buf8(chunkSize);
+          strm.next_out = 0;
+          strm.avail_out = chunkSize;
+        }
+        status2 = zlib_inflate.inflate(strm, c.Z_NO_FLUSH);
+        if (status2 === c.Z_NEED_DICT && dictionary) {
+          status2 = zlib_inflate.inflateSetDictionary(this.strm, dictionary);
+        }
+        if (status2 === c.Z_BUF_ERROR && allowBufError === true) {
+          status2 = c.Z_OK;
+          allowBufError = false;
+        }
+        if (status2 !== c.Z_STREAM_END && status2 !== c.Z_OK) {
+          this.onEnd(status2);
+          this.ended = true;
+          return false;
+        }
+        if (strm.next_out) {
+          if (strm.avail_out === 0 || status2 === c.Z_STREAM_END || strm.avail_in === 0 && (_mode === c.Z_FINISH || _mode === c.Z_SYNC_FLUSH)) {
+            if (this.options.to === "string") {
+              next_out_utf8 = strings.utf8border(strm.output, strm.next_out);
+              tail = strm.next_out - next_out_utf8;
+              utf8str = strings.buf2string(strm.output, next_out_utf8);
+              strm.next_out = tail;
+              strm.avail_out = chunkSize - tail;
+              if (tail) {
+                utils.arraySet(strm.output, strm.output, next_out_utf8, tail, 0);
+              }
+              this.onData(utf8str);
+            } else {
+              this.onData(utils.shrinkBuf(strm.output, strm.next_out));
+            }
+          }
+        }
+        if (strm.avail_in === 0 && strm.avail_out === 0) {
+          allowBufError = true;
+        }
+      } while ((strm.avail_in > 0 || strm.avail_out === 0) && status2 !== c.Z_STREAM_END);
+      if (status2 === c.Z_STREAM_END) {
+        _mode = c.Z_FINISH;
+      }
+      if (_mode === c.Z_FINISH) {
+        status2 = zlib_inflate.inflateEnd(this.strm);
+        this.onEnd(status2);
+        this.ended = true;
+        return status2 === c.Z_OK;
+      }
+      if (_mode === c.Z_SYNC_FLUSH) {
+        this.onEnd(c.Z_OK);
+        strm.avail_out = 0;
+        return true;
+      }
+      return true;
+    };
+    Inflate.prototype.onData = function(chunk) {
+      this.chunks.push(chunk);
+    };
+    Inflate.prototype.onEnd = function(status2) {
+      if (status2 === c.Z_OK) {
+        if (this.options.to === "string") {
+          this.result = this.chunks.join("");
+        } else {
+          this.result = utils.flattenChunks(this.chunks);
+        }
+      }
+      this.chunks = [];
+      this.err = status2;
+      this.msg = this.strm.msg;
+    };
+    function inflate2(input, options) {
+      var inflator = new Inflate(options);
+      inflator.push(input, true);
+      if (inflator.err) {
+        throw inflator.msg || msg[inflator.err];
+      }
+      return inflator.result;
+    }
+    function inflateRaw(input, options) {
+      options = options || {};
+      options.raw = true;
+      return inflate2(input, options);
+    }
+    exports.Inflate = Inflate;
+    exports.inflate = inflate2;
+    exports.inflateRaw = inflateRaw;
+    exports.ungzip = inflate2;
+  }
+});
+
+// node_modules/pako/index.js
+var require_pako = __commonJS({
+  "node_modules/pako/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var assign = require_common().assign;
+    var deflate2 = require_deflate2();
+    var inflate2 = require_inflate2();
+    var constants = require_constants();
+    var pako2 = {};
+    assign(pako2, deflate2, inflate2, constants);
+    module.exports = pako2;
+  }
+});
+
+// node_modules/pify/index.js
+var require_pify = __commonJS({
+  "node_modules/pify/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    var processFn = (fn, options) => function(...args) {
+      const P = options.promiseModule;
+      return new P((resolve, reject) => {
+        if (options.multiArgs) {
+          args.push((...result) => {
+            if (options.errorFirst) {
+              if (result[0]) {
+                reject(result);
+              } else {
+                result.shift();
+                resolve(result);
+              }
+            } else {
+              resolve(result);
+            }
+          });
+        } else if (options.errorFirst) {
+          args.push((error, result) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve(result);
+            }
+          });
+        } else {
+          args.push(resolve);
+        }
+        fn.apply(this, args);
+      });
+    };
+    module.exports = (input, options) => {
+      options = Object.assign({
+        exclude: [/.+(Sync|Stream)$/],
+        errorFirst: true,
+        promiseModule: Promise
+      }, options);
+      const objType = typeof input;
+      if (!(input !== null && (objType === "object" || objType === "function"))) {
+        throw new TypeError(`Expected \`input\` to be a \`Function\` or \`Object\`, got \`${input === null ? "null" : objType}\``);
+      }
+      const filter = (key) => {
+        const match = (pattern) => typeof pattern === "string" ? key === pattern : pattern.test(key);
+        return options.include ? options.include.some(match) : !options.exclude.some(match);
+      };
+      let ret;
+      if (objType === "function") {
+        ret = function(...args) {
+          return options.excludeMain ? input(...args) : processFn(input, options).apply(this, args);
+        };
+      } else {
+        ret = Object.create(Object.getPrototypeOf(input));
+      }
+      for (const key in input) {
+        const property = input[key];
+        ret[key] = typeof property === "function" && filter(key) ? processFn(property, options) : property;
+      }
+      return ret;
+    };
+  }
+});
+
+// node_modules/ignore/index.js
+var require_ignore = __commonJS({
+  "node_modules/ignore/index.js"(exports, module) {
+    init_bufinject();
+    function makeArray(subject) {
+      return Array.isArray(subject) ? subject : [subject];
+    }
+    var EMPTY = "";
+    var SPACE = " ";
+    var ESCAPE = "\\";
+    var REGEX_TEST_BLANK_LINE = /^\s+$/;
+    var REGEX_INVALID_TRAILING_BACKSLASH = /(?:[^\\]|^)\\$/;
+    var REGEX_REPLACE_LEADING_EXCAPED_EXCLAMATION = /^\\!/;
+    var REGEX_REPLACE_LEADING_EXCAPED_HASH = /^\\#/;
+    var REGEX_SPLITALL_CRLF = /\r?\n/g;
+    var REGEX_TEST_INVALID_PATH = /^\.*\/|^\.+$/;
+    var SLASH = "/";
+    var TMP_KEY_IGNORE = "node-ignore";
+    if (typeof Symbol !== "undefined") {
+      TMP_KEY_IGNORE = /* @__PURE__ */ Symbol.for("node-ignore");
+    }
+    var KEY_IGNORE = TMP_KEY_IGNORE;
+    var define2 = (object, key, value) => Object.defineProperty(object, key, { value });
+    var REGEX_REGEXP_RANGE = /([0-z])-([0-z])/g;
+    var RETURN_FALSE = () => false;
+    var sanitizeRange = (range) => range.replace(
+      REGEX_REGEXP_RANGE,
+      (match, from, to) => from.charCodeAt(0) <= to.charCodeAt(0) ? match : EMPTY
+    );
+    var cleanRangeBackSlash = (slashes) => {
+      const { length } = slashes;
+      return slashes.slice(0, length - length % 2);
+    };
+    var REPLACERS = [
+      [
+        // remove BOM
+        // TODO:
+        // Other similar zero-width characters?
+        /^\uFEFF/,
+        () => EMPTY
+      ],
+      // > Trailing spaces are ignored unless they are quoted with backslash ("\")
+      [
+        // (a\ ) -> (a )
+        // (a  ) -> (a)
+        // (a ) -> (a)
+        // (a \ ) -> (a  )
+        /((?:\\\\)*?)(\\?\s+)$/,
+        (_, m1, m2) => m1 + (m2.indexOf("\\") === 0 ? SPACE : EMPTY)
+      ],
+      // replace (\ ) with ' '
+      // (\ ) -> ' '
+      // (\\ ) -> '\\ '
+      // (\\\ ) -> '\\ '
+      [
+        /(\\+?)\s/g,
+        (_, m1) => {
+          const { length } = m1;
+          return m1.slice(0, length - length % 2) + SPACE;
+        }
+      ],
+      // Escape metacharacters
+      // which is written down by users but means special for regular expressions.
+      // > There are 12 characters with special meanings:
+      // > - the backslash \,
+      // > - the caret ^,
+      // > - the dollar sign $,
+      // > - the period or dot .,
+      // > - the vertical bar or pipe symbol |,
+      // > - the question mark ?,
+      // > - the asterisk or star *,
+      // > - the plus sign +,
+      // > - the opening parenthesis (,
+      // > - the closing parenthesis ),
+      // > - and the opening square bracket [,
+      // > - the opening curly brace {,
+      // > These special characters are often called "metacharacters".
+      [
+        /[\\$.|*+(){^]/g,
+        (match) => `\\${match}`
+      ],
+      [
+        // > a question mark (?) matches a single character
+        /(?!\\)\?/g,
+        () => "[^/]"
+      ],
+      // leading slash
+      [
+        // > A leading slash matches the beginning of the pathname.
+        // > For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
+        // A leading slash matches the beginning of the pathname
+        /^\//,
+        () => "^"
+      ],
+      // replace special metacharacter slash after the leading slash
+      [
+        /\//g,
+        () => "\\/"
+      ],
+      [
+        // > A leading "**" followed by a slash means match in all directories.
+        // > For example, "**/foo" matches file or directory "foo" anywhere,
+        // > the same as pattern "foo".
+        // > "**/foo/bar" matches file or directory "bar" anywhere that is directly
+        // >   under directory "foo".
+        // Notice that the '*'s have been replaced as '\\*'
+        /^\^*\\\*\\\*\\\//,
+        // '**/foo' <-> 'foo'
+        () => "^(?:.*\\/)?"
+      ],
+      // starting
+      [
+        // there will be no leading '/'
+        //   (which has been replaced by section "leading slash")
+        // If starts with '**', adding a '^' to the regular expression also works
+        /^(?=[^^])/,
+        function startingReplacer() {
+          return !/\/(?!$)/.test(this) ? "(?:^|\\/)" : "^";
+        }
+      ],
+      // two globstars
+      [
+        // Use lookahead assertions so that we could match more than one `'/**'`
+        /\\\/\\\*\\\*(?=\\\/|$)/g,
+        // Zero, one or several directories
+        // should not use '*', or it will be replaced by the next replacer
+        // Check if it is not the last `'/**'`
+        (_, index3, str) => index3 + 6 < str.length ? "(?:\\/[^\\/]+)*" : "\\/.+"
+      ],
+      // normal intermediate wildcards
+      [
+        // Never replace escaped '*'
+        // ignore rule '\*' will match the path '*'
+        // 'abc.*/' -> go
+        // 'abc.*'  -> skip this rule,
+        //    coz trailing single wildcard will be handed by [trailing wildcard]
+        /(^|[^\\]+)(\\\*)+(?=.+)/g,
+        // '*.js' matches '.js'
+        // '*.js' doesn't match 'abc'
+        (_, p1, p2) => {
+          const unescaped = p2.replace(/\\\*/g, "[^\\/]*");
+          return p1 + unescaped;
+        }
+      ],
+      [
+        // unescape, revert step 3 except for back slash
+        // For example, if a user escape a '\\*',
+        // after step 3, the result will be '\\\\\\*'
+        /\\\\\\(?=[$.|*+(){^])/g,
+        () => ESCAPE
+      ],
+      [
+        // '\\\\' -> '\\'
+        /\\\\/g,
+        () => ESCAPE
+      ],
+      [
+        // > The range notation, e.g. [a-zA-Z],
+        // > can be used to match one of the characters in a range.
+        // `\` is escaped by step 3
+        /(\\)?\[([^\]/]*?)(\\*)($|\])/g,
+        (match, leadEscape, range, endEscape, close) => leadEscape === ESCAPE ? `\\[${range}${cleanRangeBackSlash(endEscape)}${close}` : close === "]" ? endEscape.length % 2 === 0 ? `[${sanitizeRange(range)}${endEscape}]` : "[]" : "[]"
+      ],
+      // ending
+      [
+        // 'js' will not match 'js.'
+        // 'ab' will not match 'abc'
+        /(?:[^*])$/,
+        // WTF!
+        // https://git-scm.com/docs/gitignore
+        // changes in [2.22.1](https://git-scm.com/docs/gitignore/2.22.1)
+        // which re-fixes #24, #38
+        // > If there is a separator at the end of the pattern then the pattern
+        // > will only match directories, otherwise the pattern can match both
+        // > files and directories.
+        // 'js*' will not match 'a.js'
+        // 'js/' will not match 'a.js'
+        // 'js' will match 'a.js' and 'a.js/'
+        (match) => /\/$/.test(match) ? `${match}$` : `${match}(?=$|\\/$)`
+      ],
+      // trailing wildcard
+      [
+        /(\^|\\\/)?\\\*$/,
+        (_, p1) => {
+          const prefix = p1 ? `${p1}[^/]+` : "[^/]*";
+          return `${prefix}(?=$|\\/$)`;
+        }
+      ]
+    ];
+    var regexCache = /* @__PURE__ */ Object.create(null);
+    var makeRegex = (pattern, ignoreCase) => {
+      let source = regexCache[pattern];
+      if (!source) {
+        source = REPLACERS.reduce(
+          (prev, [matcher, replacer]) => prev.replace(matcher, replacer.bind(pattern)),
+          pattern
+        );
+        regexCache[pattern] = source;
+      }
+      return ignoreCase ? new RegExp(source, "i") : new RegExp(source);
+    };
+    var isString = (subject) => typeof subject === "string";
+    var checkPattern = (pattern) => pattern && isString(pattern) && !REGEX_TEST_BLANK_LINE.test(pattern) && !REGEX_INVALID_TRAILING_BACKSLASH.test(pattern) && pattern.indexOf("#") !== 0;
+    var splitPattern = (pattern) => pattern.split(REGEX_SPLITALL_CRLF);
+    var IgnoreRule = class {
+      constructor(origin, pattern, negative, regex) {
+        this.origin = origin;
+        this.pattern = pattern;
+        this.negative = negative;
+        this.regex = regex;
+      }
+    };
+    var createRule = (pattern, ignoreCase) => {
+      const origin = pattern;
+      let negative = false;
+      if (pattern.indexOf("!") === 0) {
+        negative = true;
+        pattern = pattern.substr(1);
+      }
+      pattern = pattern.replace(REGEX_REPLACE_LEADING_EXCAPED_EXCLAMATION, "!").replace(REGEX_REPLACE_LEADING_EXCAPED_HASH, "#");
+      const regex = makeRegex(pattern, ignoreCase);
+      return new IgnoreRule(
+        origin,
+        pattern,
+        negative,
+        regex
+      );
+    };
+    var throwError = (message, Ctor) => {
+      throw new Ctor(message);
+    };
+    var checkPath = (path, originalPath, doThrow) => {
+      if (!isString(path)) {
+        return doThrow(
+          `path must be a string, but got \`${originalPath}\``,
+          TypeError
+        );
+      }
+      if (!path) {
+        return doThrow(`path must not be empty`, TypeError);
+      }
+      if (checkPath.isNotRelative(path)) {
+        const r = "`path.relative()`d";
+        return doThrow(
+          `path should be a ${r} string, but got "${originalPath}"`,
+          RangeError
+        );
+      }
+      return true;
+    };
+    var isNotRelative = (path) => REGEX_TEST_INVALID_PATH.test(path);
+    checkPath.isNotRelative = isNotRelative;
+    checkPath.convert = (p) => p;
+    var Ignore = class {
+      constructor({
+        ignorecase = true,
+        ignoreCase = ignorecase,
+        allowRelativePaths = false
+      } = {}) {
+        define2(this, KEY_IGNORE, true);
+        this._rules = [];
+        this._ignoreCase = ignoreCase;
+        this._allowRelativePaths = allowRelativePaths;
+        this._initCache();
+      }
+      _initCache() {
+        this._ignoreCache = /* @__PURE__ */ Object.create(null);
+        this._testCache = /* @__PURE__ */ Object.create(null);
+      }
+      _addPattern(pattern) {
+        if (pattern && pattern[KEY_IGNORE]) {
+          this._rules = this._rules.concat(pattern._rules);
+          this._added = true;
+          return;
+        }
+        if (checkPattern(pattern)) {
+          const rule = createRule(pattern, this._ignoreCase);
+          this._added = true;
+          this._rules.push(rule);
+        }
+      }
+      // @param {Array<string> | string | Ignore} pattern
+      add(pattern) {
+        this._added = false;
+        makeArray(
+          isString(pattern) ? splitPattern(pattern) : pattern
+        ).forEach(this._addPattern, this);
+        if (this._added) {
+          this._initCache();
+        }
+        return this;
+      }
+      // legacy
+      addPattern(pattern) {
+        return this.add(pattern);
+      }
+      //          |           ignored : unignored
+      // negative |   0:0   |   0:1   |   1:0   |   1:1
+      // -------- | ------- | ------- | ------- | --------
+      //     0    |  TEST   |  TEST   |  SKIP   |    X
+      //     1    |  TESTIF |  SKIP   |  TEST   |    X
+      // - SKIP: always skip
+      // - TEST: always test
+      // - TESTIF: only test if checkUnignored
+      // - X: that never happen
+      // @param {boolean} whether should check if the path is unignored,
+      //   setting `checkUnignored` to `false` could reduce additional
+      //   path matching.
+      // @returns {TestResult} true if a file is ignored
+      _testOne(path, checkUnignored) {
+        let ignored = false;
+        let unignored = false;
+        this._rules.forEach((rule) => {
+          const { negative } = rule;
+          if (unignored === negative && ignored !== unignored || negative && !ignored && !unignored && !checkUnignored) {
+            return;
+          }
+          const matched = rule.regex.test(path);
+          if (matched) {
+            ignored = !negative;
+            unignored = negative;
+          }
+        });
+        return {
+          ignored,
+          unignored
+        };
+      }
+      // @returns {TestResult}
+      _test(originalPath, cache, checkUnignored, slices) {
+        const path = originalPath && checkPath.convert(originalPath);
+        checkPath(
+          path,
+          originalPath,
+          this._allowRelativePaths ? RETURN_FALSE : throwError
+        );
+        return this._t(path, cache, checkUnignored, slices);
+      }
+      _t(path, cache, checkUnignored, slices) {
+        if (path in cache) {
+          return cache[path];
+        }
+        if (!slices) {
+          slices = path.split(SLASH);
+        }
+        slices.pop();
+        if (!slices.length) {
+          return cache[path] = this._testOne(path, checkUnignored);
+        }
+        const parent = this._t(
+          slices.join(SLASH) + SLASH,
+          cache,
+          checkUnignored,
+          slices
+        );
+        return cache[path] = parent.ignored ? parent : this._testOne(path, checkUnignored);
+      }
+      ignores(path) {
+        return this._test(path, this._ignoreCache, false).ignored;
+      }
+      createFilter() {
+        return (path) => !this.ignores(path);
+      }
+      filter(paths) {
+        return makeArray(paths).filter(this.createFilter());
+      }
+      // @returns {TestResult}
+      test(path) {
+        return this._test(path, this._testCache, true);
+      }
+    };
+    var factory = (options) => new Ignore(options);
+    var isPathValid = (path) => checkPath(path && checkPath.convert(path), path, RETURN_FALSE);
+    factory.isPathValid = isPathValid;
+    factory.default = factory;
+    module.exports = factory;
+    if (
+      // Detect `process` so that it can run in browsers.
+      typeof process !== "undefined" && (process.env && process.env.IGNORE_TEST_WIN32 || process.platform === "win32")
+    ) {
+      const makePosix = (str) => /^\\\\\?\\/.test(str) || /["<>|\u0000-\u001F]+/u.test(str) ? str : str.replace(/\\/g, "/");
+      checkPath.convert = makePosix;
+      const REGIX_IS_WINDOWS_PATH_ABSOLUTE = /^[a-z]:\//i;
+      checkPath.isNotRelative = (path) => REGIX_IS_WINDOWS_PATH_ABSOLUTE.test(path) || isNotRelative(path);
+    }
+  }
+});
+
+// node_modules/clean-git-ref/lib/index.js
+var require_lib2 = __commonJS({
+  "node_modules/clean-git-ref/lib/index.js"(exports, module) {
+    "use strict";
+    init_bufinject();
+    function escapeRegExp(string) {
+      return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+    function replaceAll(str, search, replacement) {
+      search = search instanceof RegExp ? search : new RegExp(escapeRegExp(search), "g");
+      return str.replace(search, replacement);
+    }
+    var CleanGitRef = {
+      clean: function clean(value) {
+        if (typeof value !== "string") {
+          throw new Error("Expected a string, received: " + value);
+        }
+        value = replaceAll(value, "./", "/");
+        value = replaceAll(value, "..", ".");
+        value = replaceAll(value, " ", "-");
+        value = replaceAll(value, /^[~^:?*\\\-]/g, "");
+        value = replaceAll(value, /[~^:?*\\]/g, "-");
+        value = replaceAll(value, /[~^:?*\\\-]$/g, "");
+        value = replaceAll(value, "@{", "-");
+        value = replaceAll(value, /\.$/g, "");
+        value = replaceAll(value, /\/$/g, "");
+        value = replaceAll(value, /\.lock$/g, "");
+        return value;
+      }
+    };
+    module.exports = CleanGitRef;
+  }
+});
+
+// node_modules/diff3/onp.js
+var require_onp = __commonJS({
+  "node_modules/diff3/onp.js"(exports, module) {
+    init_bufinject();
+    module.exports = function(a_, b_) {
+      var a = a_, b = b_, m = a.length, n = b.length, reverse = false, ed = null, offset = m + 1, path = [], pathposi = [], ses = [], lcs = "", SES_DELETE = -1, SES_COMMON = 0, SES_ADD = 1;
+      var tmp1, tmp2;
+      var init2 = function() {
+        if (m >= n) {
+          tmp1 = a;
+          tmp2 = m;
+          a = b;
+          b = tmp1;
+          m = n;
+          n = tmp2;
+          reverse = true;
+          offset = m + 1;
+        }
+      };
+      var P = function(x, y, k) {
+        return {
+          "x": x,
+          "y": y,
+          "k": k
+        };
+      };
+      var seselem = function(elem, t) {
+        return {
+          "elem": elem,
+          "t": t
+        };
+      };
+      var snake = function(k, p, pp) {
+        var r, x, y;
+        if (p > pp) {
+          r = path[k - 1 + offset];
+        } else {
+          r = path[k + 1 + offset];
+        }
+        y = Math.max(p, pp);
+        x = y - k;
+        while (x < m && y < n && a[x] === b[y]) {
+          ++x;
+          ++y;
+        }
+        path[k + offset] = pathposi.length;
+        pathposi[pathposi.length] = new P(x, y, r);
+        return y;
+      };
+      var recordseq = function(epc) {
+        var x_idx, y_idx, px_idx, py_idx, i;
+        x_idx = y_idx = 1;
+        px_idx = py_idx = 0;
+        for (i = epc.length - 1; i >= 0; --i) {
+          while (px_idx < epc[i].x || py_idx < epc[i].y) {
+            if (epc[i].y - epc[i].x > py_idx - px_idx) {
+              if (reverse) {
+                ses[ses.length] = new seselem(b[py_idx], SES_DELETE);
+              } else {
+                ses[ses.length] = new seselem(b[py_idx], SES_ADD);
+              }
+              ++y_idx;
+              ++py_idx;
+            } else if (epc[i].y - epc[i].x < py_idx - px_idx) {
+              if (reverse) {
+                ses[ses.length] = new seselem(a[px_idx], SES_ADD);
+              } else {
+                ses[ses.length] = new seselem(a[px_idx], SES_DELETE);
+              }
+              ++x_idx;
+              ++px_idx;
+            } else {
+              ses[ses.length] = new seselem(a[px_idx], SES_COMMON);
+              lcs += a[px_idx];
+              ++x_idx;
+              ++y_idx;
+              ++px_idx;
+              ++py_idx;
+            }
+          }
+        }
+      };
+      init2();
+      return {
+        SES_DELETE: -1,
+        SES_COMMON: 0,
+        SES_ADD: 1,
+        editdistance: function() {
+          return ed;
+        },
+        getlcs: function() {
+          return lcs;
+        },
+        getses: function() {
+          return ses;
+        },
+        compose: function() {
+          var delta, size, fp, p, r, epc, i, k;
+          delta = n - m;
+          size = m + n + 3;
+          fp = {};
+          for (i = 0; i < size; ++i) {
+            fp[i] = -1;
+            path[i] = -1;
+          }
+          p = -1;
+          do {
+            ++p;
+            for (k = -p; k <= delta - 1; ++k) {
+              fp[k + offset] = snake(k, fp[k - 1 + offset] + 1, fp[k + 1 + offset]);
+            }
+            for (k = delta + p; k >= delta + 1; --k) {
+              fp[k + offset] = snake(k, fp[k - 1 + offset] + 1, fp[k + 1 + offset]);
+            }
+            fp[delta + offset] = snake(delta, fp[delta - 1 + offset] + 1, fp[delta + 1 + offset]);
+          } while (fp[delta + offset] !== n);
+          ed = delta + 2 * p;
+          r = path[delta + offset];
+          epc = [];
+          while (r !== -1) {
+            epc[epc.length] = new P(pathposi[r].x, pathposi[r].y, null);
+            r = pathposi[r].k;
+          }
+          recordseq(epc);
+        }
+      };
+    };
+  }
+});
+
+// node_modules/diff3/diff3.js
+var require_diff3 = __commonJS({
+  "node_modules/diff3/diff3.js"(exports, module) {
+    init_bufinject();
+    var onp = require_onp();
+    function longestCommonSubsequence(file1, file2) {
+      var diff = new onp(file1, file2);
+      diff.compose();
+      var ses = diff.getses();
+      var root;
+      var prev;
+      var file1RevIdx = file1.length - 1, file2RevIdx = file2.length - 1;
+      for (var i = ses.length - 1; i >= 0; --i) {
+        if (ses[i].t === diff.SES_COMMON) {
+          if (prev) {
+            prev.chain = {
+              file1index: file1RevIdx,
+              file2index: file2RevIdx,
+              chain: null
+            };
+            prev = prev.chain;
+          } else {
+            root = {
+              file1index: file1RevIdx,
+              file2index: file2RevIdx,
+              chain: null
+            };
+            prev = root;
+          }
+          file1RevIdx--;
+          file2RevIdx--;
+        } else if (ses[i].t === diff.SES_DELETE) {
+          file1RevIdx--;
+        } else if (ses[i].t === diff.SES_ADD) {
+          file2RevIdx--;
+        }
+      }
+      var tail = {
+        file1index: -1,
+        file2index: -1,
+        chain: null
+      };
+      if (!prev) {
+        return tail;
+      }
+      prev.chain = tail;
+      return root;
+    }
+    function diffIndices(file1, file2) {
+      var result = [];
+      var tail1 = file1.length;
+      var tail2 = file2.length;
+      for (var candidate = longestCommonSubsequence(file1, file2); candidate !== null; candidate = candidate.chain) {
+        var mismatchLength1 = tail1 - candidate.file1index - 1;
+        var mismatchLength2 = tail2 - candidate.file2index - 1;
+        tail1 = candidate.file1index;
+        tail2 = candidate.file2index;
+        if (mismatchLength1 || mismatchLength2) {
+          result.push({
+            file1: [tail1 + 1, mismatchLength1],
+            file2: [tail2 + 1, mismatchLength2]
+          });
+        }
+      }
+      result.reverse();
+      return result;
+    }
+    function diff3MergeIndices(a, o, b) {
+      var i;
+      var m1 = diffIndices(o, a);
+      var m2 = diffIndices(o, b);
+      var hunks = [];
+      function addHunk(h, side2) {
+        hunks.push([h.file1[0], side2, h.file1[1], h.file2[0], h.file2[1]]);
+      }
+      for (i = 0; i < m1.length; i++) {
+        addHunk(m1[i], 0);
+      }
+      for (i = 0; i < m2.length; i++) {
+        addHunk(m2[i], 2);
+      }
+      hunks.sort(function(x, y) {
+        return x[0] - y[0];
+      });
+      var result = [];
+      var commonOffset = 0;
+      function copyCommon(targetOffset) {
+        if (targetOffset > commonOffset) {
+          result.push([1, commonOffset, targetOffset - commonOffset]);
+          commonOffset = targetOffset;
+        }
+      }
+      for (var hunkIndex = 0; hunkIndex < hunks.length; hunkIndex++) {
+        var firstHunkIndex = hunkIndex;
+        var hunk = hunks[hunkIndex];
+        var regionLhs = hunk[0];
+        var regionRhs = regionLhs + hunk[2];
+        while (hunkIndex < hunks.length - 1) {
+          var maybeOverlapping = hunks[hunkIndex + 1];
+          var maybeLhs = maybeOverlapping[0];
+          if (maybeLhs > regionRhs) break;
+          regionRhs = Math.max(regionRhs, maybeLhs + maybeOverlapping[2]);
+          hunkIndex++;
+        }
+        copyCommon(regionLhs);
+        if (firstHunkIndex == hunkIndex) {
+          if (hunk[4] > 0) {
+            result.push([hunk[1], hunk[3], hunk[4]]);
+          }
+        } else {
+          var regions = {
+            0: [a.length, -1, o.length, -1],
+            2: [b.length, -1, o.length, -1]
+          };
+          for (i = firstHunkIndex; i <= hunkIndex; i++) {
+            hunk = hunks[i];
+            var side = hunk[1];
+            var r = regions[side];
+            var oLhs = hunk[0];
+            var oRhs = oLhs + hunk[2];
+            var abLhs = hunk[3];
+            var abRhs = abLhs + hunk[4];
+            r[0] = Math.min(abLhs, r[0]);
+            r[1] = Math.max(abRhs, r[1]);
+            r[2] = Math.min(oLhs, r[2]);
+            r[3] = Math.max(oRhs, r[3]);
+          }
+          var aLhs = regions[0][0] + (regionLhs - regions[0][2]);
+          var aRhs = regions[0][1] + (regionRhs - regions[0][3]);
+          var bLhs = regions[2][0] + (regionLhs - regions[2][2]);
+          var bRhs = regions[2][1] + (regionRhs - regions[2][3]);
+          result.push([
+            -1,
+            aLhs,
+            aRhs - aLhs,
+            regionLhs,
+            regionRhs - regionLhs,
+            bLhs,
+            bRhs - bLhs
+          ]);
+        }
+        commonOffset = regionRhs;
+      }
+      copyCommon(o.length);
+      return result;
+    }
+    function diff3Merge2(a, o, b) {
+      var result = [];
+      var files = [a, o, b];
+      var indices = diff3MergeIndices(a, o, b);
+      var okLines = [];
+      function flushOk() {
+        if (okLines.length) {
+          result.push({
+            ok: okLines
+          });
+        }
+        okLines = [];
+      }
+      function pushOk(xs) {
+        for (var j = 0; j < xs.length; j++) {
+          okLines.push(xs[j]);
+        }
+      }
+      function isTrueConflict(rec) {
+        if (rec[2] != rec[6]) return true;
+        var aoff = rec[1];
+        var boff = rec[5];
+        for (var j = 0; j < rec[2]; j++) {
+          if (a[j + aoff] != b[j + boff]) return true;
+        }
+        return false;
+      }
+      for (var i = 0; i < indices.length; i++) {
+        var x = indices[i];
+        var side = x[0];
+        if (side == -1) {
+          if (!isTrueConflict(x)) {
+            pushOk(files[0].slice(x[1], x[1] + x[2]));
+          } else {
+            flushOk();
+            result.push({
+              conflict: {
+                a: a.slice(x[1], x[1] + x[2]),
+                aIndex: x[1],
+                o: o.slice(x[3], x[3] + x[4]),
+                oIndex: x[3],
+                b: b.slice(x[5], x[5] + x[6]),
+                bIndex: x[5]
+              }
+            });
+          }
+        } else {
+          pushOk(files[side].slice(x[1], x[1] + x[2]));
+        }
+      }
+      flushOk();
+      return result;
+    }
+    module.exports = diff3Merge2;
+  }
+});
+
+// entry.mjs
+init_bufinject();
+
+// node_modules/isomorphic-git/index.js
+init_bufinject();
+var import_async_lock = __toESM(require_async_lock(), 1);
+var import_sha1 = __toESM(require_sha1(), 1);
+var import_crc_32 = __toESM(require_crc32(), 1);
+var import_pako = __toESM(require_pako(), 1);
+var import_pify = __toESM(require_pify(), 1);
+var import_ignore = __toESM(require_ignore(), 1);
+var import_clean_git_ref = __toESM(require_lib2(), 1);
+var import_diff3 = __toESM(require_diff3(), 1);
+var BaseError = class _BaseError extends Error {
+  constructor(message) {
+    super(message);
+    this.caller = "";
+  }
+  toJSON() {
+    return {
+      code: this.code,
+      data: this.data,
+      caller: this.caller,
+      message: this.message,
+      stack: this.stack
+    };
+  }
+  fromJSON(json) {
+    const e = new _BaseError(json.message);
+    e.code = json.code;
+    e.data = json.data;
+    e.caller = json.caller;
+    e.stack = json.stack;
+    return e;
+  }
+  get isIsomorphicGitError() {
+    return true;
+  }
+};
+var UnmergedPathsError = class _UnmergedPathsError extends BaseError {
+  /**
+   * @param {Array<string>} filepaths
+   */
+  constructor(filepaths) {
+    super(
+      `Modifying the index is not possible because you have unmerged files: ${filepaths.toString}. Fix them up in the work tree, and then use 'git add/rm as appropriate to mark resolution and make a commit.`
+    );
+    this.code = this.name = _UnmergedPathsError.code;
+    this.data = { filepaths };
+  }
+};
+UnmergedPathsError.code = "UnmergedPathsError";
+var InternalError = class _InternalError extends BaseError {
+  /**
+   * @param {string} message
+   */
+  constructor(message) {
+    super(
+      `An internal error caused this command to fail. Please file a bug report at https://github.com/isomorphic-git/isomorphic-git/issues with this error message: ${message}`
+    );
+    this.code = this.name = _InternalError.code;
+    this.data = { message };
+  }
+};
+InternalError.code = "InternalError";
+var UnsafeFilepathError = class _UnsafeFilepathError extends BaseError {
+  /**
+   * @param {string} filepath
+   */
+  constructor(filepath) {
+    super(`The filepath "${filepath}" contains unsafe character sequences`);
+    this.code = this.name = _UnsafeFilepathError.code;
+    this.data = { filepath };
+  }
+};
+UnsafeFilepathError.code = "UnsafeFilepathError";
+var BufferCursor = class {
+  constructor(buffer) {
+    this.buffer = buffer;
+    this._start = 0;
+  }
+  eof() {
+    return this._start >= this.buffer.length;
+  }
+  tell() {
+    return this._start;
+  }
+  seek(n) {
+    this._start = n;
+  }
+  slice(n) {
+    const r = this.buffer.slice(this._start, this._start + n);
+    this._start += n;
+    return r;
+  }
+  toString(enc, length) {
+    const r = this.buffer.toString(enc, this._start, this._start + length);
+    this._start += length;
+    return r;
+  }
+  write(value, length, enc) {
+    const r = this.buffer.write(value, this._start, length, enc);
+    this._start += length;
+    return r;
+  }
+  copy(source, start, end) {
+    const r = source.copy(this.buffer, this._start, start, end);
+    this._start += r;
+    return r;
+  }
+  readUInt8() {
+    const r = this.buffer.readUInt8(this._start);
+    this._start += 1;
+    return r;
+  }
+  writeUInt8(value) {
+    const r = this.buffer.writeUInt8(value, this._start);
+    this._start += 1;
+    return r;
+  }
+  readUInt16BE() {
+    const r = this.buffer.readUInt16BE(this._start);
+    this._start += 2;
+    return r;
+  }
+  writeUInt16BE(value) {
+    const r = this.buffer.writeUInt16BE(value, this._start);
+    this._start += 2;
+    return r;
+  }
+  readUInt32BE() {
+    const r = this.buffer.readUInt32BE(this._start);
+    this._start += 4;
+    return r;
+  }
+  writeUInt32BE(value) {
+    const r = this.buffer.writeUInt32BE(value, this._start);
+    this._start += 4;
+    return r;
+  }
+};
+function compareStrings(a, b) {
+  return -(a < b) || +(a > b);
+}
+function comparePath(a, b) {
+  return compareStrings(a.path, b.path);
+}
+function normalizeMode(mode) {
+  let type = mode > 0 ? mode >> 12 : 0;
+  if (type !== 4 && type !== 8 && type !== 10 && type !== 14) {
+    type = 8;
+  }
+  let permissions = mode & 511;
+  if (permissions & 73) {
+    permissions = 493;
+  } else {
+    permissions = 420;
+  }
+  if (type !== 8) permissions = 0;
+  return (type << 12) + permissions;
+}
+var MAX_UINT32 = 2 ** 32;
+function SecondsNanoseconds(givenSeconds, givenNanoseconds, milliseconds, date) {
+  if (givenSeconds !== void 0 && givenNanoseconds !== void 0) {
+    return [givenSeconds, givenNanoseconds];
+  }
+  if (milliseconds === void 0) {
+    milliseconds = date.valueOf();
+  }
+  const seconds = Math.floor(milliseconds / 1e3);
+  const nanoseconds = (milliseconds - seconds * 1e3) * 1e6;
+  return [seconds, nanoseconds];
+}
+function normalizeStats(e) {
+  const [ctimeSeconds, ctimeNanoseconds] = SecondsNanoseconds(
+    e.ctimeSeconds,
+    e.ctimeNanoseconds,
+    e.ctimeMs,
+    e.ctime
+  );
+  const [mtimeSeconds, mtimeNanoseconds] = SecondsNanoseconds(
+    e.mtimeSeconds,
+    e.mtimeNanoseconds,
+    e.mtimeMs,
+    e.mtime
+  );
+  return {
+    ctimeSeconds: ctimeSeconds % MAX_UINT32,
+    ctimeNanoseconds: ctimeNanoseconds % MAX_UINT32,
+    mtimeSeconds: mtimeSeconds % MAX_UINT32,
+    mtimeNanoseconds: mtimeNanoseconds % MAX_UINT32,
+    dev: e.dev % MAX_UINT32,
+    ino: e.ino % MAX_UINT32,
+    mode: normalizeMode(e.mode % MAX_UINT32),
+    uid: e.uid % MAX_UINT32,
+    gid: e.gid % MAX_UINT32,
+    // size of -1 happens over a BrowserFS HTTP Backend that doesn't serve Content-Length headers
+    // (like the Karma webserver) because BrowserFS HTTP Backend uses HTTP HEAD requests to do fs.stat
+    size: e.size > -1 ? e.size % MAX_UINT32 : 0
+  };
+}
+function toHex(buffer) {
+  let hex = "";
+  for (const byte of new Uint8Array(buffer)) {
+    if (byte < 16) hex += "0";
+    hex += byte.toString(16);
+  }
+  return hex;
+}
+var supportsSubtleSHA1 = null;
+async function shasum(buffer) {
+  if (supportsSubtleSHA1 === null) {
+    supportsSubtleSHA1 = await testSubtleSHA1();
+  }
+  return supportsSubtleSHA1 ? subtleSHA1(buffer) : shasumSync(buffer);
+}
+function shasumSync(buffer) {
+  return new import_sha1.default().update(buffer).digest("hex");
+}
+async function subtleSHA1(buffer) {
+  const hash = await crypto.subtle.digest("SHA-1", buffer);
+  return toHex(hash);
+}
+async function testSubtleSHA1() {
+  try {
+    const hash = await subtleSHA1(new Uint8Array([]));
+    if (hash === "da39a3ee5e6b4b0d3255bfef95601890afd80709") return true;
+  } catch (_) {
+  }
+  return false;
+}
+function parseCacheEntryFlags(bits) {
+  return {
+    assumeValid: Boolean(bits & 32768),
+    extended: Boolean(bits & 16384),
+    stage: (bits & 12288) >> 12,
+    nameLength: bits & 4095
+  };
+}
+function renderCacheEntryFlags(entry) {
+  const flags = entry.flags;
+  flags.extended = false;
+  flags.nameLength = Math.min(import_buffer.Buffer.from(entry.path).length, 4095);
+  return (flags.assumeValid ? 32768 : 0) + (flags.extended ? 16384 : 0) + ((flags.stage & 3) << 12) + (flags.nameLength & 4095);
+}
+var GitIndex = class _GitIndex {
+  /*::
+   _entries: Map<string, CacheEntry>
+   _dirty: boolean // Used to determine if index needs to be saved to filesystem
+   */
+  constructor(entries, unmergedPaths) {
+    this._dirty = false;
+    this._unmergedPaths = unmergedPaths || /* @__PURE__ */ new Set();
+    this._entries = entries || /* @__PURE__ */ new Map();
+  }
+  _addEntry(entry) {
+    if (entry.flags.stage === 0) {
+      entry.stages = [entry];
+      this._entries.set(entry.path, entry);
+      this._unmergedPaths.delete(entry.path);
+    } else {
+      let existingEntry = this._entries.get(entry.path);
+      if (!existingEntry) {
+        this._entries.set(entry.path, entry);
+        existingEntry = entry;
+      }
+      existingEntry.stages[entry.flags.stage] = entry;
+      this._unmergedPaths.add(entry.path);
+    }
+  }
+  static async from(buffer) {
+    if (import_buffer.Buffer.isBuffer(buffer)) {
+      return _GitIndex.fromBuffer(buffer);
+    } else if (buffer === null) {
+      return new _GitIndex(null);
+    } else {
+      throw new InternalError("invalid type passed to GitIndex.from");
+    }
+  }
+  static async fromBuffer(buffer) {
+    if (buffer.length === 0) {
+      throw new InternalError("Index file is empty (.git/index)");
+    }
+    const index3 = new _GitIndex();
+    const reader = new BufferCursor(buffer);
+    const magic = reader.toString("utf8", 4);
+    if (magic !== "DIRC") {
+      throw new InternalError(`Invalid dircache magic file number: ${magic}`);
+    }
+    const shaComputed = await shasum(buffer.slice(0, -20));
+    const shaClaimed = buffer.slice(-20).toString("hex");
+    if (shaClaimed !== shaComputed) {
+      throw new InternalError(
+        `Invalid checksum in GitIndex buffer: expected ${shaClaimed} but saw ${shaComputed}`
+      );
+    }
+    const version2 = reader.readUInt32BE();
+    if (version2 !== 2) {
+      throw new InternalError(`Unsupported dircache version: ${version2}`);
+    }
+    const numEntries = reader.readUInt32BE();
+    let i = 0;
+    while (!reader.eof() && i < numEntries) {
+      const entry = {};
+      entry.ctimeSeconds = reader.readUInt32BE();
+      entry.ctimeNanoseconds = reader.readUInt32BE();
+      entry.mtimeSeconds = reader.readUInt32BE();
+      entry.mtimeNanoseconds = reader.readUInt32BE();
+      entry.dev = reader.readUInt32BE();
+      entry.ino = reader.readUInt32BE();
+      entry.mode = reader.readUInt32BE();
+      entry.uid = reader.readUInt32BE();
+      entry.gid = reader.readUInt32BE();
+      entry.size = reader.readUInt32BE();
+      entry.oid = reader.slice(20).toString("hex");
+      const flags = reader.readUInt16BE();
+      entry.flags = parseCacheEntryFlags(flags);
+      const pathlength = buffer.indexOf(0, reader.tell() + 1) - reader.tell();
+      if (pathlength < 1) {
+        throw new InternalError(`Got a path length of: ${pathlength}`);
+      }
+      entry.path = reader.toString("utf8", pathlength);
+      if (entry.path.includes("..\\") || entry.path.includes("../")) {
+        throw new UnsafeFilepathError(entry.path);
+      }
+      let padding = 8 - (reader.tell() - 12) % 8;
+      if (padding === 0) padding = 8;
+      while (padding--) {
+        const tmp = reader.readUInt8();
+        if (tmp !== 0) {
+          throw new InternalError(
+            `Expected 1-8 null characters but got '${tmp}' after ${entry.path}`
+          );
+        } else if (reader.eof()) {
+          throw new InternalError("Unexpected end of file");
+        }
+      }
+      entry.stages = [];
+      index3._addEntry(entry);
+      i++;
+    }
+    return index3;
+  }
+  get unmergedPaths() {
+    return [...this._unmergedPaths];
+  }
+  get entries() {
+    return [...this._entries.values()].sort(comparePath);
+  }
+  get entriesMap() {
+    return this._entries;
+  }
+  get entriesFlat() {
+    return [...this.entries].flatMap((entry) => {
+      return entry.stages.length > 1 ? entry.stages.filter((x) => x) : entry;
+    });
+  }
+  *[Symbol.iterator]() {
+    for (const entry of this.entries) {
+      yield entry;
+    }
+  }
+  insert({ filepath, stats, oid, stage = 0 }) {
+    if (!stats) {
+      stats = {
+        ctimeSeconds: 0,
+        ctimeNanoseconds: 0,
+        mtimeSeconds: 0,
+        mtimeNanoseconds: 0,
+        dev: 0,
+        ino: 0,
+        mode: 0,
+        uid: 0,
+        gid: 0,
+        size: 0
+      };
+    }
+    stats = normalizeStats(stats);
+    const bfilepath = import_buffer.Buffer.from(filepath);
+    const entry = {
+      ctimeSeconds: stats.ctimeSeconds,
+      ctimeNanoseconds: stats.ctimeNanoseconds,
+      mtimeSeconds: stats.mtimeSeconds,
+      mtimeNanoseconds: stats.mtimeNanoseconds,
+      dev: stats.dev,
+      ino: stats.ino,
+      // We provide a fallback value for `mode` here because not all fs
+      // implementations assign it, but we use it in GitTree.
+      // '100644' is for a "regular non-executable file"
+      mode: stats.mode || 33188,
+      uid: stats.uid,
+      gid: stats.gid,
+      size: stats.size,
+      path: filepath,
+      oid,
+      flags: {
+        assumeValid: false,
+        extended: false,
+        stage,
+        nameLength: bfilepath.length < 4095 ? bfilepath.length : 4095
+      },
+      stages: []
+    };
+    this._addEntry(entry);
+    this._dirty = true;
+  }
+  delete({ filepath }) {
+    if (this._entries.has(filepath)) {
+      this._entries.delete(filepath);
+    } else {
+      for (const key of this._entries.keys()) {
+        if (key.startsWith(filepath + "/")) {
+          this._entries.delete(key);
+        }
+      }
+    }
+    if (this._unmergedPaths.has(filepath)) {
+      this._unmergedPaths.delete(filepath);
+    }
+    this._dirty = true;
+  }
+  clear() {
+    this._entries.clear();
+    this._dirty = true;
+  }
+  has({ filepath }) {
+    return this._entries.has(filepath);
+  }
+  render() {
+    return this.entries.map((entry) => `${entry.mode.toString(8)} ${entry.oid}    ${entry.path}`).join("\n");
+  }
+  static async _entryToBuffer(entry) {
+    const bpath = import_buffer.Buffer.from(entry.path);
+    const length = Math.ceil((62 + bpath.length + 1) / 8) * 8;
+    const written = import_buffer.Buffer.alloc(length);
+    const writer = new BufferCursor(written);
+    const stat = normalizeStats(entry);
+    writer.writeUInt32BE(stat.ctimeSeconds);
+    writer.writeUInt32BE(stat.ctimeNanoseconds);
+    writer.writeUInt32BE(stat.mtimeSeconds);
+    writer.writeUInt32BE(stat.mtimeNanoseconds);
+    writer.writeUInt32BE(stat.dev);
+    writer.writeUInt32BE(stat.ino);
+    writer.writeUInt32BE(stat.mode);
+    writer.writeUInt32BE(stat.uid);
+    writer.writeUInt32BE(stat.gid);
+    writer.writeUInt32BE(stat.size);
+    writer.write(entry.oid, 20, "hex");
+    writer.writeUInt16BE(renderCacheEntryFlags(entry));
+    writer.write(entry.path, bpath.length, "utf8");
+    return written;
+  }
+  async toObject() {
+    const header = import_buffer.Buffer.alloc(12);
+    const writer = new BufferCursor(header);
+    writer.write("DIRC", 4, "utf8");
+    writer.writeUInt32BE(2);
+    writer.writeUInt32BE(this.entriesFlat.length);
+    let entryBuffers = [];
+    for (const entry of this.entries) {
+      entryBuffers.push(_GitIndex._entryToBuffer(entry));
+      if (entry.stages.length > 1) {
+        for (const stage of entry.stages) {
+          if (stage && stage !== entry) {
+            entryBuffers.push(_GitIndex._entryToBuffer(stage));
+          }
+        }
+      }
+    }
+    entryBuffers = await Promise.all(entryBuffers);
+    const body = import_buffer.Buffer.concat(entryBuffers);
+    const main = import_buffer.Buffer.concat([header, body]);
+    const sum = await shasum(main);
+    return import_buffer.Buffer.concat([main, import_buffer.Buffer.from(sum, "hex")]);
+  }
+};
+function compareStats(entry, stats, filemode = true, trustino = true) {
+  const e = normalizeStats(entry);
+  const s = normalizeStats(stats);
+  const staleness = filemode && e.mode !== s.mode || e.mtimeSeconds !== s.mtimeSeconds || e.ctimeSeconds !== s.ctimeSeconds || e.uid !== s.uid || e.gid !== s.gid || trustino && e.ino !== s.ino || e.size !== s.size;
+  return staleness;
+}
+var lock = null;
+var IndexCache = /* @__PURE__ */ Symbol("IndexCache");
+function createCache() {
+  return {
+    map: /* @__PURE__ */ new Map(),
+    stats: /* @__PURE__ */ new Map()
+  };
+}
+async function updateCachedIndexFile(fs, filepath, cache) {
+  const stat = await fs.lstat(filepath);
+  const rawIndexFile = await fs.read(filepath);
+  const index3 = await GitIndex.from(rawIndexFile);
+  cache.map.set(filepath, index3);
+  cache.stats.set(filepath, stat);
+}
+async function isIndexStale(fs, filepath, cache) {
+  const savedStats = cache.stats.get(filepath);
+  if (savedStats === void 0) return true;
+  const currStats = await fs.lstat(filepath);
+  if (savedStats === null) return false;
+  if (currStats === null) return false;
+  return compareStats(savedStats, currStats);
+}
+var GitIndexManager = class {
+  /**
+   *
+   * @param {object} opts
+   * @param {import('../models/FileSystem.js').FileSystem} opts.fs
+   * @param {string} opts.gitdir
+   * @param {object} opts.cache
+   * @param {bool} opts.allowUnmerged
+   * @param {function(GitIndex): any} closure
+   */
+  static async acquire({ fs, gitdir, cache, allowUnmerged = true }, closure) {
+    if (!cache[IndexCache]) cache[IndexCache] = createCache();
+    const filepath = `${gitdir}/index`;
+    if (lock === null) lock = new import_async_lock.default({ maxPending: Infinity });
+    let result;
+    let unmergedPaths = [];
+    await lock.acquire(filepath, async () => {
+      if (await isIndexStale(fs, filepath, cache[IndexCache])) {
+        await updateCachedIndexFile(fs, filepath, cache[IndexCache]);
+      }
+      const index3 = cache[IndexCache].map.get(filepath);
+      unmergedPaths = index3.unmergedPaths;
+      if (unmergedPaths.length && !allowUnmerged)
+        throw new UnmergedPathsError(unmergedPaths);
+      result = await closure(index3);
+      if (index3._dirty) {
+        const buffer = await index3.toObject();
+        await fs.write(filepath, buffer);
+        cache[IndexCache].stats.set(filepath, await fs.lstat(filepath));
+        index3._dirty = false;
+      }
+    });
+    return result;
+  }
+};
+function basename(path) {
+  const last = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (last > -1) {
+    path = path.slice(last + 1);
+  }
+  return path;
+}
+function dirname(path) {
+  const last = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  if (last === -1) return ".";
+  if (last === 0) return "/";
+  return path.slice(0, last);
+}
+function flatFileListToDirectoryStructure(files) {
+  const inodes = /* @__PURE__ */ new Map();
+  const mkdir = function(name) {
+    if (!inodes.has(name)) {
+      const dir = {
+        type: "tree",
+        fullpath: name,
+        basename: basename(name),
+        metadata: {},
+        children: []
+      };
+      inodes.set(name, dir);
+      dir.parent = mkdir(dirname(name));
+      if (dir.parent && dir.parent !== dir) dir.parent.children.push(dir);
+    }
+    return inodes.get(name);
+  };
+  const mkfile = function(name, metadata) {
+    if (!inodes.has(name)) {
+      const file = {
+        type: "blob",
+        fullpath: name,
+        basename: basename(name),
+        metadata,
+        // This recursively generates any missing parent folders.
+        parent: mkdir(dirname(name)),
+        children: []
+      };
+      if (file.parent) file.parent.children.push(file);
+      inodes.set(name, file);
+    }
+    return inodes.get(name);
+  };
+  mkdir(".");
+  for (const file of files) {
+    mkfile(file.path, file);
+  }
+  return inodes;
+}
+function mode2type(mode) {
+  switch (mode) {
+    case 16384:
+      return "tree";
+    case 33188:
+      return "blob";
+    case 33261:
+      return "blob";
+    case 40960:
+      return "blob";
+    case 57344:
+      return "commit";
+  }
+  throw new InternalError(`Unexpected GitTree entry mode: ${mode.toString(8)}`);
+}
+var GitWalkerIndex = class {
+  constructor({ fs, gitdir, cache }) {
+    this.treePromise = GitIndexManager.acquire(
+      { fs, gitdir, cache },
+      async function(index3) {
+        return flatFileListToDirectoryStructure(index3.entries);
+      }
+    );
+    const walker = this;
+    this.ConstructEntry = class StageEntry {
+      constructor(fullpath) {
+        this._fullpath = fullpath;
+        this._type = false;
+        this._mode = false;
+        this._stat = false;
+        this._oid = false;
+      }
+      async type() {
+        return walker.type(this);
+      }
+      async mode() {
+        return walker.mode(this);
+      }
+      async stat() {
+        return walker.stat(this);
+      }
+      async content() {
+        return walker.content(this);
+      }
+      async oid() {
+        return walker.oid(this);
+      }
+    };
+  }
+  async readdir(entry) {
+    const filepath = entry._fullpath;
+    const tree = await this.treePromise;
+    const inode = tree.get(filepath);
+    if (!inode) return null;
+    if (inode.type === "blob") return null;
+    if (inode.type !== "tree") {
+      throw new Error(`ENOTDIR: not a directory, scandir '${filepath}'`);
+    }
+    const names = inode.children.map((inode2) => inode2.fullpath);
+    names.sort(compareStrings);
+    return names;
+  }
+  async type(entry) {
+    if (entry._type === false) {
+      await entry.stat();
+    }
+    return entry._type;
+  }
+  async mode(entry) {
+    if (entry._mode === false) {
+      await entry.stat();
+    }
+    return entry._mode;
+  }
+  async stat(entry) {
+    if (entry._stat === false) {
+      const tree = await this.treePromise;
+      const inode = tree.get(entry._fullpath);
+      if (!inode) {
+        throw new Error(
+          `ENOENT: no such file or directory, lstat '${entry._fullpath}'`
+        );
+      }
+      const stats = inode.type === "tree" ? {} : normalizeStats(inode.metadata);
+      entry._type = inode.type === "tree" ? "tree" : mode2type(stats.mode);
+      entry._mode = stats.mode;
+      if (inode.type === "tree") {
+        entry._stat = void 0;
+      } else {
+        entry._stat = stats;
+      }
+    }
+    return entry._stat;
+  }
+  async content(_entry) {
+  }
+  async oid(entry) {
+    if (entry._oid === false) {
+      const tree = await this.treePromise;
+      const inode = tree.get(entry._fullpath);
+      entry._oid = inode.metadata.oid;
+    }
+    return entry._oid;
+  }
+};
+var GitWalkSymbol = /* @__PURE__ */ Symbol("GitWalkSymbol");
+function STAGE() {
+  const o = /* @__PURE__ */ Object.create(null);
+  Object.defineProperty(o, GitWalkSymbol, {
+    value: function({ fs, gitdir, cache }) {
+      return new GitWalkerIndex({ fs, gitdir, cache });
+    }
+  });
+  Object.freeze(o);
+  return o;
+}
+var NotFoundError = class _NotFoundError extends BaseError {
+  /**
+   * @param {string} what
+   */
+  constructor(what) {
+    super(`Could not find ${what}.`);
+    this.code = this.name = _NotFoundError.code;
+    this.data = { what };
+  }
+};
+NotFoundError.code = "NotFoundError";
+var ObjectTypeError = class _ObjectTypeError extends BaseError {
+  /**
+   * @param {string} oid
+   * @param {'blob'|'commit'|'tag'|'tree'} actual
+   * @param {'blob'|'commit'|'tag'|'tree'} expected
+   * @param {string} [filepath]
+   */
+  constructor(oid, actual, expected, filepath) {
+    super(
+      `Object ${oid} ${filepath ? `at ${filepath}` : ""}was anticipated to be a ${expected} but it is a ${actual}.`
+    );
+    this.code = this.name = _ObjectTypeError.code;
+    this.data = { oid, actual, expected, filepath };
+  }
+};
+ObjectTypeError.code = "ObjectTypeError";
+var InvalidOidError = class _InvalidOidError extends BaseError {
+  /**
+   * @param {string} value
+   */
+  constructor(value) {
+    super(`Expected a 40-char hex object id but saw "${value}".`);
+    this.code = this.name = _InvalidOidError.code;
+    this.data = { value };
+  }
+};
+InvalidOidError.code = "InvalidOidError";
+var NoRefspecError = class _NoRefspecError extends BaseError {
+  /**
+   * @param {string} remote
+   */
+  constructor(remote) {
+    super(`Could not find a fetch refspec for remote "${remote}". Make sure the config file has an entry like the following:
+[remote "${remote}"]
+	fetch = +refs/heads/*:refs/remotes/origin/*
+`);
+    this.code = this.name = _NoRefspecError.code;
+    this.data = { remote };
+  }
+};
+NoRefspecError.code = "NoRefspecError";
+var GitPackedRefs = class _GitPackedRefs {
+  constructor(text) {
+    this.refs = /* @__PURE__ */ new Map();
+    this.parsedConfig = [];
+    if (text) {
+      let key = null;
+      this.parsedConfig = text.trim().split("\n").map((line) => {
+        if (/^\s*#/.test(line)) {
+          return { line, comment: true };
+        }
+        const i = line.indexOf(" ");
+        if (line.startsWith("^")) {
+          const value = line.slice(1);
+          this.refs.set(key + "^{}", value);
+          return { line, ref: key, peeled: value };
+        } else {
+          const value = line.slice(0, i);
+          key = line.slice(i + 1);
+          this.refs.set(key, value);
+          return { line, ref: key, oid: value };
+        }
+      });
+    }
+    return this;
+  }
+  static from(text) {
+    return new _GitPackedRefs(text);
+  }
+  delete(ref) {
+    this.parsedConfig = this.parsedConfig.filter((entry) => entry.ref !== ref);
+    this.refs.delete(ref);
+  }
+  toString() {
+    return this.parsedConfig.map(({ line }) => line).join("\n") + "\n";
+  }
+};
+var GitRefSpec = class _GitRefSpec {
+  constructor({ remotePath, localPath, force, matchPrefix }) {
+    Object.assign(this, {
+      remotePath,
+      localPath,
+      force,
+      matchPrefix
+    });
+  }
+  static from(refspec) {
+    const [
+      forceMatch,
+      remotePath,
+      remoteGlobMatch,
+      localPath,
+      localGlobMatch
+    ] = refspec.match(/^(\+?)(.*?)(\*?):(.*?)(\*?)$/).slice(1);
+    const force = forceMatch === "+";
+    const remoteIsGlob = remoteGlobMatch === "*";
+    const localIsGlob = localGlobMatch === "*";
+    if (remoteIsGlob !== localIsGlob) {
+      throw new InternalError("Invalid refspec");
+    }
+    return new _GitRefSpec({
+      remotePath,
+      localPath,
+      force,
+      matchPrefix: remoteIsGlob
+    });
+  }
+  translate(remoteBranch) {
+    if (this.matchPrefix) {
+      if (remoteBranch.startsWith(this.remotePath)) {
+        return this.localPath + remoteBranch.replace(this.remotePath, "");
+      }
+    } else {
+      if (remoteBranch === this.remotePath) return this.localPath;
+    }
+    return null;
+  }
+  reverseTranslate(localBranch) {
+    if (this.matchPrefix) {
+      if (localBranch.startsWith(this.localPath)) {
+        return this.remotePath + localBranch.replace(this.localPath, "");
+      }
+    } else {
+      if (localBranch === this.localPath) return this.remotePath;
+    }
+    return null;
+  }
+};
+var GitRefSpecSet = class _GitRefSpecSet {
+  constructor(rules = []) {
+    this.rules = rules;
+  }
+  static from(refspecs) {
+    const rules = [];
+    for (const refspec of refspecs) {
+      rules.push(GitRefSpec.from(refspec));
+    }
+    return new _GitRefSpecSet(rules);
+  }
+  add(refspec) {
+    const rule = GitRefSpec.from(refspec);
+    this.rules.push(rule);
+  }
+  translate(remoteRefs) {
+    const result = [];
+    for (const rule of this.rules) {
+      for (const remoteRef of remoteRefs) {
+        const localRef = rule.translate(remoteRef);
+        if (localRef) {
+          result.push([remoteRef, localRef]);
+        }
+      }
+    }
+    return result;
+  }
+  translateOne(remoteRef) {
+    let result = null;
+    for (const rule of this.rules) {
+      const localRef = rule.translate(remoteRef);
+      if (localRef) {
+        result = localRef;
+      }
+    }
+    return result;
+  }
+  localNamespaces() {
+    return this.rules.filter((rule) => rule.matchPrefix).map((rule) => rule.localPath.replace(/\/$/, ""));
+  }
+};
+function compareRefNames(a, b) {
+  const _a = a.replace(/\^\{\}$/, "");
+  const _b = b.replace(/\^\{\}$/, "");
+  const tmp = -(_a < _b) || +(_a > _b);
+  if (tmp === 0) {
+    return a.endsWith("^{}") ? 1 : -1;
+  }
+  return tmp;
+}
+var memo = /* @__PURE__ */ new Map();
+function normalizePath(path) {
+  let normalizedPath = memo.get(path);
+  if (!normalizedPath) {
+    normalizedPath = normalizePathInternal(path);
+    memo.set(path, normalizedPath);
+  }
+  return normalizedPath;
+}
+function normalizePathInternal(path) {
+  path = path.split("/./").join("/").replace(/\/{2,}/g, "/");
+  if (path === "/.") return "/";
+  if (path === "./") return ".";
+  if (path.startsWith("./")) path = path.slice(2);
+  if (path.endsWith("/.")) path = path.slice(0, -2);
+  if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
+  if (path === "") return ".";
+  return path;
+}
+function join(...parts) {
+  return normalizePath(parts.map(normalizePath).join("/"));
+}
+var num = (val) => {
+  val = val.toLowerCase();
+  let n = parseInt(val);
+  if (val.endsWith("k")) n *= 1024;
+  if (val.endsWith("m")) n *= 1024 * 1024;
+  if (val.endsWith("g")) n *= 1024 * 1024 * 1024;
+  return n;
+};
+var bool = (val) => {
+  val = val.trim().toLowerCase();
+  if (val === "true" || val === "yes" || val === "on") return true;
+  if (val === "false" || val === "no" || val === "off") return false;
+  throw Error(
+    `Expected 'true', 'false', 'yes', 'no', 'on', or 'off', but got ${val}`
+  );
+};
+var schema = {
+  core: {
+    filemode: bool,
+    bare: bool,
+    logallrefupdates: bool,
+    symlinks: bool,
+    ignorecase: bool,
+    bigFileThreshold: num
+  }
+};
+var SECTION_LINE_REGEX = /^\[([A-Za-z0-9-.]+)(?: "(.*)")?\]$/;
+var SECTION_REGEX = /^[A-Za-z0-9-.]+$/;
+var VARIABLE_LINE_REGEX = /^([A-Za-z][A-Za-z-]*)(?: *= *(.*))?$/;
+var VARIABLE_NAME_REGEX = /^[A-Za-z][A-Za-z-]*$/;
+var VARIABLE_VALUE_COMMENT_REGEX = /^(.*?)( *[#;].*)$/;
+var extractSectionLine = (line) => {
+  const matches = SECTION_LINE_REGEX.exec(line);
+  if (matches != null) {
+    const [section, subsection] = matches.slice(1);
+    return [section, subsection];
+  }
+  return null;
+};
+var extractVariableLine = (line) => {
+  const matches = VARIABLE_LINE_REGEX.exec(line);
+  if (matches != null) {
+    const [name, rawValue = "true"] = matches.slice(1);
+    const valueWithoutComments = removeComments(rawValue);
+    const valueWithoutQuotes = removeQuotes(valueWithoutComments);
+    return [name, valueWithoutQuotes];
+  }
+  return null;
+};
+var removeComments = (rawValue) => {
+  const commentMatches = VARIABLE_VALUE_COMMENT_REGEX.exec(rawValue);
+  if (commentMatches == null) {
+    return rawValue;
+  }
+  const [valueWithoutComment, comment] = commentMatches.slice(1);
+  if (hasOddNumberOfQuotes(valueWithoutComment) && hasOddNumberOfQuotes(comment)) {
+    return `${valueWithoutComment}${comment}`;
+  }
+  return valueWithoutComment;
+};
+var hasOddNumberOfQuotes = (text) => {
+  const numberOfQuotes = (text.match(/(?:^|[^\\])"/g) || []).length;
+  return numberOfQuotes % 2 !== 0;
+};
+var removeQuotes = (text) => {
+  return text.split("").reduce((newText, c, idx, text2) => {
+    const isQuote = c === '"' && text2[idx - 1] !== "\\";
+    const isEscapeForQuote = c === "\\" && text2[idx + 1] === '"';
+    if (isQuote || isEscapeForQuote) {
+      return newText;
+    }
+    return newText + c;
+  }, "");
+};
+var lower = (text) => {
+  return text != null ? text.toLowerCase() : null;
+};
+var getPath = (section, subsection, name) => {
+  return [lower(section), subsection, lower(name)].filter((a) => a != null).join(".");
+};
+var normalizePath$1 = (path) => {
+  const pathSegments = path.split(".");
+  const section = pathSegments.shift();
+  const name = pathSegments.pop();
+  const subsection = pathSegments.length ? pathSegments.join(".") : void 0;
+  return {
+    section,
+    subsection,
+    name,
+    path: getPath(section, subsection, name),
+    sectionPath: getPath(section, subsection, null)
+  };
+};
+var findLastIndex = (array, callback) => {
+  return array.reduce((lastIndex, item, index3) => {
+    return callback(item) ? index3 : lastIndex;
+  }, -1);
+};
+var GitConfig = class _GitConfig {
+  constructor(text) {
+    let section = null;
+    let subsection = null;
+    this.parsedConfig = text ? text.split("\n").map((line) => {
+      let name = null;
+      let value = null;
+      const trimmedLine = line.trim();
+      const extractedSection = extractSectionLine(trimmedLine);
+      const isSection = extractedSection != null;
+      if (isSection) {
+        ;
+        [section, subsection] = extractedSection;
+      } else {
+        const extractedVariable = extractVariableLine(trimmedLine);
+        const isVariable = extractedVariable != null;
+        if (isVariable) {
+          ;
+          [name, value] = extractedVariable;
+        }
+      }
+      const path = getPath(section, subsection, name);
+      return { line, isSection, section, subsection, name, value, path };
+    }) : [];
+  }
+  static from(text) {
+    return new _GitConfig(text);
+  }
+  async get(path, getall = false) {
+    const normalizedPath = normalizePath$1(path).path;
+    const allValues = this.parsedConfig.filter((config) => config.path === normalizedPath).map(({ section, name, value }) => {
+      const fn = schema[section] && schema[section][name];
+      return fn ? fn(value) : value;
+    });
+    return getall ? allValues : allValues.pop();
+  }
+  async getall(path) {
+    return this.get(path, true);
+  }
+  async getSubsections(section) {
+    return this.parsedConfig.filter((config) => config.section === section && config.isSection).map((config) => config.subsection);
+  }
+  async deleteSection(section, subsection) {
+    this.parsedConfig = this.parsedConfig.filter(
+      (config) => !(config.section === section && config.subsection === subsection)
+    );
+  }
+  async append(path, value) {
+    return this.set(path, value, true);
+  }
+  async set(path, value, append = false) {
+    const {
+      section,
+      subsection,
+      name,
+      path: normalizedPath,
+      sectionPath
+    } = normalizePath$1(path);
+    const configIndex = findLastIndex(
+      this.parsedConfig,
+      (config) => config.path === normalizedPath
+    );
+    if (value == null) {
+      if (configIndex !== -1) {
+        this.parsedConfig.splice(configIndex, 1);
+      }
+    } else {
+      if (configIndex !== -1) {
+        const config = this.parsedConfig[configIndex];
+        const modifiedConfig = Object.assign({}, config, {
+          name,
+          value,
+          modified: true
+        });
+        if (append) {
+          this.parsedConfig.splice(configIndex + 1, 0, modifiedConfig);
+        } else {
+          this.parsedConfig[configIndex] = modifiedConfig;
+        }
+      } else {
+        const sectionIndex = this.parsedConfig.findIndex(
+          (config) => config.path === sectionPath
+        );
+        const newConfig = {
+          section,
+          subsection,
+          name,
+          value,
+          modified: true,
+          path: normalizedPath
+        };
+        if (SECTION_REGEX.test(section) && VARIABLE_NAME_REGEX.test(name)) {
+          if (sectionIndex >= 0) {
+            this.parsedConfig.splice(sectionIndex + 1, 0, newConfig);
+          } else {
+            const newSection = {
+              section,
+              subsection,
+              modified: true,
+              path: sectionPath
+            };
+            this.parsedConfig.push(newSection, newConfig);
+          }
+        }
+      }
+    }
+  }
+  toString() {
+    return this.parsedConfig.map(({ line, section, subsection, name, value, modified: modified2 = false }) => {
+      if (!modified2) {
+        return line;
+      }
+      if (name != null && value != null) {
+        if (typeof value === "string" && /[#;]/.test(value)) {
+          return `	${name} = "${value}"`;
+        }
+        return `	${name} = ${value}`;
+      }
+      if (subsection != null) {
+        return `[${section} "${subsection}"]`;
+      }
+      return `[${section}]`;
+    }).join("\n");
+  }
+};
+var GitConfigManager = class {
+  static async get({ fs, gitdir }) {
+    const text = await fs.read(`${gitdir}/config`, { encoding: "utf8" });
+    return GitConfig.from(text);
+  }
+  static async save({ fs, gitdir, config }) {
+    await fs.write(`${gitdir}/config`, config.toString(), {
+      encoding: "utf8"
+    });
+  }
+};
+var refpaths = (ref) => [
+  `${ref}`,
+  `refs/${ref}`,
+  `refs/tags/${ref}`,
+  `refs/heads/${ref}`,
+  `refs/remotes/${ref}`,
+  `refs/remotes/${ref}/HEAD`
+];
+var GIT_FILES = ["config", "description", "index", "shallow", "commondir"];
+var lock$1;
+async function acquireLock(ref, callback) {
+  if (lock$1 === void 0) lock$1 = new import_async_lock.default();
+  return lock$1.acquire(ref, callback);
+}
+var GitRefManager = class _GitRefManager {
+  static async updateRemoteRefs({
+    fs,
+    gitdir,
+    remote,
+    refs,
+    symrefs,
+    tags,
+    refspecs = void 0,
+    prune = false,
+    pruneTags = false
+  }) {
+    for (const value of refs.values()) {
+      if (!value.match(/[0-9a-f]{40}/)) {
+        throw new InvalidOidError(value);
+      }
+    }
+    const config = await GitConfigManager.get({ fs, gitdir });
+    if (!refspecs) {
+      refspecs = await config.getall(`remote.${remote}.fetch`);
+      if (refspecs.length === 0) {
+        throw new NoRefspecError(remote);
+      }
+      refspecs.unshift(`+HEAD:refs/remotes/${remote}/HEAD`);
+    }
+    const refspec = GitRefSpecSet.from(refspecs);
+    const actualRefsToWrite = /* @__PURE__ */ new Map();
+    if (pruneTags) {
+      const tags2 = await _GitRefManager.listRefs({
+        fs,
+        gitdir,
+        filepath: "refs/tags"
+      });
+      await _GitRefManager.deleteRefs({
+        fs,
+        gitdir,
+        refs: tags2.map((tag2) => `refs/tags/${tag2}`)
+      });
+    }
+    if (tags) {
+      for (const serverRef of refs.keys()) {
+        if (serverRef.startsWith("refs/tags") && !serverRef.endsWith("^{}")) {
+          if (!await _GitRefManager.exists({ fs, gitdir, ref: serverRef })) {
+            const oid = refs.get(serverRef);
+            actualRefsToWrite.set(serverRef, oid);
+          }
+        }
+      }
+    }
+    const refTranslations = refspec.translate([...refs.keys()]);
+    for (const [serverRef, translatedRef] of refTranslations) {
+      const value = refs.get(serverRef);
+      actualRefsToWrite.set(translatedRef, value);
+    }
+    const symrefTranslations = refspec.translate([...symrefs.keys()]);
+    for (const [serverRef, translatedRef] of symrefTranslations) {
+      const value = symrefs.get(serverRef);
+      const symtarget = refspec.translateOne(value);
+      if (symtarget) {
+        actualRefsToWrite.set(translatedRef, `ref: ${symtarget}`);
+      }
+    }
+    const pruned = [];
+    if (prune) {
+      for (const filepath of refspec.localNamespaces()) {
+        const refs2 = (await _GitRefManager.listRefs({
+          fs,
+          gitdir,
+          filepath
+        })).map((file) => `${filepath}/${file}`);
+        for (const ref of refs2) {
+          if (!actualRefsToWrite.has(ref)) {
+            pruned.push(ref);
+          }
+        }
+      }
+      if (pruned.length > 0) {
+        await _GitRefManager.deleteRefs({ fs, gitdir, refs: pruned });
+      }
+    }
+    for (const [key, value] of actualRefsToWrite) {
+      await acquireLock(
+        key,
+        async () => fs.write(join(gitdir, key), `${value.trim()}
+`, "utf8")
+      );
+    }
+    return { pruned };
+  }
+  // TODO: make this less crude?
+  static async writeRef({ fs, gitdir, ref, value }) {
+    if (!value.match(/[0-9a-f]{40}/)) {
+      throw new InvalidOidError(value);
+    }
+    await acquireLock(
+      ref,
+      async () => fs.write(join(gitdir, ref), `${value.trim()}
+`, "utf8")
+    );
+  }
+  static async writeSymbolicRef({ fs, gitdir, ref, value }) {
+    await acquireLock(
+      ref,
+      async () => fs.write(join(gitdir, ref), `ref: ${value.trim()}
+`, "utf8")
+    );
+  }
+  static async deleteRef({ fs, gitdir, ref }) {
+    return _GitRefManager.deleteRefs({ fs, gitdir, refs: [ref] });
+  }
+  static async deleteRefs({ fs, gitdir, refs }) {
+    await Promise.all(refs.map((ref) => fs.rm(join(gitdir, ref))));
+    let text = await acquireLock(
+      "packed-refs",
+      async () => fs.read(`${gitdir}/packed-refs`, { encoding: "utf8" })
+    );
+    const packed = GitPackedRefs.from(text);
+    const beforeSize = packed.refs.size;
+    for (const ref of refs) {
+      if (packed.refs.has(ref)) {
+        packed.delete(ref);
+      }
+    }
+    if (packed.refs.size < beforeSize) {
+      text = packed.toString();
+      await acquireLock(
+        "packed-refs",
+        async () => fs.write(`${gitdir}/packed-refs`, text, { encoding: "utf8" })
+      );
+    }
+  }
+  /**
+   * @param {object} args
+   * @param {import('../models/FileSystem.js').FileSystem} args.fs
+   * @param {string} args.gitdir
+   * @param {string} args.ref
+   * @param {number} [args.depth]
+   * @returns {Promise<string>}
+   */
+  static async resolve({ fs, gitdir, ref, depth = void 0 }) {
+    if (depth !== void 0) {
+      depth--;
+      if (depth === -1) {
+        return ref;
+      }
+    }
+    if (ref.startsWith("ref: ")) {
+      ref = ref.slice("ref: ".length);
+      return _GitRefManager.resolve({ fs, gitdir, ref, depth });
+    }
+    if (ref.length === 40 && /[0-9a-f]{40}/.test(ref)) {
+      return ref;
+    }
+    const packedMap = await _GitRefManager.packedRefs({ fs, gitdir });
+    const allpaths = refpaths(ref).filter((p) => !GIT_FILES.includes(p));
+    for (const ref2 of allpaths) {
+      const sha = await acquireLock(
+        ref2,
+        async () => await fs.read(`${gitdir}/${ref2}`, { encoding: "utf8" }) || packedMap.get(ref2)
+      );
+      if (sha) {
+        return _GitRefManager.resolve({ fs, gitdir, ref: sha.trim(), depth });
+      }
+    }
+    throw new NotFoundError(ref);
+  }
+  static async exists({ fs, gitdir, ref }) {
+    try {
+      await _GitRefManager.expand({ fs, gitdir, ref });
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+  static async expand({ fs, gitdir, ref }) {
+    if (ref.length === 40 && /[0-9a-f]{40}/.test(ref)) {
+      return ref;
+    }
+    const packedMap = await _GitRefManager.packedRefs({ fs, gitdir });
+    const allpaths = refpaths(ref);
+    for (const ref2 of allpaths) {
+      const refExists = await acquireLock(
+        ref2,
+        async () => fs.exists(`${gitdir}/${ref2}`)
+      );
+      if (refExists) return ref2;
+      if (packedMap.has(ref2)) return ref2;
+    }
+    throw new NotFoundError(ref);
+  }
+  static async expandAgainstMap({ ref, map }) {
+    const allpaths = refpaths(ref);
+    for (const ref2 of allpaths) {
+      if (await map.has(ref2)) return ref2;
+    }
+    throw new NotFoundError(ref);
+  }
+  static resolveAgainstMap({ ref, fullref = ref, depth = void 0, map }) {
+    if (depth !== void 0) {
+      depth--;
+      if (depth === -1) {
+        return { fullref, oid: ref };
+      }
+    }
+    if (ref.startsWith("ref: ")) {
+      ref = ref.slice("ref: ".length);
+      return _GitRefManager.resolveAgainstMap({ ref, fullref, depth, map });
+    }
+    if (ref.length === 40 && /[0-9a-f]{40}/.test(ref)) {
+      return { fullref, oid: ref };
+    }
+    const allpaths = refpaths(ref);
+    for (const ref2 of allpaths) {
+      const sha = map.get(ref2);
+      if (sha) {
+        return _GitRefManager.resolveAgainstMap({
+          ref: sha.trim(),
+          fullref: ref2,
+          depth,
+          map
+        });
+      }
+    }
+    throw new NotFoundError(ref);
+  }
+  static async packedRefs({ fs, gitdir }) {
+    const text = await acquireLock(
+      "packed-refs",
+      async () => fs.read(`${gitdir}/packed-refs`, { encoding: "utf8" })
+    );
+    const packed = GitPackedRefs.from(text);
+    return packed.refs;
+  }
+  // List all the refs that match the `filepath` prefix
+  static async listRefs({ fs, gitdir, filepath }) {
+    const packedMap = _GitRefManager.packedRefs({ fs, gitdir });
+    let files = null;
+    try {
+      files = await fs.readdirDeep(`${gitdir}/${filepath}`);
+      files = files.map((x) => x.replace(`${gitdir}/${filepath}/`, ""));
+    } catch (err) {
+      files = [];
+    }
+    for (let key of (await packedMap).keys()) {
+      if (key.startsWith(filepath)) {
+        key = key.replace(filepath + "/", "");
+        if (!files.includes(key)) {
+          files.push(key);
+        }
+      }
+    }
+    files.sort(compareRefNames);
+    return files;
+  }
+  static async listBranches({ fs, gitdir, remote }) {
+    if (remote) {
+      return _GitRefManager.listRefs({
+        fs,
+        gitdir,
+        filepath: `refs/remotes/${remote}`
+      });
+    } else {
+      return _GitRefManager.listRefs({ fs, gitdir, filepath: `refs/heads` });
+    }
+  }
+  static async listTags({ fs, gitdir }) {
+    const tags = await _GitRefManager.listRefs({
+      fs,
+      gitdir,
+      filepath: `refs/tags`
+    });
+    return tags.filter((x) => !x.endsWith("^{}"));
+  }
+};
+function compareTreeEntryPath(a, b) {
+  return compareStrings(appendSlashIfDir(a), appendSlashIfDir(b));
+}
+function appendSlashIfDir(entry) {
+  return entry.mode === "040000" ? entry.path + "/" : entry.path;
+}
+function mode2type$1(mode) {
+  switch (mode) {
+    case "040000":
+      return "tree";
+    case "100644":
+      return "blob";
+    case "100755":
+      return "blob";
+    case "120000":
+      return "blob";
+    case "160000":
+      return "commit";
+  }
+  throw new InternalError(`Unexpected GitTree entry mode: ${mode}`);
+}
+function parseBuffer(buffer) {
+  const _entries = [];
+  let cursor = 0;
+  while (cursor < buffer.length) {
+    const space = buffer.indexOf(32, cursor);
+    if (space === -1) {
+      throw new InternalError(
+        `GitTree: Error parsing buffer at byte location ${cursor}: Could not find the next space character.`
+      );
+    }
+    const nullchar = buffer.indexOf(0, cursor);
+    if (nullchar === -1) {
+      throw new InternalError(
+        `GitTree: Error parsing buffer at byte location ${cursor}: Could not find the next null character.`
+      );
+    }
+    let mode = buffer.slice(cursor, space).toString("utf8");
+    if (mode === "40000") mode = "040000";
+    const type = mode2type$1(mode);
+    const path = buffer.slice(space + 1, nullchar).toString("utf8");
+    if (path.includes("\\") || path.includes("/")) {
+      throw new UnsafeFilepathError(path);
+    }
+    const oid = buffer.slice(nullchar + 1, nullchar + 21).toString("hex");
+    cursor = nullchar + 21;
+    _entries.push({ mode, path, oid, type });
+  }
+  return _entries;
+}
+function limitModeToAllowed(mode) {
+  if (typeof mode === "number") {
+    mode = mode.toString(8);
+  }
+  if (mode.match(/^0?4.*/)) return "040000";
+  if (mode.match(/^1006.*/)) return "100644";
+  if (mode.match(/^1007.*/)) return "100755";
+  if (mode.match(/^120.*/)) return "120000";
+  if (mode.match(/^160.*/)) return "160000";
+  throw new InternalError(`Could not understand file mode: ${mode}`);
+}
+function nudgeIntoShape(entry) {
+  if (!entry.oid && entry.sha) {
+    entry.oid = entry.sha;
+  }
+  entry.mode = limitModeToAllowed(entry.mode);
+  if (!entry.type) {
+    entry.type = mode2type$1(entry.mode);
+  }
+  return entry;
+}
+var GitTree = class _GitTree {
+  constructor(entries) {
+    if (import_buffer.Buffer.isBuffer(entries)) {
+      this._entries = parseBuffer(entries);
+    } else if (Array.isArray(entries)) {
+      this._entries = entries.map(nudgeIntoShape);
+    } else {
+      throw new InternalError("invalid type passed to GitTree constructor");
+    }
+    this._entries.sort(comparePath);
+  }
+  static from(tree) {
+    return new _GitTree(tree);
+  }
+  render() {
+    return this._entries.map((entry) => `${entry.mode} ${entry.type} ${entry.oid}    ${entry.path}`).join("\n");
+  }
+  toObject() {
+    const entries = [...this._entries];
+    entries.sort(compareTreeEntryPath);
+    return import_buffer.Buffer.concat(
+      entries.map((entry) => {
+        const mode = import_buffer.Buffer.from(entry.mode.replace(/^0/, ""));
+        const space = import_buffer.Buffer.from(" ");
+        const path = import_buffer.Buffer.from(entry.path, "utf8");
+        const nullchar = import_buffer.Buffer.from([0]);
+        const oid = import_buffer.Buffer.from(entry.oid, "hex");
+        return import_buffer.Buffer.concat([mode, space, path, nullchar, oid]);
+      })
+    );
+  }
+  /**
+   * @returns {TreeEntry[]}
+   */
+  entries() {
+    return this._entries;
+  }
+  *[Symbol.iterator]() {
+    for (const entry of this._entries) {
+      yield entry;
+    }
+  }
+};
+var GitObject = class {
+  static wrap({ type, object }) {
+    return import_buffer.Buffer.concat([
+      import_buffer.Buffer.from(`${type} ${object.byteLength.toString()}\0`),
+      import_buffer.Buffer.from(object)
+    ]);
+  }
+  static unwrap(buffer) {
+    const s = buffer.indexOf(32);
+    const i = buffer.indexOf(0);
+    const type = buffer.slice(0, s).toString("utf8");
+    const length = buffer.slice(s + 1, i).toString("utf8");
+    const actualLength = buffer.length - (i + 1);
+    if (parseInt(length) !== actualLength) {
+      throw new InternalError(
+        `Length mismatch: expected ${length} bytes but got ${actualLength} instead.`
+      );
+    }
+    return {
+      type,
+      object: import_buffer.Buffer.from(buffer.slice(i + 1))
+    };
+  }
+};
+async function readObjectLoose({ fs, gitdir, oid }) {
+  const source = `objects/${oid.slice(0, 2)}/${oid.slice(2)}`;
+  const file = await fs.read(`${gitdir}/${source}`);
+  if (!file) {
+    return null;
+  }
+  return { object: file, format: "deflated", source };
+}
+function applyDelta(delta, source) {
+  const reader = new BufferCursor(delta);
+  const sourceSize = readVarIntLE(reader);
+  if (sourceSize !== source.byteLength) {
+    throw new InternalError(
+      `applyDelta expected source buffer to be ${sourceSize} bytes but the provided buffer was ${source.length} bytes`
+    );
+  }
+  const targetSize = readVarIntLE(reader);
+  let target;
+  const firstOp = readOp(reader, source);
+  if (firstOp.byteLength === targetSize) {
+    target = firstOp;
+  } else {
+    target = import_buffer.Buffer.alloc(targetSize);
+    const writer = new BufferCursor(target);
+    writer.copy(firstOp);
+    while (!reader.eof()) {
+      writer.copy(readOp(reader, source));
+    }
+    const tell = writer.tell();
+    if (targetSize !== tell) {
+      throw new InternalError(
+        `applyDelta expected target buffer to be ${targetSize} bytes but the resulting buffer was ${tell} bytes`
+      );
+    }
+  }
+  return target;
+}
+function readVarIntLE(reader) {
+  let result = 0;
+  let shift = 0;
+  let byte = null;
+  do {
+    byte = reader.readUInt8();
+    result |= (byte & 127) << shift;
+    shift += 7;
+  } while (byte & 128);
+  return result;
+}
+function readCompactLE(reader, flags, size) {
+  let result = 0;
+  let shift = 0;
+  while (size--) {
+    if (flags & 1) {
+      result |= reader.readUInt8() << shift;
+    }
+    flags >>= 1;
+    shift += 8;
+  }
+  return result;
+}
+function readOp(reader, source) {
+  const byte = reader.readUInt8();
+  const COPY = 128;
+  const OFFS = 15;
+  const SIZE = 112;
+  if (byte & COPY) {
+    const offset = readCompactLE(reader, byte & OFFS, 4);
+    let size = readCompactLE(reader, (byte & SIZE) >> 4, 3);
+    if (size === 0) size = 65536;
+    return source.slice(offset, offset + size);
+  } else {
+    return reader.slice(byte);
+  }
+}
+function fromValue(value) {
+  let queue = [value];
+  return {
+    next() {
+      return Promise.resolve({ done: queue.length === 0, value: queue.pop() });
+    },
+    return() {
+      queue = [];
+      return {};
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    }
+  };
+}
+function getIterator(iterable) {
+  if (iterable[Symbol.asyncIterator]) {
+    return iterable[Symbol.asyncIterator]();
+  }
+  if (iterable[Symbol.iterator]) {
+    return iterable[Symbol.iterator]();
+  }
+  if (iterable.next) {
+    return iterable;
+  }
+  return fromValue(iterable);
+}
+var StreamReader = class {
+  constructor(stream) {
+    if (typeof import_buffer.Buffer === "undefined") {
+      throw new Error("Missing Buffer dependency");
+    }
+    this.stream = getIterator(stream);
+    this.buffer = null;
+    this.cursor = 0;
+    this.undoCursor = 0;
+    this.started = false;
+    this._ended = false;
+    this._discardedBytes = 0;
+  }
+  eof() {
+    return this._ended && this.cursor === this.buffer.length;
+  }
+  tell() {
+    return this._discardedBytes + this.cursor;
+  }
+  async byte() {
+    if (this.eof()) return;
+    if (!this.started) await this._init();
+    if (this.cursor === this.buffer.length) {
+      await this._loadnext();
+      if (this._ended) return;
+    }
+    this._moveCursor(1);
+    return this.buffer[this.undoCursor];
+  }
+  async chunk() {
+    if (this.eof()) return;
+    if (!this.started) await this._init();
+    if (this.cursor === this.buffer.length) {
+      await this._loadnext();
+      if (this._ended) return;
+    }
+    this._moveCursor(this.buffer.length);
+    return this.buffer.slice(this.undoCursor, this.cursor);
+  }
+  async read(n) {
+    if (this.eof()) return;
+    if (!this.started) await this._init();
+    if (this.cursor + n > this.buffer.length) {
+      this._trim();
+      await this._accumulate(n);
+    }
+    this._moveCursor(n);
+    return this.buffer.slice(this.undoCursor, this.cursor);
+  }
+  async skip(n) {
+    if (this.eof()) return;
+    if (!this.started) await this._init();
+    if (this.cursor + n > this.buffer.length) {
+      this._trim();
+      await this._accumulate(n);
+    }
+    this._moveCursor(n);
+  }
+  async undo() {
+    this.cursor = this.undoCursor;
+  }
+  async _next() {
+    this.started = true;
+    let { done, value } = await this.stream.next();
+    if (done) {
+      this._ended = true;
+      if (!value) return import_buffer.Buffer.alloc(0);
+    }
+    if (value) {
+      value = import_buffer.Buffer.from(value);
+    }
+    return value;
+  }
+  _trim() {
+    this.buffer = this.buffer.slice(this.undoCursor);
+    this.cursor -= this.undoCursor;
+    this._discardedBytes += this.undoCursor;
+    this.undoCursor = 0;
+  }
+  _moveCursor(n) {
+    this.undoCursor = this.cursor;
+    this.cursor += n;
+    if (this.cursor > this.buffer.length) {
+      this.cursor = this.buffer.length;
+    }
+  }
+  async _accumulate(n) {
+    if (this._ended) return;
+    const buffers = [this.buffer];
+    while (this.cursor + n > lengthBuffers(buffers)) {
+      const nextbuffer = await this._next();
+      if (this._ended) break;
+      buffers.push(nextbuffer);
+    }
+    this.buffer = import_buffer.Buffer.concat(buffers);
+  }
+  async _loadnext() {
+    this._discardedBytes += this.buffer.length;
+    this.undoCursor = 0;
+    this.cursor = 0;
+    this.buffer = await this._next();
+  }
+  async _init() {
+    this.buffer = await this._next();
+  }
+};
+function lengthBuffers(buffers) {
+  return buffers.reduce((acc, buffer) => acc + buffer.length, 0);
+}
+async function listpack(stream, onData) {
+  const reader = new StreamReader(stream);
+  let PACK = await reader.read(4);
+  PACK = PACK.toString("utf8");
+  if (PACK !== "PACK") {
+    throw new InternalError(`Invalid PACK header '${PACK}'`);
+  }
+  let version2 = await reader.read(4);
+  version2 = version2.readUInt32BE(0);
+  if (version2 !== 2) {
+    throw new InternalError(`Invalid packfile version: ${version2}`);
+  }
+  let numObjects = await reader.read(4);
+  numObjects = numObjects.readUInt32BE(0);
+  if (numObjects < 1) return;
+  while (!reader.eof() && numObjects--) {
+    const offset = reader.tell();
+    const { type, length, ofs, reference } = await parseHeader(reader);
+    const inflator = new import_pako.default.Inflate();
+    while (!inflator.result) {
+      const chunk = await reader.chunk();
+      if (!chunk) break;
+      inflator.push(chunk, false);
+      if (inflator.err) {
+        throw new InternalError(`Pako error: ${inflator.msg}`);
+      }
+      if (inflator.result) {
+        if (inflator.result.length !== length) {
+          throw new InternalError(
+            `Inflated object size is different from that stated in packfile.`
+          );
+        }
+        await reader.undo();
+        await reader.read(chunk.length - inflator.strm.avail_in);
+        const end = reader.tell();
+        await onData({
+          data: inflator.result,
+          type,
+          num: numObjects,
+          offset,
+          end,
+          reference,
+          ofs
+        });
+      }
+    }
+  }
+}
+async function parseHeader(reader) {
+  let byte = await reader.byte();
+  const type = byte >> 4 & 7;
+  let length = byte & 15;
+  if (byte & 128) {
+    let shift = 4;
+    do {
+      byte = await reader.byte();
+      length |= (byte & 127) << shift;
+      shift += 7;
+    } while (byte & 128);
+  }
+  let ofs;
+  let reference;
+  if (type === 6) {
+    let shift = 0;
+    ofs = 0;
+    const bytes = [];
+    do {
+      byte = await reader.byte();
+      ofs |= (byte & 127) << shift;
+      shift += 7;
+      bytes.push(byte);
+    } while (byte & 128);
+    reference = import_buffer.Buffer.from(bytes);
+  }
+  if (type === 7) {
+    const buf = await reader.read(20);
+    reference = buf;
+  }
+  return { type, length, ofs, reference };
+}
+var supportsDecompressionStream = false;
+async function inflate(buffer) {
+  if (supportsDecompressionStream === null) {
+    supportsDecompressionStream = testDecompressionStream();
+  }
+  return supportsDecompressionStream ? browserInflate(buffer) : import_pako.default.inflate(buffer);
+}
+async function browserInflate(buffer) {
+  const ds = new DecompressionStream("deflate");
+  const d = new Blob([buffer]).stream().pipeThrough(ds);
+  return new Uint8Array(await new Response(d).arrayBuffer());
+}
+function testDecompressionStream() {
+  try {
+    const ds = new DecompressionStream("deflate");
+    if (ds) return true;
+  } catch (_) {
+  }
+  return false;
+}
+function decodeVarInt(reader) {
+  const bytes = [];
+  let byte = 0;
+  let multibyte = 0;
+  do {
+    byte = reader.readUInt8();
+    const lastSeven = byte & 127;
+    bytes.push(lastSeven);
+    multibyte = byte & 128;
+  } while (multibyte);
+  return bytes.reduce((a, b) => a + 1 << 7 | b, -1);
+}
+function otherVarIntDecode(reader, startWith) {
+  let result = startWith;
+  let shift = 4;
+  let byte = null;
+  do {
+    byte = reader.readUInt8();
+    result |= (byte & 127) << shift;
+    shift += 7;
+  } while (byte & 128);
+  return result;
+}
+var GitPackIndex = class _GitPackIndex {
+  constructor(stuff) {
+    Object.assign(this, stuff);
+    this.offsetCache = {};
+  }
+  static async fromIdx({ idx, getExternalRefDelta }) {
+    const reader = new BufferCursor(idx);
+    const magic = reader.slice(4).toString("hex");
+    if (magic !== "ff744f63") {
+      return;
+    }
+    const version2 = reader.readUInt32BE();
+    if (version2 !== 2) {
+      throw new InternalError(
+        `Unable to read version ${version2} packfile IDX. (Only version 2 supported)`
+      );
+    }
+    if (idx.byteLength > 2048 * 1024 * 1024) {
+      throw new InternalError(
+        `To keep implementation simple, I haven't implemented the layer 5 feature needed to support packfiles > 2GB in size.`
+      );
+    }
+    reader.seek(reader.tell() + 4 * 255);
+    const size = reader.readUInt32BE();
+    const hashes = [];
+    for (let i = 0; i < size; i++) {
+      const hash = reader.slice(20).toString("hex");
+      hashes[i] = hash;
+    }
+    reader.seek(reader.tell() + 4 * size);
+    const offsets = /* @__PURE__ */ new Map();
+    for (let i = 0; i < size; i++) {
+      offsets.set(hashes[i], reader.readUInt32BE());
+    }
+    const packfileSha = reader.slice(20).toString("hex");
+    return new _GitPackIndex({
+      hashes,
+      crcs: {},
+      offsets,
+      packfileSha,
+      getExternalRefDelta
+    });
+  }
+  static async fromPack({ pack, getExternalRefDelta, onProgress }) {
+    const listpackTypes = {
+      1: "commit",
+      2: "tree",
+      3: "blob",
+      4: "tag",
+      6: "ofs-delta",
+      7: "ref-delta"
+    };
+    const offsetToObject = {};
+    const packfileSha = pack.slice(-20).toString("hex");
+    const hashes = [];
+    const crcs = {};
+    const offsets = /* @__PURE__ */ new Map();
+    let totalObjectCount = null;
+    let lastPercent = null;
+    await listpack([pack], async ({ data, type, reference, offset, num: num2 }) => {
+      if (totalObjectCount === null) totalObjectCount = num2;
+      const percent = Math.floor(
+        (totalObjectCount - num2) * 100 / totalObjectCount
+      );
+      if (percent !== lastPercent) {
+        if (onProgress) {
+          await onProgress({
+            phase: "Receiving objects",
+            loaded: totalObjectCount - num2,
+            total: totalObjectCount
+          });
+        }
+      }
+      lastPercent = percent;
+      type = listpackTypes[type];
+      if (["commit", "tree", "blob", "tag"].includes(type)) {
+        offsetToObject[offset] = {
+          type,
+          offset
+        };
+      } else if (type === "ofs-delta") {
+        offsetToObject[offset] = {
+          type,
+          offset
+        };
+      } else if (type === "ref-delta") {
+        offsetToObject[offset] = {
+          type,
+          offset
+        };
+      }
+    });
+    const offsetArray = Object.keys(offsetToObject).map(Number);
+    for (const [i, start] of offsetArray.entries()) {
+      const end = i + 1 === offsetArray.length ? pack.byteLength - 20 : offsetArray[i + 1];
+      const o = offsetToObject[start];
+      const crc = import_crc_32.default.buf(pack.slice(start, end)) >>> 0;
+      o.end = end;
+      o.crc = crc;
+    }
+    const p = new _GitPackIndex({
+      pack: Promise.resolve(pack),
+      packfileSha,
+      crcs,
+      hashes,
+      offsets,
+      getExternalRefDelta
+    });
+    lastPercent = null;
+    let count = 0;
+    const objectsByDepth = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    for (let offset in offsetToObject) {
+      offset = Number(offset);
+      const percent = Math.floor(count * 100 / totalObjectCount);
+      if (percent !== lastPercent) {
+        if (onProgress) {
+          await onProgress({
+            phase: "Resolving deltas",
+            loaded: count,
+            total: totalObjectCount
+          });
+        }
+      }
+      count++;
+      lastPercent = percent;
+      const o = offsetToObject[offset];
+      if (o.oid) continue;
+      try {
+        p.readDepth = 0;
+        p.externalReadDepth = 0;
+        const { type, object } = await p.readSlice({ start: offset });
+        objectsByDepth[p.readDepth] += 1;
+        const oid = await shasum(GitObject.wrap({ type, object }));
+        o.oid = oid;
+        hashes.push(oid);
+        offsets.set(oid, offset);
+        crcs[oid] = o.crc;
+      } catch (err) {
+        continue;
+      }
+    }
+    hashes.sort();
+    return p;
+  }
+  async toBuffer() {
+    const buffers = [];
+    const write = (str, encoding) => {
+      buffers.push(import_buffer.Buffer.from(str, encoding));
+    };
+    write("ff744f63", "hex");
+    write("00000002", "hex");
+    const fanoutBuffer = new BufferCursor(import_buffer.Buffer.alloc(256 * 4));
+    for (let i = 0; i < 256; i++) {
+      let count = 0;
+      for (const hash of this.hashes) {
+        if (parseInt(hash.slice(0, 2), 16) <= i) count++;
+      }
+      fanoutBuffer.writeUInt32BE(count);
+    }
+    buffers.push(fanoutBuffer.buffer);
+    for (const hash of this.hashes) {
+      write(hash, "hex");
+    }
+    const crcsBuffer = new BufferCursor(import_buffer.Buffer.alloc(this.hashes.length * 4));
+    for (const hash of this.hashes) {
+      crcsBuffer.writeUInt32BE(this.crcs[hash]);
+    }
+    buffers.push(crcsBuffer.buffer);
+    const offsetsBuffer = new BufferCursor(import_buffer.Buffer.alloc(this.hashes.length * 4));
+    for (const hash of this.hashes) {
+      offsetsBuffer.writeUInt32BE(this.offsets.get(hash));
+    }
+    buffers.push(offsetsBuffer.buffer);
+    write(this.packfileSha, "hex");
+    const totalBuffer = import_buffer.Buffer.concat(buffers);
+    const sha = await shasum(totalBuffer);
+    const shaBuffer = import_buffer.Buffer.alloc(20);
+    shaBuffer.write(sha, "hex");
+    return import_buffer.Buffer.concat([totalBuffer, shaBuffer]);
+  }
+  async load({ pack }) {
+    this.pack = pack;
+  }
+  async unload() {
+    this.pack = null;
+  }
+  async read({ oid }) {
+    if (!this.offsets.get(oid)) {
+      if (this.getExternalRefDelta) {
+        this.externalReadDepth++;
+        return this.getExternalRefDelta(oid);
+      } else {
+        throw new InternalError(`Could not read object ${oid} from packfile`);
+      }
+    }
+    const start = this.offsets.get(oid);
+    return this.readSlice({ start });
+  }
+  async readSlice({ start }) {
+    if (this.offsetCache[start]) {
+      return Object.assign({}, this.offsetCache[start]);
+    }
+    this.readDepth++;
+    const types2 = {
+      16: "commit",
+      32: "tree",
+      48: "blob",
+      64: "tag",
+      96: "ofs_delta",
+      112: "ref_delta"
+    };
+    if (!this.pack) {
+      throw new InternalError(
+        "Tried to read from a GitPackIndex with no packfile loaded into memory"
+      );
+    }
+    const raw = (await this.pack).slice(start);
+    const reader = new BufferCursor(raw);
+    const byte = reader.readUInt8();
+    const btype = byte & 112;
+    let type = types2[btype];
+    if (type === void 0) {
+      throw new InternalError("Unrecognized type: 0b" + btype.toString(2));
+    }
+    const lastFour = byte & 15;
+    let length = lastFour;
+    const multibyte = byte & 128;
+    if (multibyte) {
+      length = otherVarIntDecode(reader, lastFour);
+    }
+    let base = null;
+    let object = null;
+    if (type === "ofs_delta") {
+      const offset = decodeVarInt(reader);
+      const baseOffset = start - offset;
+      ({ object: base, type } = await this.readSlice({ start: baseOffset }));
+    }
+    if (type === "ref_delta") {
+      const oid = reader.slice(20).toString("hex");
+      ({ object: base, type } = await this.read({ oid }));
+    }
+    const buffer = raw.slice(reader.tell());
+    object = import_buffer.Buffer.from(await inflate(buffer));
+    if (object.byteLength !== length) {
+      throw new InternalError(
+        `Packfile told us object would have length ${length} but it had length ${object.byteLength}`
+      );
+    }
+    if (base) {
+      object = import_buffer.Buffer.from(applyDelta(object, base));
+    }
+    if (this.readDepth > 3) {
+      this.offsetCache[start] = { type, object };
+    }
+    return { type, format: "content", object };
+  }
+};
+var PackfileCache = /* @__PURE__ */ Symbol("PackfileCache");
+async function loadPackIndex({
+  fs,
+  filename,
+  getExternalRefDelta,
+  emitter,
+  emitterPrefix
+}) {
+  const idx = await fs.read(filename);
+  return GitPackIndex.fromIdx({ idx, getExternalRefDelta });
+}
+function readPackIndex({
+  fs,
+  cache,
+  filename,
+  getExternalRefDelta,
+  emitter,
+  emitterPrefix
+}) {
+  if (!cache[PackfileCache]) cache[PackfileCache] = /* @__PURE__ */ new Map();
+  let p = cache[PackfileCache].get(filename);
+  if (!p) {
+    p = loadPackIndex({
+      fs,
+      filename,
+      getExternalRefDelta,
+      emitter,
+      emitterPrefix
+    });
+    cache[PackfileCache].set(filename, p);
+  }
+  return p;
+}
+async function readObjectPacked({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  format = "content",
+  getExternalRefDelta
+}) {
+  let list = await fs.readdir(join(gitdir, "objects/pack"));
+  list = list.filter((x) => x.endsWith(".idx"));
+  for (const filename of list) {
+    const indexFile = `${gitdir}/objects/pack/${filename}`;
+    const p = await readPackIndex({
+      fs,
+      cache,
+      filename: indexFile,
+      getExternalRefDelta
+    });
+    if (p.error) throw new InternalError(p.error);
+    if (p.offsets.has(oid)) {
+      if (!p.pack) {
+        const packFile = indexFile.replace(/idx$/, "pack");
+        p.pack = fs.read(packFile);
+      }
+      const result = await p.read({ oid, getExternalRefDelta });
+      result.format = "content";
+      result.source = `objects/pack/${filename.replace(/idx$/, "pack")}`;
+      return result;
+    }
+  }
+  return null;
+}
+async function _readObject({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  format = "content"
+}) {
+  const getExternalRefDelta = (oid2) => _readObject({ fs, cache, gitdir, oid: oid2 });
+  let result;
+  if (oid === "4b825dc642cb6eb9a060e54bf8d69288fbee4904") {
+    result = { format: "wrapped", object: import_buffer.Buffer.from(`tree 0\0`) };
+  }
+  if (!result) {
+    result = await readObjectLoose({ fs, gitdir, oid });
+  }
+  if (!result) {
+    result = await readObjectPacked({
+      fs,
+      cache,
+      gitdir,
+      oid,
+      getExternalRefDelta
+    });
+    if (!result) {
+      throw new NotFoundError(oid);
+    }
+    return result;
+  }
+  if (format === "deflated") {
+    return result;
+  }
+  if (result.format === "deflated") {
+    result.object = import_buffer.Buffer.from(await inflate(result.object));
+    result.format = "wrapped";
+  }
+  if (format === "wrapped") {
+    return result;
+  }
+  const sha = await shasum(result.object);
+  if (sha !== oid) {
+    throw new InternalError(
+      `SHA check failed! Expected ${oid}, computed ${sha}`
+    );
+  }
+  const { object, type } = GitObject.unwrap(result.object);
+  result.type = type;
+  result.object = object;
+  result.format = "content";
+  if (format === "content") {
+    return result;
+  }
+  throw new InternalError(`invalid requested format "${format}"`);
+}
+var AlreadyExistsError = class _AlreadyExistsError extends BaseError {
+  /**
+   * @param {'note'|'remote'|'tag'|'branch'} noun
+   * @param {string} where
+   * @param {boolean} canForce
+   */
+  constructor(noun, where, canForce = true) {
+    super(
+      `Failed to create ${noun} at ${where} because it already exists.${canForce ? ` (Hint: use 'force: true' parameter to overwrite existing ${noun}.)` : ""}`
+    );
+    this.code = this.name = _AlreadyExistsError.code;
+    this.data = { noun, where, canForce };
+  }
+};
+AlreadyExistsError.code = "AlreadyExistsError";
+var AmbiguousError = class _AmbiguousError extends BaseError {
+  /**
+   * @param {'oids'|'refs'} nouns
+   * @param {string} short
+   * @param {string[]} matches
+   */
+  constructor(nouns, short, matches) {
+    super(
+      `Found multiple ${nouns} matching "${short}" (${matches.join(
+        ", "
+      )}). Use a longer abbreviation length to disambiguate them.`
+    );
+    this.code = this.name = _AmbiguousError.code;
+    this.data = { nouns, short, matches };
+  }
+};
+AmbiguousError.code = "AmbiguousError";
+var CheckoutConflictError = class _CheckoutConflictError extends BaseError {
+  /**
+   * @param {string[]} filepaths
+   */
+  constructor(filepaths) {
+    super(
+      `Your local changes to the following files would be overwritten by checkout: ${filepaths.join(
+        ", "
+      )}`
+    );
+    this.code = this.name = _CheckoutConflictError.code;
+    this.data = { filepaths };
+  }
+};
+CheckoutConflictError.code = "CheckoutConflictError";
+var CommitNotFetchedError = class _CommitNotFetchedError extends BaseError {
+  /**
+   * @param {string} ref
+   * @param {string} oid
+   */
+  constructor(ref, oid) {
+    super(
+      `Failed to checkout "${ref}" because commit ${oid} is not available locally. Do a git fetch to make the branch available locally.`
+    );
+    this.code = this.name = _CommitNotFetchedError.code;
+    this.data = { ref, oid };
+  }
+};
+CommitNotFetchedError.code = "CommitNotFetchedError";
+var EmptyServerResponseError = class _EmptyServerResponseError extends BaseError {
+  constructor() {
+    super(`Empty response from git server.`);
+    this.code = this.name = _EmptyServerResponseError.code;
+    this.data = {};
+  }
+};
+EmptyServerResponseError.code = "EmptyServerResponseError";
+var FastForwardError = class _FastForwardError extends BaseError {
+  constructor() {
+    super(`A simple fast-forward merge was not possible.`);
+    this.code = this.name = _FastForwardError.code;
+    this.data = {};
+  }
+};
+FastForwardError.code = "FastForwardError";
+var GitPushError = class _GitPushError extends BaseError {
+  /**
+   * @param {string} prettyDetails
+   * @param {PushResult} result
+   */
+  constructor(prettyDetails, result) {
+    super(`One or more branches were not updated: ${prettyDetails}`);
+    this.code = this.name = _GitPushError.code;
+    this.data = { prettyDetails, result };
+  }
+};
+GitPushError.code = "GitPushError";
+var HttpError = class _HttpError extends BaseError {
+  /**
+   * @param {number} statusCode
+   * @param {string} statusMessage
+   * @param {string} response
+   */
+  constructor(statusCode, statusMessage, response) {
+    super(`HTTP Error: ${statusCode} ${statusMessage}`);
+    this.code = this.name = _HttpError.code;
+    this.data = { statusCode, statusMessage, response };
+  }
+};
+HttpError.code = "HttpError";
+var InvalidFilepathError = class _InvalidFilepathError extends BaseError {
+  /**
+   * @param {'leading-slash'|'trailing-slash'|'directory'} [reason]
+   */
+  constructor(reason) {
+    let message = "invalid filepath";
+    if (reason === "leading-slash" || reason === "trailing-slash") {
+      message = `"filepath" parameter should not include leading or trailing directory separators because these can cause problems on some platforms.`;
+    } else if (reason === "directory") {
+      message = `"filepath" should not be a directory.`;
+    }
+    super(message);
+    this.code = this.name = _InvalidFilepathError.code;
+    this.data = { reason };
+  }
+};
+InvalidFilepathError.code = "InvalidFilepathError";
+var InvalidRefNameError = class _InvalidRefNameError extends BaseError {
+  /**
+   * @param {string} ref
+   * @param {string} suggestion
+   * @param {boolean} canForce
+   */
+  constructor(ref, suggestion) {
+    super(
+      `"${ref}" would be an invalid git reference. (Hint: a valid alternative would be "${suggestion}".)`
+    );
+    this.code = this.name = _InvalidRefNameError.code;
+    this.data = { ref, suggestion };
+  }
+};
+InvalidRefNameError.code = "InvalidRefNameError";
+var MaxDepthError = class _MaxDepthError extends BaseError {
+  /**
+   * @param {number} depth
+   */
+  constructor(depth) {
+    super(`Maximum search depth of ${depth} exceeded.`);
+    this.code = this.name = _MaxDepthError.code;
+    this.data = { depth };
+  }
+};
+MaxDepthError.code = "MaxDepthError";
+var MergeNotSupportedError = class _MergeNotSupportedError extends BaseError {
+  constructor() {
+    super(`Merges with conflicts are not supported yet.`);
+    this.code = this.name = _MergeNotSupportedError.code;
+    this.data = {};
+  }
+};
+MergeNotSupportedError.code = "MergeNotSupportedError";
+var MergeConflictError = class _MergeConflictError extends BaseError {
+  /**
+   * @param {Array<string>} filepaths
+   * @param {Array<string>} bothModified
+   * @param {Array<string>} deleteByUs
+   * @param {Array<string>} deleteByTheirs
+   */
+  constructor(filepaths, bothModified, deleteByUs, deleteByTheirs) {
+    super(
+      `Automatic merge failed with one or more merge conflicts in the following files: ${filepaths.toString()}. Fix conflicts then commit the result.`
+    );
+    this.code = this.name = _MergeConflictError.code;
+    this.data = { filepaths, bothModified, deleteByUs, deleteByTheirs };
+  }
+};
+MergeConflictError.code = "MergeConflictError";
+var MissingNameError = class _MissingNameError extends BaseError {
+  /**
+   * @param {'author'|'committer'|'tagger'} role
+   */
+  constructor(role) {
+    super(
+      `No name was provided for ${role} in the argument or in the .git/config file.`
+    );
+    this.code = this.name = _MissingNameError.code;
+    this.data = { role };
+  }
+};
+MissingNameError.code = "MissingNameError";
+var MissingParameterError = class _MissingParameterError extends BaseError {
+  /**
+   * @param {string} parameter
+   */
+  constructor(parameter) {
+    super(
+      `The function requires a "${parameter}" parameter but none was provided.`
+    );
+    this.code = this.name = _MissingParameterError.code;
+    this.data = { parameter };
+  }
+};
+MissingParameterError.code = "MissingParameterError";
+var MultipleGitError = class _MultipleGitError extends BaseError {
+  /**
+   * @param {Error[]} errors
+   * @param {string} message
+   */
+  constructor(errors) {
+    super(
+      `There are multiple errors that were thrown by the method. Please refer to the "errors" property to see more`
+    );
+    this.code = this.name = _MultipleGitError.code;
+    this.data = { errors };
+    this.errors = errors;
+  }
+};
+MultipleGitError.code = "MultipleGitError";
+var ParseError = class _ParseError extends BaseError {
+  /**
+   * @param {string} expected
+   * @param {string} actual
+   */
+  constructor(expected, actual) {
+    super(`Expected "${expected}" but received "${actual}".`);
+    this.code = this.name = _ParseError.code;
+    this.data = { expected, actual };
+  }
+};
+ParseError.code = "ParseError";
+var PushRejectedError = class _PushRejectedError extends BaseError {
+  /**
+   * @param {'not-fast-forward'|'tag-exists'} reason
+   */
+  constructor(reason) {
+    let message = "";
+    if (reason === "not-fast-forward") {
+      message = " because it was not a simple fast-forward";
+    } else if (reason === "tag-exists") {
+      message = " because tag already exists";
+    }
+    super(`Push rejected${message}. Use "force: true" to override.`);
+    this.code = this.name = _PushRejectedError.code;
+    this.data = { reason };
+  }
+};
+PushRejectedError.code = "PushRejectedError";
+var RemoteCapabilityError = class _RemoteCapabilityError extends BaseError {
+  /**
+   * @param {'shallow'|'deepen-since'|'deepen-not'|'deepen-relative'} capability
+   * @param {'depth'|'since'|'exclude'|'relative'} parameter
+   */
+  constructor(capability, parameter) {
+    super(
+      `Remote does not support the "${capability}" so the "${parameter}" parameter cannot be used.`
+    );
+    this.code = this.name = _RemoteCapabilityError.code;
+    this.data = { capability, parameter };
+  }
+};
+RemoteCapabilityError.code = "RemoteCapabilityError";
+var SmartHttpError = class _SmartHttpError extends BaseError {
+  /**
+   * @param {string} preview
+   * @param {string} response
+   */
+  constructor(preview, response) {
+    super(
+      `Remote did not reply using the "smart" HTTP protocol. Expected "001e# service=git-upload-pack" but received: ${preview}`
+    );
+    this.code = this.name = _SmartHttpError.code;
+    this.data = { preview, response };
+  }
+};
+SmartHttpError.code = "SmartHttpError";
+var UnknownTransportError = class _UnknownTransportError extends BaseError {
+  /**
+   * @param {string} url
+   * @param {string} transport
+   * @param {string} [suggestion]
+   */
+  constructor(url, transport, suggestion) {
+    super(
+      `Git remote "${url}" uses an unrecognized transport protocol: "${transport}"`
+    );
+    this.code = this.name = _UnknownTransportError.code;
+    this.data = { url, transport, suggestion };
+  }
+};
+UnknownTransportError.code = "UnknownTransportError";
+var UrlParseError = class _UrlParseError extends BaseError {
+  /**
+   * @param {string} url
+   */
+  constructor(url) {
+    super(`Cannot parse remote URL: "${url}"`);
+    this.code = this.name = _UrlParseError.code;
+    this.data = { url };
+  }
+};
+UrlParseError.code = "UrlParseError";
+var UserCanceledError = class _UserCanceledError extends BaseError {
+  constructor() {
+    super(`The operation was canceled.`);
+    this.code = this.name = _UserCanceledError.code;
+    this.data = {};
+  }
+};
+UserCanceledError.code = "UserCanceledError";
+var IndexResetError = class _IndexResetError extends BaseError {
+  /**
+   * @param {Array<string>} filepaths
+   */
+  constructor(filepath) {
+    super(
+      `Could not merge index: Entry for '${filepath}' is not up to date. Either reset the index entry to HEAD, or stage your unstaged changes.`
+    );
+    this.code = this.name = _IndexResetError.code;
+    this.data = { filepath };
+  }
+};
+IndexResetError.code = "IndexResetError";
+var NoCommitError = class _NoCommitError extends BaseError {
+  /**
+   * @param {string} ref
+   */
+  constructor(ref) {
+    super(
+      `"${ref}" does not point to any commit. You're maybe working on a repository with no commits yet. `
+    );
+    this.code = this.name = _NoCommitError.code;
+    this.data = { ref };
+  }
+};
+NoCommitError.code = "NoCommitError";
+var Errors = /* @__PURE__ */ Object.freeze({
+  __proto__: null,
+  AlreadyExistsError,
+  AmbiguousError,
+  CheckoutConflictError,
+  CommitNotFetchedError,
+  EmptyServerResponseError,
+  FastForwardError,
+  GitPushError,
+  HttpError,
+  InternalError,
+  InvalidFilepathError,
+  InvalidOidError,
+  InvalidRefNameError,
+  MaxDepthError,
+  MergeNotSupportedError,
+  MergeConflictError,
+  MissingNameError,
+  MissingParameterError,
+  MultipleGitError,
+  NoRefspecError,
+  NotFoundError,
+  ObjectTypeError,
+  ParseError,
+  PushRejectedError,
+  RemoteCapabilityError,
+  SmartHttpError,
+  UnknownTransportError,
+  UnsafeFilepathError,
+  UrlParseError,
+  UserCanceledError,
+  UnmergedPathsError,
+  IndexResetError,
+  NoCommitError
+});
+function formatAuthor({ name, email, timestamp, timezoneOffset }) {
+  timezoneOffset = formatTimezoneOffset(timezoneOffset);
+  return `${name} <${email}> ${timestamp} ${timezoneOffset}`;
+}
+function formatTimezoneOffset(minutes) {
+  const sign = simpleSign(negateExceptForZero(minutes));
+  minutes = Math.abs(minutes);
+  const hours = Math.floor(minutes / 60);
+  minutes -= hours * 60;
+  let strHours = String(hours);
+  let strMinutes = String(minutes);
+  if (strHours.length < 2) strHours = "0" + strHours;
+  if (strMinutes.length < 2) strMinutes = "0" + strMinutes;
+  return (sign === -1 ? "-" : "+") + strHours + strMinutes;
+}
+function simpleSign(n) {
+  return Math.sign(n) || (Object.is(n, -0) ? -1 : 1);
+}
+function negateExceptForZero(n) {
+  return n === 0 ? n : -n;
+}
+function normalizeNewlines(str) {
+  str = str.replace(/\r/g, "");
+  str = str.replace(/^\n+/, "");
+  str = str.replace(/\n+$/, "") + "\n";
+  return str;
+}
+function parseAuthor(author) {
+  const [, name, email, timestamp, offset] = author.match(
+    /^(.*) <(.*)> (.*) (.*)$/
+  );
+  return {
+    name,
+    email,
+    timestamp: Number(timestamp),
+    timezoneOffset: parseTimezoneOffset(offset)
+  };
+}
+function parseTimezoneOffset(offset) {
+  let [, sign, hours, minutes] = offset.match(/(\+|-)(\d\d)(\d\d)/);
+  minutes = (sign === "+" ? 1 : -1) * (Number(hours) * 60 + Number(minutes));
+  return negateExceptForZero$1(minutes);
+}
+function negateExceptForZero$1(n) {
+  return n === 0 ? n : -n;
+}
+var GitAnnotatedTag = class _GitAnnotatedTag {
+  constructor(tag2) {
+    if (typeof tag2 === "string") {
+      this._tag = tag2;
+    } else if (import_buffer.Buffer.isBuffer(tag2)) {
+      this._tag = tag2.toString("utf8");
+    } else if (typeof tag2 === "object") {
+      this._tag = _GitAnnotatedTag.render(tag2);
+    } else {
+      throw new InternalError(
+        "invalid type passed to GitAnnotatedTag constructor"
+      );
+    }
+  }
+  static from(tag2) {
+    return new _GitAnnotatedTag(tag2);
+  }
+  static render(obj) {
+    return `object ${obj.object}
+type ${obj.type}
+tag ${obj.tag}
+tagger ${formatAuthor(obj.tagger)}
+
+${obj.message}
+${obj.gpgsig ? obj.gpgsig : ""}`;
+  }
+  justHeaders() {
+    return this._tag.slice(0, this._tag.indexOf("\n\n"));
+  }
+  message() {
+    const tag2 = this.withoutSignature();
+    return tag2.slice(tag2.indexOf("\n\n") + 2);
+  }
+  parse() {
+    return Object.assign(this.headers(), {
+      message: this.message(),
+      gpgsig: this.gpgsig()
+    });
+  }
+  render() {
+    return this._tag;
+  }
+  headers() {
+    const headers = this.justHeaders().split("\n");
+    const hs = [];
+    for (const h of headers) {
+      if (h[0] === " ") {
+        hs[hs.length - 1] += "\n" + h.slice(1);
+      } else {
+        hs.push(h);
+      }
+    }
+    const obj = {};
+    for (const h of hs) {
+      const key = h.slice(0, h.indexOf(" "));
+      const value = h.slice(h.indexOf(" ") + 1);
+      if (Array.isArray(obj[key])) {
+        obj[key].push(value);
+      } else {
+        obj[key] = value;
+      }
+    }
+    if (obj.tagger) {
+      obj.tagger = parseAuthor(obj.tagger);
+    }
+    if (obj.committer) {
+      obj.committer = parseAuthor(obj.committer);
+    }
+    return obj;
+  }
+  withoutSignature() {
+    const tag2 = normalizeNewlines(this._tag);
+    if (tag2.indexOf("\n-----BEGIN PGP SIGNATURE-----") === -1) return tag2;
+    return tag2.slice(0, tag2.lastIndexOf("\n-----BEGIN PGP SIGNATURE-----"));
+  }
+  gpgsig() {
+    if (this._tag.indexOf("\n-----BEGIN PGP SIGNATURE-----") === -1) return;
+    const signature = this._tag.slice(
+      this._tag.indexOf("-----BEGIN PGP SIGNATURE-----"),
+      this._tag.indexOf("-----END PGP SIGNATURE-----") + "-----END PGP SIGNATURE-----".length
+    );
+    return normalizeNewlines(signature);
+  }
+  payload() {
+    return this.withoutSignature() + "\n";
+  }
+  toObject() {
+    return import_buffer.Buffer.from(this._tag, "utf8");
+  }
+  static async sign(tag2, sign, secretKey) {
+    const payload = tag2.payload();
+    let { signature } = await sign({ payload, secretKey });
+    signature = normalizeNewlines(signature);
+    const signedTag = payload + signature;
+    return _GitAnnotatedTag.from(signedTag);
+  }
+};
+function indent(str) {
+  return str.trim().split("\n").map((x) => " " + x).join("\n") + "\n";
+}
+function outdent(str) {
+  return str.split("\n").map((x) => x.replace(/^ /, "")).join("\n");
+}
+var GitCommit = class _GitCommit {
+  constructor(commit2) {
+    if (typeof commit2 === "string") {
+      this._commit = commit2;
+    } else if (import_buffer.Buffer.isBuffer(commit2)) {
+      this._commit = commit2.toString("utf8");
+    } else if (typeof commit2 === "object") {
+      this._commit = _GitCommit.render(commit2);
+    } else {
+      throw new InternalError("invalid type passed to GitCommit constructor");
+    }
+  }
+  static fromPayloadSignature({ payload, signature }) {
+    const headers = _GitCommit.justHeaders(payload);
+    const message = _GitCommit.justMessage(payload);
+    const commit2 = normalizeNewlines(
+      headers + "\ngpgsig" + indent(signature) + "\n" + message
+    );
+    return new _GitCommit(commit2);
+  }
+  static from(commit2) {
+    return new _GitCommit(commit2);
+  }
+  toObject() {
+    return import_buffer.Buffer.from(this._commit, "utf8");
+  }
+  // Todo: allow setting the headers and message
+  headers() {
+    return this.parseHeaders();
+  }
+  // Todo: allow setting the headers and message
+  message() {
+    return _GitCommit.justMessage(this._commit);
+  }
+  parse() {
+    return Object.assign({ message: this.message() }, this.headers());
+  }
+  static justMessage(commit2) {
+    return normalizeNewlines(commit2.slice(commit2.indexOf("\n\n") + 2));
+  }
+  static justHeaders(commit2) {
+    return commit2.slice(0, commit2.indexOf("\n\n"));
+  }
+  parseHeaders() {
+    const headers = _GitCommit.justHeaders(this._commit).split("\n");
+    const hs = [];
+    for (const h of headers) {
+      if (h[0] === " ") {
+        hs[hs.length - 1] += "\n" + h.slice(1);
+      } else {
+        hs.push(h);
+      }
+    }
+    const obj = {
+      parent: []
+    };
+    for (const h of hs) {
+      const key = h.slice(0, h.indexOf(" "));
+      const value = h.slice(h.indexOf(" ") + 1);
+      if (Array.isArray(obj[key])) {
+        obj[key].push(value);
+      } else {
+        obj[key] = value;
+      }
+    }
+    if (obj.author) {
+      obj.author = parseAuthor(obj.author);
+    }
+    if (obj.committer) {
+      obj.committer = parseAuthor(obj.committer);
+    }
+    return obj;
+  }
+  static renderHeaders(obj) {
+    let headers = "";
+    if (obj.tree) {
+      headers += `tree ${obj.tree}
+`;
+    } else {
+      headers += `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+`;
+    }
+    if (obj.parent) {
+      if (obj.parent.length === void 0) {
+        throw new InternalError(`commit 'parent' property should be an array`);
+      }
+      for (const p of obj.parent) {
+        headers += `parent ${p}
+`;
+      }
+    }
+    const author = obj.author;
+    headers += `author ${formatAuthor(author)}
+`;
+    const committer = obj.committer || obj.author;
+    headers += `committer ${formatAuthor(committer)}
+`;
+    if (obj.gpgsig) {
+      headers += "gpgsig" + indent(obj.gpgsig);
+    }
+    return headers;
+  }
+  static render(obj) {
+    return _GitCommit.renderHeaders(obj) + "\n" + normalizeNewlines(obj.message);
+  }
+  render() {
+    return this._commit;
+  }
+  withoutSignature() {
+    const commit2 = normalizeNewlines(this._commit);
+    if (commit2.indexOf("\ngpgsig") === -1) return commit2;
+    const headers = commit2.slice(0, commit2.indexOf("\ngpgsig"));
+    const message = commit2.slice(
+      commit2.indexOf("-----END PGP SIGNATURE-----\n") + "-----END PGP SIGNATURE-----\n".length
+    );
+    return normalizeNewlines(headers + "\n" + message);
+  }
+  isolateSignature() {
+    const signature = this._commit.slice(
+      this._commit.indexOf("-----BEGIN PGP SIGNATURE-----"),
+      this._commit.indexOf("-----END PGP SIGNATURE-----") + "-----END PGP SIGNATURE-----".length
+    );
+    return outdent(signature);
+  }
+  static async sign(commit2, sign, secretKey) {
+    const payload = commit2.withoutSignature();
+    const message = _GitCommit.justMessage(commit2._commit);
+    let { signature } = await sign({ payload, secretKey });
+    signature = normalizeNewlines(signature);
+    const headers = _GitCommit.justHeaders(commit2._commit);
+    const signedCommit = headers + "\ngpgsig" + indent(signature) + "\n" + message;
+    return _GitCommit.from(signedCommit);
+  }
+};
+async function resolveTree({ fs, cache, gitdir, oid }) {
+  if (oid === "4b825dc642cb6eb9a060e54bf8d69288fbee4904") {
+    return { tree: GitTree.from([]), oid };
+  }
+  const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+  if (type === "tag") {
+    oid = GitAnnotatedTag.from(object).parse().object;
+    return resolveTree({ fs, cache, gitdir, oid });
+  }
+  if (type === "commit") {
+    oid = GitCommit.from(object).parse().tree;
+    return resolveTree({ fs, cache, gitdir, oid });
+  }
+  if (type !== "tree") {
+    throw new ObjectTypeError(oid, type, "tree");
+  }
+  return { tree: GitTree.from(object), oid };
+}
+var GitWalkerRepo = class {
+  constructor({ fs, gitdir, ref, cache }) {
+    this.fs = fs;
+    this.cache = cache;
+    this.gitdir = gitdir;
+    this.mapPromise = (async () => {
+      const map = /* @__PURE__ */ new Map();
+      let oid;
+      try {
+        oid = await GitRefManager.resolve({ fs, gitdir, ref });
+      } catch (e) {
+        if (e instanceof NotFoundError) {
+          oid = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+        }
+      }
+      const tree = await resolveTree({ fs, cache: this.cache, gitdir, oid });
+      tree.type = "tree";
+      tree.mode = "40000";
+      map.set(".", tree);
+      return map;
+    })();
+    const walker = this;
+    this.ConstructEntry = class TreeEntry {
+      constructor(fullpath) {
+        this._fullpath = fullpath;
+        this._type = false;
+        this._mode = false;
+        this._stat = false;
+        this._content = false;
+        this._oid = false;
+      }
+      async type() {
+        return walker.type(this);
+      }
+      async mode() {
+        return walker.mode(this);
+      }
+      async stat() {
+        return walker.stat(this);
+      }
+      async content() {
+        return walker.content(this);
+      }
+      async oid() {
+        return walker.oid(this);
+      }
+    };
+  }
+  async readdir(entry) {
+    const filepath = entry._fullpath;
+    const { fs, cache, gitdir } = this;
+    const map = await this.mapPromise;
+    const obj = map.get(filepath);
+    if (!obj) throw new Error(`No obj for ${filepath}`);
+    const oid = obj.oid;
+    if (!oid) throw new Error(`No oid for obj ${JSON.stringify(obj)}`);
+    if (obj.type !== "tree") {
+      return null;
+    }
+    const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+    if (type !== obj.type) {
+      throw new ObjectTypeError(oid, type, obj.type);
+    }
+    const tree = GitTree.from(object);
+    for (const entry2 of tree) {
+      map.set(join(filepath, entry2.path), entry2);
+    }
+    return tree.entries().map((entry2) => join(filepath, entry2.path));
+  }
+  async type(entry) {
+    if (entry._type === false) {
+      const map = await this.mapPromise;
+      const { type } = map.get(entry._fullpath);
+      entry._type = type;
+    }
+    return entry._type;
+  }
+  async mode(entry) {
+    if (entry._mode === false) {
+      const map = await this.mapPromise;
+      const { mode } = map.get(entry._fullpath);
+      entry._mode = normalizeMode(parseInt(mode, 8));
+    }
+    return entry._mode;
+  }
+  async stat(_entry) {
+  }
+  async content(entry) {
+    if (entry._content === false) {
+      const map = await this.mapPromise;
+      const { fs, cache, gitdir } = this;
+      const obj = map.get(entry._fullpath);
+      const oid = obj.oid;
+      const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+      if (type !== "blob") {
+        entry._content = void 0;
+      } else {
+        entry._content = new Uint8Array(object);
+      }
+    }
+    return entry._content;
+  }
+  async oid(entry) {
+    if (entry._oid === false) {
+      const map = await this.mapPromise;
+      const obj = map.get(entry._fullpath);
+      entry._oid = obj.oid;
+    }
+    return entry._oid;
+  }
+};
+function TREE({ ref = "HEAD" } = {}) {
+  const o = /* @__PURE__ */ Object.create(null);
+  Object.defineProperty(o, GitWalkSymbol, {
+    value: function({ fs, gitdir, cache }) {
+      return new GitWalkerRepo({ fs, gitdir, ref, cache });
+    }
+  });
+  Object.freeze(o);
+  return o;
+}
+var GitWalkerFs = class {
+  constructor({ fs, dir, gitdir, cache }) {
+    this.fs = fs;
+    this.cache = cache;
+    this.dir = dir;
+    this.gitdir = gitdir;
+    const walker = this;
+    this.ConstructEntry = class WorkdirEntry {
+      constructor(fullpath) {
+        this._fullpath = fullpath;
+        this._type = false;
+        this._mode = false;
+        this._stat = false;
+        this._content = false;
+        this._oid = false;
+      }
+      async type() {
+        return walker.type(this);
+      }
+      async mode() {
+        return walker.mode(this);
+      }
+      async stat() {
+        return walker.stat(this);
+      }
+      async content() {
+        return walker.content(this);
+      }
+      async oid() {
+        return walker.oid(this);
+      }
+    };
+  }
+  async readdir(entry) {
+    const filepath = entry._fullpath;
+    const { fs, dir } = this;
+    const names = await fs.readdir(join(dir, filepath));
+    if (names === null) return null;
+    return names.map((name) => join(filepath, name));
+  }
+  async type(entry) {
+    if (entry._type === false) {
+      await entry.stat();
+    }
+    return entry._type;
+  }
+  async mode(entry) {
+    if (entry._mode === false) {
+      await entry.stat();
+    }
+    return entry._mode;
+  }
+  async stat(entry) {
+    if (entry._stat === false) {
+      const { fs, dir } = this;
+      let stat = await fs.lstat(`${dir}/${entry._fullpath}`);
+      if (!stat) {
+        throw new Error(
+          `ENOENT: no such file or directory, lstat '${entry._fullpath}'`
+        );
+      }
+      let type = stat.isDirectory() ? "tree" : "blob";
+      if (type === "blob" && !stat.isFile() && !stat.isSymbolicLink()) {
+        type = "special";
+      }
+      entry._type = type;
+      stat = normalizeStats(stat);
+      entry._mode = stat.mode;
+      if (stat.size === -1 && entry._actualSize) {
+        stat.size = entry._actualSize;
+      }
+      entry._stat = stat;
+    }
+    return entry._stat;
+  }
+  async content(entry) {
+    if (entry._content === false) {
+      const { fs, dir, gitdir } = this;
+      if (await entry.type() === "tree") {
+        entry._content = void 0;
+      } else {
+        const config = await GitConfigManager.get({ fs, gitdir });
+        const autocrlf = await config.get("core.autocrlf");
+        const content = await fs.read(`${dir}/${entry._fullpath}`, { autocrlf });
+        entry._actualSize = content.length;
+        if (entry._stat && entry._stat.size === -1) {
+          entry._stat.size = entry._actualSize;
+        }
+        entry._content = new Uint8Array(content);
+      }
+    }
+    return entry._content;
+  }
+  async oid(entry) {
+    if (entry._oid === false) {
+      const { fs, gitdir, cache } = this;
+      let oid;
+      await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+        const stage = index3.entriesMap.get(entry._fullpath);
+        const stats = await entry.stat();
+        const config = await GitConfigManager.get({ fs, gitdir });
+        const filemode = await config.get("core.filemode");
+        const trustino = typeof process !== "undefined" ? !(process.platform === "win32") : true;
+        if (!stage || compareStats(stats, stage, filemode, trustino)) {
+          const content = await entry.content();
+          if (content === void 0) {
+            oid = void 0;
+          } else {
+            oid = await shasum(
+              GitObject.wrap({ type: "blob", object: await entry.content() })
+            );
+            if (stage && oid === stage.oid && (!filemode || stats.mode === stage.mode) && compareStats(stats, stage, filemode, trustino)) {
+              index3.insert({
+                filepath: entry._fullpath,
+                stats,
+                oid
+              });
+            }
+          }
+        } else {
+          oid = stage.oid;
+        }
+      });
+      entry._oid = oid;
+    }
+    return entry._oid;
+  }
+};
+function WORKDIR() {
+  const o = /* @__PURE__ */ Object.create(null);
+  Object.defineProperty(o, GitWalkSymbol, {
+    value: function({ fs, dir, gitdir, cache }) {
+      return new GitWalkerFs({ fs, dir, gitdir, cache });
+    }
+  });
+  Object.freeze(o);
+  return o;
+}
+function arrayRange(start, end) {
+  const length = end - start;
+  return Array.from({ length }, (_, i) => start + i);
+}
+var flat = typeof Array.prototype.flat === "undefined" ? (entries) => entries.reduce((acc, x) => acc.concat(x), []) : (entries) => entries.flat();
+var RunningMinimum = class {
+  constructor() {
+    this.value = null;
+  }
+  consider(value) {
+    if (value === null || value === void 0) return;
+    if (this.value === null) {
+      this.value = value;
+    } else if (value < this.value) {
+      this.value = value;
+    }
+  }
+  reset() {
+    this.value = null;
+  }
+};
+function* unionOfIterators(sets) {
+  const min = new RunningMinimum();
+  let minimum;
+  const heads = [];
+  const numsets = sets.length;
+  for (let i = 0; i < numsets; i++) {
+    heads[i] = sets[i].next().value;
+    if (heads[i] !== void 0) {
+      min.consider(heads[i]);
+    }
+  }
+  if (min.value === null) return;
+  while (true) {
+    const result = [];
+    minimum = min.value;
+    min.reset();
+    for (let i = 0; i < numsets; i++) {
+      if (heads[i] !== void 0 && heads[i] === minimum) {
+        result[i] = heads[i];
+        heads[i] = sets[i].next().value;
+      } else {
+        result[i] = null;
+      }
+      if (heads[i] !== void 0) {
+        min.consider(heads[i]);
+      }
+    }
+    yield result;
+    if (min.value === null) return;
+  }
+}
+async function _walk({
+  fs,
+  cache,
+  dir,
+  gitdir,
+  trees,
+  // @ts-ignore
+  map = async (_, entry) => entry,
+  // The default reducer is a flatmap that filters out undefineds.
+  reduce = async (parent, children) => {
+    const flatten = flat(children);
+    if (parent !== void 0) flatten.unshift(parent);
+    return flatten;
+  },
+  // The default iterate function walks all children concurrently
+  iterate = (walk2, children) => Promise.all([...children].map(walk2))
+}) {
+  const walkers = trees.map(
+    (proxy) => proxy[GitWalkSymbol]({ fs, dir, gitdir, cache })
+  );
+  const root = new Array(walkers.length).fill(".");
+  const range = arrayRange(0, walkers.length);
+  const unionWalkerFromReaddir = async (entries) => {
+    range.map((i) => {
+      entries[i] = entries[i] && new walkers[i].ConstructEntry(entries[i]);
+    });
+    const subdirs = await Promise.all(
+      range.map((i) => entries[i] ? walkers[i].readdir(entries[i]) : [])
+    );
+    const iterators = subdirs.map((array) => array === null ? [] : array).map((array) => array[Symbol.iterator]());
+    return {
+      entries,
+      children: unionOfIterators(iterators)
+    };
+  };
+  const walk2 = async (root2) => {
+    const { entries, children } = await unionWalkerFromReaddir(root2);
+    const fullpath = entries.find((entry) => entry && entry._fullpath)._fullpath;
+    const parent = await map(fullpath, entries);
+    if (parent !== null) {
+      let walkedChildren = await iterate(walk2, children);
+      walkedChildren = walkedChildren.filter((x) => x !== void 0);
+      return reduce(parent, walkedChildren);
+    }
+  };
+  return walk2(root);
+}
+async function rmRecursive(fs, filepath) {
+  const entries = await fs.readdir(filepath);
+  if (entries == null) {
+    await fs.rm(filepath);
+  } else if (entries.length) {
+    await Promise.all(
+      entries.map((entry) => {
+        const subpath = join(filepath, entry);
+        return fs.lstat(subpath).then((stat) => {
+          if (!stat) return;
+          return stat.isDirectory() ? rmRecursive(fs, subpath) : fs.rm(subpath);
+        });
+      })
+    ).then(() => fs.rmdir(filepath));
+  } else {
+    await fs.rmdir(filepath);
+  }
+}
+function isPromiseLike(obj) {
+  return isObject(obj) && isFunction(obj.then) && isFunction(obj.catch);
+}
+function isObject(obj) {
+  return obj && typeof obj === "object";
+}
+function isFunction(obj) {
+  return typeof obj === "function";
+}
+function isPromiseFs(fs) {
+  const test = (targetFs) => {
+    try {
+      return targetFs.readFile().catch((e) => e);
+    } catch (e) {
+      return e;
+    }
+  };
+  return isPromiseLike(test(fs));
+}
+var commands = [
+  "readFile",
+  "writeFile",
+  "mkdir",
+  "rmdir",
+  "unlink",
+  "stat",
+  "lstat",
+  "readdir",
+  "readlink",
+  "symlink"
+];
+function bindFs(target, fs) {
+  if (isPromiseFs(fs)) {
+    for (const command of commands) {
+      target[`_${command}`] = fs[command].bind(fs);
+    }
+  } else {
+    for (const command of commands) {
+      target[`_${command}`] = (0, import_pify.default)(fs[command].bind(fs));
+    }
+  }
+  if (isPromiseFs(fs)) {
+    if (fs.rm) target._rm = fs.rm.bind(fs);
+    else if (fs.rmdir.length > 1) target._rm = fs.rmdir.bind(fs);
+    else target._rm = rmRecursive.bind(null, target);
+  } else {
+    if (fs.rm) target._rm = (0, import_pify.default)(fs.rm.bind(fs));
+    else if (fs.rmdir.length > 2) target._rm = (0, import_pify.default)(fs.rmdir.bind(fs));
+    else target._rm = rmRecursive.bind(null, target);
+  }
+}
+var FileSystem = class {
+  constructor(fs) {
+    if (typeof fs._original_unwrapped_fs !== "undefined") return fs;
+    const promises = Object.getOwnPropertyDescriptor(fs, "promises");
+    if (promises && promises.enumerable) {
+      bindFs(this, fs.promises);
+    } else {
+      bindFs(this, fs);
+    }
+    this._original_unwrapped_fs = fs;
+  }
+  /**
+   * Return true if a file exists, false if it doesn't exist.
+   * Rethrows errors that aren't related to file existence.
+   */
+  async exists(filepath, options = {}) {
+    try {
+      await this._stat(filepath);
+      return true;
+    } catch (err) {
+      if (err.code === "ENOENT" || err.code === "ENOTDIR") {
+        return false;
+      } else {
+        console.log('Unhandled error in "FileSystem.exists()" function', err);
+        throw err;
+      }
+    }
+  }
+  /**
+   * Return the contents of a file if it exists, otherwise returns null.
+   *
+   * @param {string} filepath
+   * @param {object} [options]
+   *
+   * @returns {Promise<Buffer|string|null>}
+   */
+  async read(filepath, options = {}) {
+    try {
+      let buffer = await this._readFile(filepath, options);
+      if (options.autocrlf === "true") {
+        try {
+          buffer = new TextDecoder("utf8", { fatal: true }).decode(buffer);
+          buffer = buffer.replace(/\r\n/g, "\n");
+          buffer = new TextEncoder().encode(buffer);
+        } catch (error) {
+        }
+      }
+      if (typeof buffer !== "string") {
+        buffer = import_buffer.Buffer.from(buffer);
+      }
+      return buffer;
+    } catch (err) {
+      return null;
+    }
+  }
+  /**
+   * Write a file (creating missing directories if need be) without throwing errors.
+   *
+   * @param {string} filepath
+   * @param {Buffer|Uint8Array|string} contents
+   * @param {object|string} [options]
+   */
+  async write(filepath, contents, options = {}) {
+    try {
+      await this._writeFile(filepath, contents, options);
+      return;
+    } catch (err) {
+      await this.mkdir(dirname(filepath));
+      await this._writeFile(filepath, contents, options);
+    }
+  }
+  /**
+   * Make a directory (or series of nested directories) without throwing an error if it already exists.
+   */
+  async mkdir(filepath, _selfCall = false) {
+    try {
+      await this._mkdir(filepath);
+      return;
+    } catch (err) {
+      if (err === null) return;
+      if (err.code === "EEXIST") return;
+      if (_selfCall) throw err;
+      if (err.code === "ENOENT") {
+        const parent = dirname(filepath);
+        if (parent === "." || parent === "/" || parent === filepath) throw err;
+        await this.mkdir(parent);
+        await this.mkdir(filepath, true);
+      }
+    }
+  }
+  /**
+   * Delete a file without throwing an error if it is already deleted.
+   */
+  async rm(filepath) {
+    try {
+      await this._unlink(filepath);
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+  /**
+   * Delete a directory without throwing an error if it is already deleted.
+   */
+  async rmdir(filepath, opts) {
+    try {
+      if (opts && opts.recursive) {
+        await this._rm(filepath, opts);
+      } else {
+        await this._rmdir(filepath);
+      }
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+  /**
+   * Read a directory without throwing an error is the directory doesn't exist
+   */
+  async readdir(filepath) {
+    try {
+      const names = await this._readdir(filepath);
+      names.sort(compareStrings);
+      return names;
+    } catch (err) {
+      if (err.code === "ENOTDIR") return null;
+      return [];
+    }
+  }
+  /**
+   * Return a flast list of all the files nested inside a directory
+   *
+   * Based on an elegant concurrent recursive solution from SO
+   * https://stackoverflow.com/a/45130990/2168416
+   */
+  async readdirDeep(dir) {
+    const subdirs = await this._readdir(dir);
+    const files = await Promise.all(
+      subdirs.map(async (subdir) => {
+        const res = dir + "/" + subdir;
+        return (await this._stat(res)).isDirectory() ? this.readdirDeep(res) : res;
+      })
+    );
+    return files.reduce((a, f) => a.concat(f), []);
+  }
+  /**
+   * Return the Stats of a file/symlink if it exists, otherwise returns null.
+   * Rethrows errors that aren't related to file existence.
+   */
+  async lstat(filename) {
+    try {
+      const stats = await this._lstat(filename);
+      return stats;
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    }
+  }
+  /**
+   * Reads the contents of a symlink if it exists, otherwise returns null.
+   * Rethrows errors that aren't related to file existence.
+   */
+  async readlink(filename, opts = { encoding: "buffer" }) {
+    try {
+      const link = await this._readlink(filename, opts);
+      return import_buffer.Buffer.isBuffer(link) ? link : import_buffer.Buffer.from(link);
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    }
+  }
+  /**
+   * Write the contents of buffer to a symlink.
+   */
+  async writelink(filename, buffer) {
+    return this._symlink(buffer.toString("utf8"), filename);
+  }
+};
+function assertParameter(name, value) {
+  if (value === void 0) {
+    throw new MissingParameterError(name);
+  }
+}
+async function modified(entry, base) {
+  if (!entry && !base) return false;
+  if (entry && !base) return true;
+  if (!entry && base) return true;
+  if (await entry.type() === "tree" && await base.type() === "tree") {
+    return false;
+  }
+  if (await entry.type() === await base.type() && await entry.mode() === await base.mode() && await entry.oid() === await base.oid()) {
+    return false;
+  }
+  return true;
+}
+async function abortMerge({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  commit: commit2 = "HEAD",
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("dir", dir);
+    assertParameter("gitdir", gitdir);
+    const fs = new FileSystem(_fs);
+    const trees = [TREE({ ref: commit2 }), WORKDIR(), STAGE()];
+    let unmergedPaths = [];
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      unmergedPaths = index3.unmergedPaths;
+    });
+    const results = await _walk({
+      fs,
+      cache,
+      dir,
+      gitdir,
+      trees,
+      map: async function(path, [head, workdir, index3]) {
+        const staged = !await modified(workdir, index3);
+        const unmerged = unmergedPaths.includes(path);
+        const unmodified = !await modified(index3, head);
+        if (staged || unmerged) {
+          return head ? {
+            path,
+            mode: await head.mode(),
+            oid: await head.oid(),
+            type: await head.type(),
+            content: await head.content()
+          } : void 0;
+        }
+        if (unmodified) return false;
+        else throw new IndexResetError(path);
+      }
+    });
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      for (const entry of results) {
+        if (entry === false) continue;
+        if (!entry) {
+          await fs.rmdir(`${dir}/${entry.path}`, { recursive: true });
+          index3.delete({ filepath: entry.path });
+          continue;
+        }
+        if (entry.type === "blob") {
+          const content = new TextDecoder().decode(entry.content);
+          await fs.write(`${dir}/${entry.path}`, content, { mode: entry.mode });
+          index3.insert({
+            filepath: entry.path,
+            oid: entry.oid,
+            stage: 0
+          });
+        }
+      }
+    });
+  } catch (err) {
+    err.caller = "git.abortMerge";
+    throw err;
+  }
+}
+var GitIgnoreManager = class {
+  static async isIgnored({ fs, dir, gitdir = join(dir, ".git"), filepath }) {
+    if (basename(filepath) === ".git") return true;
+    if (filepath === ".") return false;
+    let excludes = "";
+    const excludesFile = join(gitdir, "info", "exclude");
+    if (await fs.exists(excludesFile)) {
+      excludes = await fs.read(excludesFile, "utf8");
+    }
+    const pairs = [
+      {
+        gitignore: join(dir, ".gitignore"),
+        filepath
+      }
+    ];
+    const pieces = filepath.split("/").filter(Boolean);
+    for (let i = 1; i < pieces.length; i++) {
+      const folder = pieces.slice(0, i).join("/");
+      const file = pieces.slice(i).join("/");
+      pairs.push({
+        gitignore: join(dir, folder, ".gitignore"),
+        filepath: file
+      });
+    }
+    let ignoredStatus = false;
+    for (const p of pairs) {
+      let file;
+      try {
+        file = await fs.read(p.gitignore, "utf8");
+      } catch (err) {
+        if (err.code === "NOENT") continue;
+      }
+      const ign = (0, import_ignore.default)().add(excludes);
+      ign.add(file);
+      const parentdir = dirname(p.filepath);
+      if (parentdir !== "." && ign.ignores(parentdir)) return true;
+      if (ignoredStatus) {
+        ignoredStatus = !ign.test(p.filepath).unignored;
+      } else {
+        ignoredStatus = ign.test(p.filepath).ignored;
+      }
+    }
+    return ignoredStatus;
+  }
+};
+async function writeObjectLoose({ fs, gitdir, object, format, oid }) {
+  if (format !== "deflated") {
+    throw new InternalError(
+      "GitObjectStoreLoose expects objects to write to be in deflated format"
+    );
+  }
+  const source = `objects/${oid.slice(0, 2)}/${oid.slice(2)}`;
+  const filepath = `${gitdir}/${source}`;
+  if (!await fs.exists(filepath)) await fs.write(filepath, object);
+}
+var supportsCompressionStream = null;
+async function deflate(buffer) {
+  if (supportsCompressionStream === null) {
+    supportsCompressionStream = testCompressionStream();
+  }
+  return supportsCompressionStream ? browserDeflate(buffer) : import_pako.default.deflate(buffer);
+}
+async function browserDeflate(buffer) {
+  const cs = new CompressionStream("deflate");
+  const c = new Blob([buffer]).stream().pipeThrough(cs);
+  return new Uint8Array(await new Response(c).arrayBuffer());
+}
+function testCompressionStream() {
+  try {
+    const cs = new CompressionStream("deflate");
+    cs.writable.close();
+    const stream = new Blob([]).stream();
+    stream.cancel();
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+async function _writeObject({
+  fs,
+  gitdir,
+  type,
+  object,
+  format = "content",
+  oid = void 0,
+  dryRun = false
+}) {
+  if (format !== "deflated") {
+    if (format !== "wrapped") {
+      object = GitObject.wrap({ type, object });
+    }
+    oid = await shasum(object);
+    object = import_buffer.Buffer.from(await deflate(object));
+  }
+  if (!dryRun) {
+    await writeObjectLoose({ fs, gitdir, object, format: "deflated", oid });
+  }
+  return oid;
+}
+function posixifyPathBuffer(buffer) {
+  let idx;
+  while (~(idx = buffer.indexOf(92))) buffer[idx] = 47;
+  return buffer;
+}
+async function add({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  filepath,
+  cache = {},
+  force = false,
+  parallel = true
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("dir", dir);
+    assertParameter("gitdir", gitdir);
+    assertParameter("filepath", filepath);
+    const fs = new FileSystem(_fs);
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async (index3) => {
+      return addToIndex({
+        dir,
+        gitdir,
+        fs,
+        filepath,
+        index: index3,
+        force,
+        parallel
+      });
+    });
+  } catch (err) {
+    err.caller = "git.add";
+    throw err;
+  }
+}
+async function addToIndex({
+  dir,
+  gitdir,
+  fs,
+  filepath,
+  index: index3,
+  force,
+  parallel
+}) {
+  filepath = Array.isArray(filepath) ? filepath : [filepath];
+  const promises = filepath.map(async (currentFilepath) => {
+    if (!force) {
+      const ignored = await GitIgnoreManager.isIgnored({
+        fs,
+        dir,
+        gitdir,
+        filepath: currentFilepath
+      });
+      if (ignored) return;
+    }
+    const stats = await fs.lstat(join(dir, currentFilepath));
+    if (!stats) throw new NotFoundError(currentFilepath);
+    if (stats.isDirectory()) {
+      const children = await fs.readdir(join(dir, currentFilepath));
+      if (parallel) {
+        const promises2 = children.map(
+          (child) => addToIndex({
+            dir,
+            gitdir,
+            fs,
+            filepath: [join(currentFilepath, child)],
+            index: index3,
+            force,
+            parallel
+          })
+        );
+        await Promise.all(promises2);
+      } else {
+        for (const child of children) {
+          await addToIndex({
+            dir,
+            gitdir,
+            fs,
+            filepath: [join(currentFilepath, child)],
+            index: index3,
+            force,
+            parallel
+          });
+        }
+      }
+    } else {
+      const config = await GitConfigManager.get({ fs, gitdir });
+      const autocrlf = await config.get("core.autocrlf");
+      const object = stats.isSymbolicLink() ? await fs.readlink(join(dir, currentFilepath)).then(posixifyPathBuffer) : await fs.read(join(dir, currentFilepath), { autocrlf });
+      if (object === null) throw new NotFoundError(currentFilepath);
+      const oid = await _writeObject({ fs, gitdir, type: "blob", object });
+      index3.insert({ filepath: currentFilepath, stats, oid });
+    }
+  });
+  const settledPromises = await Promise.allSettled(promises);
+  const rejectedPromises = settledPromises.filter((settle) => settle.status === "rejected").map((settle) => settle.reason);
+  if (rejectedPromises.length > 1) {
+    throw new MultipleGitError(rejectedPromises);
+  }
+  if (rejectedPromises.length === 1) {
+    throw rejectedPromises[0];
+  }
+  const fulfilledPromises = settledPromises.filter((settle) => settle.status === "fulfilled" && settle.value).map((settle) => settle.value);
+  return fulfilledPromises;
+}
+async function _getConfig({ fs, gitdir, path }) {
+  const config = await GitConfigManager.get({ fs, gitdir });
+  return config.get(path);
+}
+function assignDefined(target, ...sources) {
+  for (const source of sources) {
+    if (source) {
+      for (const key of Object.keys(source)) {
+        const val = source[key];
+        if (val !== void 0) {
+          target[key] = val;
+        }
+      }
+    }
+  }
+  return target;
+}
+async function normalizeAuthorObject({ fs, gitdir, author, commit: commit2 }) {
+  const timestamp = Math.floor(Date.now() / 1e3);
+  const defaultAuthor = {
+    name: await _getConfig({ fs, gitdir, path: "user.name" }),
+    email: await _getConfig({ fs, gitdir, path: "user.email" }) || "",
+    // author.email is allowed to be empty string
+    timestamp,
+    timezoneOffset: new Date(timestamp * 1e3).getTimezoneOffset()
+  };
+  const normalizedAuthor = assignDefined(
+    {},
+    defaultAuthor,
+    commit2 ? commit2.author : void 0,
+    author
+  );
+  if (normalizedAuthor.name === void 0) {
+    return void 0;
+  }
+  return normalizedAuthor;
+}
+async function normalizeCommitterObject({
+  fs,
+  gitdir,
+  author,
+  committer,
+  commit: commit2
+}) {
+  const timestamp = Math.floor(Date.now() / 1e3);
+  const defaultCommitter = {
+    name: await _getConfig({ fs, gitdir, path: "user.name" }),
+    email: await _getConfig({ fs, gitdir, path: "user.email" }) || "",
+    // committer.email is allowed to be empty string
+    timestamp,
+    timezoneOffset: new Date(timestamp * 1e3).getTimezoneOffset()
+  };
+  const normalizedCommitter = assignDefined(
+    {},
+    defaultCommitter,
+    commit2 ? commit2.committer : void 0,
+    author,
+    committer
+  );
+  if (normalizedCommitter.name === void 0) {
+    return void 0;
+  }
+  return normalizedCommitter;
+}
+async function resolveCommit({ fs, cache, gitdir, oid }) {
+  const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+  if (type === "tag") {
+    oid = GitAnnotatedTag.from(object).parse().object;
+    return resolveCommit({ fs, cache, gitdir, oid });
+  }
+  if (type !== "commit") {
+    throw new ObjectTypeError(oid, type, "commit");
+  }
+  return { commit: GitCommit.from(object), oid };
+}
+async function _readCommit({ fs, cache, gitdir, oid }) {
+  const { commit: commit2, oid: commitOid } = await resolveCommit({
+    fs,
+    cache,
+    gitdir,
+    oid
+  });
+  const result = {
+    oid: commitOid,
+    commit: commit2.parse(),
+    payload: commit2.withoutSignature()
+  };
+  return result;
+}
+async function _commit({
+  fs,
+  cache,
+  onSign,
+  gitdir,
+  message,
+  author: _author,
+  committer: _committer,
+  signingKey,
+  amend = false,
+  dryRun = false,
+  noUpdateBranch = false,
+  ref,
+  parent,
+  tree
+}) {
+  let initialCommit = false;
+  if (!ref) {
+    ref = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: "HEAD",
+      depth: 2
+    });
+  }
+  let refOid, refCommit;
+  try {
+    refOid = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref
+    });
+    refCommit = await _readCommit({ fs, gitdir, oid: refOid, cache: {} });
+  } catch {
+    initialCommit = true;
+  }
+  if (amend && initialCommit) {
+    throw new NoCommitError(ref);
+  }
+  const author = !amend ? await normalizeAuthorObject({ fs, gitdir, author: _author }) : await normalizeAuthorObject({
+    fs,
+    gitdir,
+    author: _author,
+    commit: refCommit.commit
+  });
+  if (!author) throw new MissingNameError("author");
+  const committer = !amend ? await normalizeCommitterObject({
+    fs,
+    gitdir,
+    author,
+    committer: _committer
+  }) : await normalizeCommitterObject({
+    fs,
+    gitdir,
+    author,
+    committer: _committer,
+    commit: refCommit.commit
+  });
+  if (!committer) throw new MissingNameError("committer");
+  return GitIndexManager.acquire(
+    { fs, gitdir, cache, allowUnmerged: false },
+    async function(index3) {
+      const inodes = flatFileListToDirectoryStructure(index3.entries);
+      const inode = inodes.get(".");
+      if (!tree) {
+        tree = await constructTree({ fs, gitdir, inode, dryRun });
+      }
+      if (!parent) {
+        if (!amend) {
+          parent = refOid ? [refOid] : [];
+        } else {
+          parent = refCommit.commit.parent;
+        }
+      } else {
+        parent = await Promise.all(
+          parent.map((p) => {
+            return GitRefManager.resolve({ fs, gitdir, ref: p });
+          })
+        );
+      }
+      if (!message) {
+        if (!amend) {
+          throw new MissingParameterError("message");
+        } else {
+          message = refCommit.commit.message;
+        }
+      }
+      let comm = GitCommit.from({
+        tree,
+        parent,
+        author,
+        committer,
+        message
+      });
+      if (signingKey) {
+        comm = await GitCommit.sign(comm, onSign, signingKey);
+      }
+      const oid = await _writeObject({
+        fs,
+        gitdir,
+        type: "commit",
+        object: comm.toObject(),
+        dryRun
+      });
+      if (!noUpdateBranch && !dryRun) {
+        await GitRefManager.writeRef({
+          fs,
+          gitdir,
+          ref,
+          value: oid
+        });
+      }
+      return oid;
+    }
+  );
+}
+async function constructTree({ fs, gitdir, inode, dryRun }) {
+  const children = inode.children;
+  for (const inode2 of children) {
+    if (inode2.type === "tree") {
+      inode2.metadata.mode = "040000";
+      inode2.metadata.oid = await constructTree({ fs, gitdir, inode: inode2, dryRun });
+    }
+  }
+  const entries = children.map((inode2) => ({
+    mode: inode2.metadata.mode,
+    path: inode2.basename,
+    oid: inode2.metadata.oid,
+    type: inode2.type
+  }));
+  const tree = GitTree.from(entries);
+  const oid = await _writeObject({
+    fs,
+    gitdir,
+    type: "tree",
+    object: tree.toObject(),
+    dryRun
+  });
+  return oid;
+}
+async function resolveFilepath({ fs, cache, gitdir, oid, filepath }) {
+  if (filepath.startsWith("/")) {
+    throw new InvalidFilepathError("leading-slash");
+  } else if (filepath.endsWith("/")) {
+    throw new InvalidFilepathError("trailing-slash");
+  }
+  const _oid = oid;
+  const result = await resolveTree({ fs, cache, gitdir, oid });
+  const tree = result.tree;
+  if (filepath === "") {
+    oid = result.oid;
+  } else {
+    const pathArray = filepath.split("/");
+    oid = await _resolveFilepath({
+      fs,
+      cache,
+      gitdir,
+      tree,
+      pathArray,
+      oid: _oid,
+      filepath
+    });
+  }
+  return oid;
+}
+async function _resolveFilepath({
+  fs,
+  cache,
+  gitdir,
+  tree,
+  pathArray,
+  oid,
+  filepath
+}) {
+  const name = pathArray.shift();
+  for (const entry of tree) {
+    if (entry.path === name) {
+      if (pathArray.length === 0) {
+        return entry.oid;
+      } else {
+        const { type, object } = await _readObject({
+          fs,
+          cache,
+          gitdir,
+          oid: entry.oid
+        });
+        if (type !== "tree") {
+          throw new ObjectTypeError(oid, type, "tree", filepath);
+        }
+        tree = GitTree.from(object);
+        return _resolveFilepath({
+          fs,
+          cache,
+          gitdir,
+          tree,
+          pathArray,
+          oid,
+          filepath
+        });
+      }
+    }
+  }
+  throw new NotFoundError(`file or directory found at "${oid}:${filepath}"`);
+}
+async function _readTree({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  filepath = void 0
+}) {
+  if (filepath !== void 0) {
+    oid = await resolveFilepath({ fs, cache, gitdir, oid, filepath });
+  }
+  const { tree, oid: treeOid } = await resolveTree({ fs, cache, gitdir, oid });
+  const result = {
+    oid: treeOid,
+    tree: tree.entries()
+  };
+  return result;
+}
+async function _writeTree({ fs, gitdir, tree }) {
+  const object = GitTree.from(tree).toObject();
+  const oid = await _writeObject({
+    fs,
+    gitdir,
+    type: "tree",
+    object,
+    format: "content"
+  });
+  return oid;
+}
+async function _addNote({
+  fs,
+  cache,
+  onSign,
+  gitdir,
+  ref,
+  oid,
+  note,
+  force,
+  author,
+  committer,
+  signingKey
+}) {
+  let parent;
+  try {
+    parent = await GitRefManager.resolve({ gitdir, fs, ref });
+  } catch (err) {
+    if (!(err instanceof NotFoundError)) {
+      throw err;
+    }
+  }
+  const result = await _readTree({
+    fs,
+    cache,
+    gitdir,
+    oid: parent || "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  });
+  let tree = result.tree;
+  if (force) {
+    tree = tree.filter((entry) => entry.path !== oid);
+  } else {
+    for (const entry of tree) {
+      if (entry.path === oid) {
+        throw new AlreadyExistsError("note", oid);
+      }
+    }
+  }
+  if (typeof note === "string") {
+    note = import_buffer.Buffer.from(note, "utf8");
+  }
+  const noteOid = await _writeObject({
+    fs,
+    gitdir,
+    type: "blob",
+    object: note,
+    format: "content"
+  });
+  tree.push({ mode: "100644", path: oid, oid: noteOid, type: "blob" });
+  const treeOid = await _writeTree({
+    fs,
+    gitdir,
+    tree
+  });
+  const commitOid = await _commit({
+    fs,
+    cache,
+    onSign,
+    gitdir,
+    ref,
+    tree: treeOid,
+    parent: parent && [parent],
+    message: `Note added by 'isomorphic-git addNote'
+`,
+    author,
+    committer,
+    signingKey
+  });
+  return commitOid;
+}
+async function addNote({
+  fs: _fs,
+  onSign,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref = "refs/notes/commits",
+  oid,
+  note,
+  force,
+  author: _author,
+  committer: _committer,
+  signingKey,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    assertParameter("note", note);
+    if (signingKey) {
+      assertParameter("onSign", onSign);
+    }
+    const fs = new FileSystem(_fs);
+    const author = await normalizeAuthorObject({ fs, gitdir, author: _author });
+    if (!author) throw new MissingNameError("author");
+    const committer = await normalizeCommitterObject({
+      fs,
+      gitdir,
+      author,
+      committer: _committer
+    });
+    if (!committer) throw new MissingNameError("committer");
+    return await _addNote({
+      fs: new FileSystem(fs),
+      cache,
+      onSign,
+      gitdir,
+      ref,
+      oid,
+      note,
+      force,
+      author,
+      committer,
+      signingKey
+    });
+  } catch (err) {
+    err.caller = "git.addNote";
+    throw err;
+  }
+}
+async function _addRemote({ fs, gitdir, remote, url, force }) {
+  if (remote !== import_clean_git_ref.default.clean(remote)) {
+    throw new InvalidRefNameError(remote, import_clean_git_ref.default.clean(remote));
+  }
+  const config = await GitConfigManager.get({ fs, gitdir });
+  if (!force) {
+    const remoteNames = await config.getSubsections("remote");
+    if (remoteNames.includes(remote)) {
+      if (url !== await config.get(`remote.${remote}.url`)) {
+        throw new AlreadyExistsError("remote", remote);
+      }
+    }
+  }
+  await config.set(`remote.${remote}.url`, url);
+  await config.set(
+    `remote.${remote}.fetch`,
+    `+refs/heads/*:refs/remotes/${remote}/*`
+  );
+  await GitConfigManager.save({ fs, gitdir, config });
+}
+async function addRemote({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  remote,
+  url,
+  force = false
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("remote", remote);
+    assertParameter("url", url);
+    return await _addRemote({
+      fs: new FileSystem(fs),
+      gitdir,
+      remote,
+      url,
+      force
+    });
+  } catch (err) {
+    err.caller = "git.addRemote";
+    throw err;
+  }
+}
+async function _annotatedTag({
+  fs,
+  cache,
+  onSign,
+  gitdir,
+  ref,
+  tagger,
+  message = ref,
+  gpgsig,
+  object,
+  signingKey,
+  force = false
+}) {
+  ref = ref.startsWith("refs/tags/") ? ref : `refs/tags/${ref}`;
+  if (!force && await GitRefManager.exists({ fs, gitdir, ref })) {
+    throw new AlreadyExistsError("tag", ref);
+  }
+  const oid = await GitRefManager.resolve({
+    fs,
+    gitdir,
+    ref: object || "HEAD"
+  });
+  const { type } = await _readObject({ fs, cache, gitdir, oid });
+  let tagObject = GitAnnotatedTag.from({
+    object: oid,
+    type,
+    tag: ref.replace("refs/tags/", ""),
+    tagger,
+    message,
+    gpgsig
+  });
+  if (signingKey) {
+    tagObject = await GitAnnotatedTag.sign(tagObject, onSign, signingKey);
+  }
+  const value = await _writeObject({
+    fs,
+    gitdir,
+    type: "tag",
+    object: tagObject.toObject()
+  });
+  await GitRefManager.writeRef({ fs, gitdir, ref, value });
+}
+async function annotatedTag({
+  fs: _fs,
+  onSign,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  tagger: _tagger,
+  message = ref,
+  gpgsig,
+  object,
+  signingKey,
+  force = false,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    if (signingKey) {
+      assertParameter("onSign", onSign);
+    }
+    const fs = new FileSystem(_fs);
+    const tagger = await normalizeAuthorObject({ fs, gitdir, author: _tagger });
+    if (!tagger) throw new MissingNameError("tagger");
+    return await _annotatedTag({
+      fs,
+      cache,
+      onSign,
+      gitdir,
+      ref,
+      tagger,
+      message,
+      gpgsig,
+      object,
+      signingKey,
+      force
+    });
+  } catch (err) {
+    err.caller = "git.annotatedTag";
+    throw err;
+  }
+}
+async function _branch({
+  fs,
+  gitdir,
+  ref,
+  object,
+  checkout: checkout2 = false,
+  force = false
+}) {
+  if (ref !== import_clean_git_ref.default.clean(ref)) {
+    throw new InvalidRefNameError(ref, import_clean_git_ref.default.clean(ref));
+  }
+  const fullref = `refs/heads/${ref}`;
+  if (!force) {
+    const exist = await GitRefManager.exists({ fs, gitdir, ref: fullref });
+    if (exist) {
+      throw new AlreadyExistsError("branch", ref, false);
+    }
+  }
+  let oid;
+  try {
+    oid = await GitRefManager.resolve({ fs, gitdir, ref: object || "HEAD" });
+  } catch (e) {
+  }
+  if (oid) {
+    await GitRefManager.writeRef({ fs, gitdir, ref: fullref, value: oid });
+  }
+  if (checkout2) {
+    await GitRefManager.writeSymbolicRef({
+      fs,
+      gitdir,
+      ref: "HEAD",
+      value: fullref
+    });
+  }
+}
+async function branch({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  object,
+  checkout: checkout2 = false,
+  force = false
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    return await _branch({
+      fs: new FileSystem(fs),
+      gitdir,
+      ref,
+      object,
+      checkout: checkout2,
+      force
+    });
+  } catch (err) {
+    err.caller = "git.branch";
+    throw err;
+  }
+}
+var worthWalking = (filepath, root) => {
+  if (filepath === "." || root == null || root.length === 0 || root === ".") {
+    return true;
+  }
+  if (root.length >= filepath.length) {
+    return root.startsWith(filepath);
+  } else {
+    return filepath.startsWith(root);
+  }
+};
+async function _checkout({
+  fs,
+  cache,
+  onProgress,
+  onPostCheckout,
+  dir,
+  gitdir,
+  remote,
+  ref,
+  filepaths,
+  noCheckout,
+  noUpdateHead,
+  dryRun,
+  force,
+  track = true
+}) {
+  let oldOid;
+  if (onPostCheckout) {
+    try {
+      oldOid = await GitRefManager.resolve({ fs, gitdir, ref: "HEAD" });
+    } catch (err) {
+      oldOid = "0000000000000000000000000000000000000000";
+    }
+  }
+  let oid;
+  try {
+    oid = await GitRefManager.resolve({ fs, gitdir, ref });
+  } catch (err) {
+    if (ref === "HEAD") throw err;
+    const remoteRef = `${remote}/${ref}`;
+    oid = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: remoteRef
+    });
+    if (track) {
+      const config = await GitConfigManager.get({ fs, gitdir });
+      await config.set(`branch.${ref}.remote`, remote);
+      await config.set(`branch.${ref}.merge`, `refs/heads/${ref}`);
+      await GitConfigManager.save({ fs, gitdir, config });
+    }
+    await GitRefManager.writeRef({
+      fs,
+      gitdir,
+      ref: `refs/heads/${ref}`,
+      value: oid
+    });
+  }
+  if (!noCheckout) {
+    let ops;
+    try {
+      ops = await analyze({
+        fs,
+        cache,
+        onProgress,
+        dir,
+        gitdir,
+        ref,
+        force,
+        filepaths
+      });
+    } catch (err) {
+      if (err instanceof NotFoundError && err.data.what === oid) {
+        throw new CommitNotFetchedError(ref, oid);
+      } else {
+        throw err;
+      }
+    }
+    const conflicts = ops.filter(([method]) => method === "conflict").map(([method, fullpath]) => fullpath);
+    if (conflicts.length > 0) {
+      throw new CheckoutConflictError(conflicts);
+    }
+    const errors = ops.filter(([method]) => method === "error").map(([method, fullpath]) => fullpath);
+    if (errors.length > 0) {
+      throw new InternalError(errors.join(", "));
+    }
+    if (dryRun) {
+      if (onPostCheckout) {
+        await onPostCheckout({
+          previousHead: oldOid,
+          newHead: oid,
+          type: filepaths != null && filepaths.length > 0 ? "file" : "branch"
+        });
+      }
+      return;
+    }
+    let count = 0;
+    const total = ops.length;
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      await Promise.all(
+        ops.filter(
+          ([method]) => method === "delete" || method === "delete-index"
+        ).map(async function([method, fullpath]) {
+          const filepath = `${dir}/${fullpath}`;
+          if (method === "delete") {
+            await fs.rm(filepath);
+          }
+          index3.delete({ filepath: fullpath });
+          if (onProgress) {
+            await onProgress({
+              phase: "Updating workdir",
+              loaded: ++count,
+              total
+            });
+          }
+        })
+      );
+    });
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      for (const [method, fullpath] of ops) {
+        if (method === "rmdir" || method === "rmdir-index") {
+          const filepath = `${dir}/${fullpath}`;
+          try {
+            if (method === "rmdir-index") {
+              index3.delete({ filepath: fullpath });
+            }
+            await fs.rmdir(filepath);
+            if (onProgress) {
+              await onProgress({
+                phase: "Updating workdir",
+                loaded: ++count,
+                total
+              });
+            }
+          } catch (e) {
+            if (e.code === "ENOTEMPTY") {
+              console.log(
+                `Did not delete ${fullpath} because directory is not empty`
+              );
+            } else {
+              throw e;
+            }
+          }
+        }
+      }
+    });
+    await Promise.all(
+      ops.filter(([method]) => method === "mkdir" || method === "mkdir-index").map(async function([_, fullpath]) {
+        const filepath = `${dir}/${fullpath}`;
+        await fs.mkdir(filepath);
+        if (onProgress) {
+          await onProgress({
+            phase: "Updating workdir",
+            loaded: ++count,
+            total
+          });
+        }
+      })
+    );
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      await Promise.all(
+        ops.filter(
+          ([method]) => method === "create" || method === "create-index" || method === "update" || method === "mkdir-index"
+        ).map(async function([method, fullpath, oid2, mode, chmod]) {
+          const filepath = `${dir}/${fullpath}`;
+          try {
+            if (method !== "create-index" && method !== "mkdir-index") {
+              const { object } = await _readObject({ fs, cache, gitdir, oid: oid2 });
+              if (chmod) {
+                await fs.rm(filepath);
+              }
+              if (mode === 33188) {
+                await fs.write(filepath, object);
+              } else if (mode === 33261) {
+                await fs.write(filepath, object, { mode: 511 });
+              } else if (mode === 40960) {
+                await fs.writelink(filepath, object);
+              } else {
+                throw new InternalError(
+                  `Invalid mode 0o${mode.toString(8)} detected in blob ${oid2}`
+                );
+              }
+            }
+            const stats = await fs.lstat(filepath);
+            if (mode === 33261) {
+              stats.mode = 493;
+            }
+            if (method === "mkdir-index") {
+              stats.mode = 57344;
+            }
+            index3.insert({
+              filepath: fullpath,
+              stats,
+              oid: oid2
+            });
+            if (onProgress) {
+              await onProgress({
+                phase: "Updating workdir",
+                loaded: ++count,
+                total
+              });
+            }
+          } catch (e) {
+            console.log(e);
+          }
+        })
+      );
+    });
+    if (onPostCheckout) {
+      await onPostCheckout({
+        previousHead: oldOid,
+        newHead: oid,
+        type: filepaths != null && filepaths.length > 0 ? "file" : "branch"
+      });
+    }
+  }
+  if (!noUpdateHead) {
+    const fullRef = await GitRefManager.expand({ fs, gitdir, ref });
+    if (fullRef.startsWith("refs/heads")) {
+      await GitRefManager.writeSymbolicRef({
+        fs,
+        gitdir,
+        ref: "HEAD",
+        value: fullRef
+      });
+    } else {
+      await GitRefManager.writeRef({ fs, gitdir, ref: "HEAD", value: oid });
+    }
+  }
+}
+async function analyze({
+  fs,
+  cache,
+  onProgress,
+  dir,
+  gitdir,
+  ref,
+  force,
+  filepaths
+}) {
+  let count = 0;
+  return _walk({
+    fs,
+    cache,
+    dir,
+    gitdir,
+    trees: [TREE({ ref }), WORKDIR(), STAGE()],
+    map: async function(fullpath, [commit2, workdir, stage]) {
+      if (fullpath === ".") return;
+      if (filepaths && !filepaths.some((base) => worthWalking(fullpath, base))) {
+        return null;
+      }
+      if (onProgress) {
+        await onProgress({ phase: "Analyzing workdir", loaded: ++count });
+      }
+      const key = [!!stage, !!commit2, !!workdir].map(Number).join("");
+      switch (key) {
+        // Impossible case.
+        case "000":
+          return;
+        // Ignore workdir files that are not tracked and not part of the new commit.
+        case "001":
+          if (force && filepaths && filepaths.includes(fullpath)) {
+            return ["delete", fullpath];
+          }
+          return;
+        // New entries
+        case "010": {
+          switch (await commit2.type()) {
+            case "tree": {
+              return ["mkdir", fullpath];
+            }
+            case "blob": {
+              return [
+                "create",
+                fullpath,
+                await commit2.oid(),
+                await commit2.mode()
+              ];
+            }
+            case "commit": {
+              return [
+                "mkdir-index",
+                fullpath,
+                await commit2.oid(),
+                await commit2.mode()
+              ];
+            }
+            default: {
+              return [
+                "error",
+                `new entry Unhandled type ${await commit2.type()}`
+              ];
+            }
+          }
+        }
+        // New entries but there is already something in the workdir there.
+        case "011": {
+          switch (`${await commit2.type()}-${await workdir.type()}`) {
+            case "tree-tree": {
+              return;
+            }
+            case "tree-blob":
+            case "blob-tree": {
+              return ["conflict", fullpath];
+            }
+            case "blob-blob": {
+              if (await commit2.oid() !== await workdir.oid()) {
+                if (force) {
+                  return [
+                    "update",
+                    fullpath,
+                    await commit2.oid(),
+                    await commit2.mode(),
+                    await commit2.mode() !== await workdir.mode()
+                  ];
+                } else {
+                  return ["conflict", fullpath];
+                }
+              } else {
+                if (await commit2.mode() !== await workdir.mode()) {
+                  if (force) {
+                    return [
+                      "update",
+                      fullpath,
+                      await commit2.oid(),
+                      await commit2.mode(),
+                      true
+                    ];
+                  } else {
+                    return ["conflict", fullpath];
+                  }
+                } else {
+                  return [
+                    "create-index",
+                    fullpath,
+                    await commit2.oid(),
+                    await commit2.mode()
+                  ];
+                }
+              }
+            }
+            case "commit-tree": {
+              return;
+            }
+            case "commit-blob": {
+              return ["conflict", fullpath];
+            }
+            default: {
+              return ["error", `new entry Unhandled type ${commit2.type}`];
+            }
+          }
+        }
+        // Something in stage but not in the commit OR the workdir.
+        // Note: I verified this behavior against canonical git.
+        case "100": {
+          return ["delete-index", fullpath];
+        }
+        // Deleted entries
+        // TODO: How to handle if stage type and workdir type mismatch?
+        case "101": {
+          switch (await stage.type()) {
+            case "tree": {
+              return ["rmdir", fullpath];
+            }
+            case "blob": {
+              if (await stage.oid() !== await workdir.oid()) {
+                if (force) {
+                  return ["delete", fullpath];
+                } else {
+                  return ["conflict", fullpath];
+                }
+              } else {
+                return ["delete", fullpath];
+              }
+            }
+            case "commit": {
+              return ["rmdir-index", fullpath];
+            }
+            default: {
+              return [
+                "error",
+                `delete entry Unhandled type ${await stage.type()}`
+              ];
+            }
+          }
+        }
+        /* eslint-disable no-fallthrough */
+        // File missing from workdir
+        case "110":
+        // Possibly modified entries
+        case "111": {
+          switch (`${await stage.type()}-${await commit2.type()}`) {
+            case "tree-tree": {
+              return;
+            }
+            case "blob-blob": {
+              if (await stage.oid() === await commit2.oid() && await stage.mode() === await commit2.mode() && !force) {
+                return;
+              }
+              if (workdir) {
+                if (await workdir.oid() !== await stage.oid() && await workdir.oid() !== await commit2.oid()) {
+                  if (force) {
+                    return [
+                      "update",
+                      fullpath,
+                      await commit2.oid(),
+                      await commit2.mode(),
+                      await commit2.mode() !== await workdir.mode()
+                    ];
+                  } else {
+                    return ["conflict", fullpath];
+                  }
+                }
+              } else if (force) {
+                return [
+                  "update",
+                  fullpath,
+                  await commit2.oid(),
+                  await commit2.mode(),
+                  await commit2.mode() !== await stage.mode()
+                ];
+              }
+              if (await commit2.mode() !== await stage.mode()) {
+                return [
+                  "update",
+                  fullpath,
+                  await commit2.oid(),
+                  await commit2.mode(),
+                  true
+                ];
+              }
+              if (await commit2.oid() !== await stage.oid()) {
+                return [
+                  "update",
+                  fullpath,
+                  await commit2.oid(),
+                  await commit2.mode(),
+                  false
+                ];
+              } else {
+                return;
+              }
+            }
+            case "tree-blob": {
+              return ["update-dir-to-blob", fullpath, await commit2.oid()];
+            }
+            case "blob-tree": {
+              return ["update-blob-to-tree", fullpath];
+            }
+            case "commit-commit": {
+              return [
+                "mkdir-index",
+                fullpath,
+                await commit2.oid(),
+                await commit2.mode()
+              ];
+            }
+            default: {
+              return [
+                "error",
+                `update entry Unhandled type ${await stage.type()}-${await commit2.type()}`
+              ];
+            }
+          }
+        }
+      }
+    },
+    // Modify the default flat mapping
+    reduce: async function(parent, children) {
+      children = flat(children);
+      if (!parent) {
+        return children;
+      } else if (parent && parent[0] === "rmdir") {
+        children.push(parent);
+        return children;
+      } else {
+        children.unshift(parent);
+        return children;
+      }
+    }
+  });
+}
+async function checkout({
+  fs,
+  onProgress,
+  onPostCheckout,
+  dir,
+  gitdir = join(dir, ".git"),
+  remote = "origin",
+  ref: _ref,
+  filepaths,
+  noCheckout = false,
+  noUpdateHead = _ref === void 0,
+  dryRun = false,
+  force = false,
+  track = true,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("dir", dir);
+    assertParameter("gitdir", gitdir);
+    const ref = _ref || "HEAD";
+    return await _checkout({
+      fs: new FileSystem(fs),
+      cache,
+      onProgress,
+      onPostCheckout,
+      dir,
+      gitdir,
+      remote,
+      ref,
+      filepaths,
+      noCheckout,
+      noUpdateHead,
+      dryRun,
+      force,
+      track
+    });
+  } catch (err) {
+    err.caller = "git.checkout";
+    throw err;
+  }
+}
+var abbreviateRx = new RegExp("^refs/(heads/|tags/|remotes/)?(.*)");
+function abbreviateRef(ref) {
+  const match = abbreviateRx.exec(ref);
+  if (match) {
+    if (match[1] === "remotes/" && ref.endsWith("/HEAD")) {
+      return match[2].slice(0, -5);
+    } else {
+      return match[2];
+    }
+  }
+  return ref;
+}
+async function _currentBranch({
+  fs,
+  gitdir,
+  fullname = false,
+  test = false
+}) {
+  const ref = await GitRefManager.resolve({
+    fs,
+    gitdir,
+    ref: "HEAD",
+    depth: 2
+  });
+  if (test) {
+    try {
+      await GitRefManager.resolve({ fs, gitdir, ref });
+    } catch (_) {
+      return;
+    }
+  }
+  if (!ref.startsWith("refs/")) return;
+  return fullname ? ref : abbreviateRef(ref);
+}
+function translateSSHtoHTTP(url) {
+  url = url.replace(/^git@([^:]+):/, "https://$1/");
+  url = url.replace(/^ssh:\/\//, "https://");
+  return url;
+}
+function calculateBasicAuthHeader({ username = "", password = "" }) {
+  return `Basic ${import_buffer.Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+async function forAwait(iterable, cb) {
+  const iter = getIterator(iterable);
+  while (true) {
+    const { value, done } = await iter.next();
+    if (value) await cb(value);
+    if (done) break;
+  }
+  if (iter.return) iter.return();
+}
+async function collect(iterable) {
+  let size = 0;
+  const buffers = [];
+  await forAwait(iterable, (value) => {
+    buffers.push(value);
+    size += value.byteLength;
+  });
+  const result = new Uint8Array(size);
+  let nextIndex = 0;
+  for (const buffer of buffers) {
+    result.set(buffer, nextIndex);
+    nextIndex += buffer.byteLength;
+  }
+  return result;
+}
+function extractAuthFromUrl(url) {
+  let userpass = url.match(/^https?:\/\/([^/]+)@/);
+  if (userpass == null) return { url, auth: {} };
+  userpass = userpass[1];
+  const [username, password] = userpass.split(":");
+  url = url.replace(`${userpass}@`, "");
+  return { url, auth: { username, password } };
+}
+function padHex(b, n) {
+  const s = n.toString(16);
+  return "0".repeat(b - s.length) + s;
+}
+var GitPktLine = class {
+  static flush() {
+    return import_buffer.Buffer.from("0000", "utf8");
+  }
+  static delim() {
+    return import_buffer.Buffer.from("0001", "utf8");
+  }
+  static encode(line) {
+    if (typeof line === "string") {
+      line = import_buffer.Buffer.from(line);
+    }
+    const length = line.length + 4;
+    const hexlength = padHex(4, length);
+    return import_buffer.Buffer.concat([import_buffer.Buffer.from(hexlength, "utf8"), line]);
+  }
+  static streamReader(stream) {
+    const reader = new StreamReader(stream);
+    return async function read() {
+      try {
+        let length = await reader.read(4);
+        if (length == null) return true;
+        length = parseInt(length.toString("utf8"), 16);
+        if (length === 0) return null;
+        if (length === 1) return null;
+        const buffer = await reader.read(length - 4);
+        if (buffer == null) return true;
+        return buffer;
+      } catch (err) {
+        stream.error = err;
+        return true;
+      }
+    };
+  }
+};
+async function parseCapabilitiesV2(read) {
+  const capabilities2 = {};
+  let line;
+  while (true) {
+    line = await read();
+    if (line === true) break;
+    if (line === null) continue;
+    line = line.toString("utf8").replace(/\n$/, "");
+    const i = line.indexOf("=");
+    if (i > -1) {
+      const key = line.slice(0, i);
+      const value = line.slice(i + 1);
+      capabilities2[key] = value;
+    } else {
+      capabilities2[line] = true;
+    }
+  }
+  return { protocolVersion: 2, capabilities2 };
+}
+async function parseRefsAdResponse(stream, { service }) {
+  const capabilities = /* @__PURE__ */ new Set();
+  const refs = /* @__PURE__ */ new Map();
+  const symrefs = /* @__PURE__ */ new Map();
+  const read = GitPktLine.streamReader(stream);
+  let lineOne = await read();
+  while (lineOne === null) lineOne = await read();
+  if (lineOne === true) throw new EmptyServerResponseError();
+  if (lineOne.includes("version 2")) {
+    return parseCapabilitiesV2(read);
+  }
+  if (lineOne.toString("utf8").replace(/\n$/, "") !== `# service=${service}`) {
+    throw new ParseError(`# service=${service}\\n`, lineOne.toString("utf8"));
+  }
+  let lineTwo = await read();
+  while (lineTwo === null) lineTwo = await read();
+  if (lineTwo === true) return { capabilities, refs, symrefs };
+  lineTwo = lineTwo.toString("utf8");
+  if (lineTwo.includes("version 2")) {
+    return parseCapabilitiesV2(read);
+  }
+  const [firstRef, capabilitiesLine] = splitAndAssert(lineTwo, "\0", "\\x00");
+  capabilitiesLine.split(" ").map((x) => capabilities.add(x));
+  if (firstRef !== "0000000000000000000000000000000000000000 capabilities^{}") {
+    const [ref, name] = splitAndAssert(firstRef, " ", " ");
+    refs.set(name, ref);
+    while (true) {
+      const line = await read();
+      if (line === true) break;
+      if (line !== null) {
+        const [ref2, name2] = splitAndAssert(line.toString("utf8"), " ", " ");
+        refs.set(name2, ref2);
+      }
+    }
+  }
+  for (const cap of capabilities) {
+    if (cap.startsWith("symref=")) {
+      const m = cap.match(/symref=([^:]+):(.*)/);
+      if (m.length === 3) {
+        symrefs.set(m[1], m[2]);
+      }
+    }
+  }
+  return { protocolVersion: 1, capabilities, refs, symrefs };
+}
+function splitAndAssert(line, sep, expected) {
+  const split = line.trim().split(sep);
+  if (split.length !== 2) {
+    throw new ParseError(
+      `Two strings separated by '${expected}'`,
+      line.toString("utf8")
+    );
+  }
+  return split;
+}
+var corsProxify = (corsProxy, url) => corsProxy.endsWith("?") ? `${corsProxy}${url}` : `${corsProxy}/${url.replace(/^https?:\/\//, "")}`;
+var updateHeaders = (headers, auth) => {
+  if (auth.username || auth.password) {
+    headers.Authorization = calculateBasicAuthHeader(auth);
+  }
+  if (auth.headers) {
+    Object.assign(headers, auth.headers);
+  }
+};
+var stringifyBody = async (res) => {
+  try {
+    const data = import_buffer.Buffer.from(await collect(res.body));
+    const response = data.toString("utf8");
+    const preview = response.length < 256 ? response : response.slice(0, 256) + "...";
+    return { preview, response, data };
+  } catch (e) {
+    return {};
+  }
+};
+var GitRemoteHTTP = class {
+  static async capabilities() {
+    return ["discover", "connect"];
+  }
+  /**
+   * @param {Object} args
+   * @param {HttpClient} args.http
+   * @param {ProgressCallback} [args.onProgress]
+   * @param {AuthCallback} [args.onAuth]
+   * @param {AuthFailureCallback} [args.onAuthFailure]
+   * @param {AuthSuccessCallback} [args.onAuthSuccess]
+   * @param {string} [args.corsProxy]
+   * @param {string} args.service
+   * @param {string} args.url
+   * @param {Object<string, string>} args.headers
+   * @param {1 | 2} args.protocolVersion - Git Protocol Version
+   */
+  static async discover({
+    http,
+    onProgress,
+    onAuth,
+    onAuthSuccess,
+    onAuthFailure,
+    corsProxy,
+    service,
+    url: _origUrl,
+    headers,
+    protocolVersion
+  }) {
+    let { url, auth } = extractAuthFromUrl(_origUrl);
+    const proxifiedURL = corsProxy ? corsProxify(corsProxy, url) : url;
+    if (auth.username || auth.password) {
+      headers.Authorization = calculateBasicAuthHeader(auth);
+    }
+    if (protocolVersion === 2) {
+      headers["Git-Protocol"] = "version=2";
+    }
+    let res;
+    let tryAgain;
+    let providedAuthBefore = false;
+    do {
+      res = await http.request({
+        onProgress,
+        method: "GET",
+        url: `${proxifiedURL}/info/refs?service=${service}`,
+        headers
+      });
+      tryAgain = false;
+      if (res.statusCode === 401 || res.statusCode === 203) {
+        const getAuth = providedAuthBefore ? onAuthFailure : onAuth;
+        if (getAuth) {
+          auth = await getAuth(url, {
+            ...auth,
+            headers: { ...headers }
+          });
+          if (auth && auth.cancel) {
+            throw new UserCanceledError();
+          } else if (auth) {
+            updateHeaders(headers, auth);
+            providedAuthBefore = true;
+            tryAgain = true;
+          }
+        }
+      } else if (res.statusCode === 200 && providedAuthBefore && onAuthSuccess) {
+        await onAuthSuccess(url, auth);
+      }
+    } while (tryAgain);
+    if (res.statusCode !== 200) {
+      const { response } = await stringifyBody(res);
+      throw new HttpError(res.statusCode, res.statusMessage, response);
+    }
+    if (res.headers["content-type"] === `application/x-${service}-advertisement`) {
+      const remoteHTTP = await parseRefsAdResponse(res.body, { service });
+      remoteHTTP.auth = auth;
+      return remoteHTTP;
+    } else {
+      const { preview, response, data } = await stringifyBody(res);
+      try {
+        const remoteHTTP = await parseRefsAdResponse([data], { service });
+        remoteHTTP.auth = auth;
+        return remoteHTTP;
+      } catch (e) {
+        throw new SmartHttpError(preview, response);
+      }
+    }
+  }
+  /**
+   * @param {Object} args
+   * @param {HttpClient} args.http
+   * @param {ProgressCallback} [args.onProgress]
+   * @param {string} [args.corsProxy]
+   * @param {string} args.service
+   * @param {string} args.url
+   * @param {Object<string, string>} [args.headers]
+   * @param {any} args.body
+   * @param {any} args.auth
+   */
+  static async connect({
+    http,
+    onProgress,
+    corsProxy,
+    service,
+    url,
+    auth,
+    body,
+    headers
+  }) {
+    const urlAuth = extractAuthFromUrl(url);
+    if (urlAuth) url = urlAuth.url;
+    if (corsProxy) url = corsProxify(corsProxy, url);
+    headers["content-type"] = `application/x-${service}-request`;
+    headers.accept = `application/x-${service}-result`;
+    updateHeaders(headers, auth);
+    const res = await http.request({
+      onProgress,
+      method: "POST",
+      url: `${url}/${service}`,
+      body,
+      headers
+    });
+    if (res.statusCode !== 200) {
+      const { response } = stringifyBody(res);
+      throw new HttpError(res.statusCode, res.statusMessage, response);
+    }
+    return res;
+  }
+};
+function parseRemoteUrl({ url }) {
+  if (url.startsWith("git@")) {
+    return {
+      transport: "ssh",
+      address: url
+    };
+  }
+  const matches = url.match(/(\w+)(:\/\/|::)(.*)/);
+  if (matches === null) return;
+  if (matches[2] === "://") {
+    return {
+      transport: matches[1],
+      address: matches[0]
+    };
+  }
+  if (matches[2] === "::") {
+    return {
+      transport: matches[1],
+      address: matches[3]
+    };
+  }
+}
+var GitRemoteManager = class {
+  static getRemoteHelperFor({ url }) {
+    const remoteHelpers = /* @__PURE__ */ new Map();
+    remoteHelpers.set("http", GitRemoteHTTP);
+    remoteHelpers.set("https", GitRemoteHTTP);
+    const parts = parseRemoteUrl({ url });
+    if (!parts) {
+      throw new UrlParseError(url);
+    }
+    if (remoteHelpers.has(parts.transport)) {
+      return remoteHelpers.get(parts.transport);
+    }
+    throw new UnknownTransportError(
+      url,
+      parts.transport,
+      parts.transport === "ssh" ? translateSSHtoHTTP(url) : void 0
+    );
+  }
+};
+var lock$2 = null;
+var GitShallowManager = class {
+  static async read({ fs, gitdir }) {
+    if (lock$2 === null) lock$2 = new import_async_lock.default();
+    const filepath = join(gitdir, "shallow");
+    const oids = /* @__PURE__ */ new Set();
+    await lock$2.acquire(filepath, async function() {
+      const text = await fs.read(filepath, { encoding: "utf8" });
+      if (text === null) return oids;
+      if (text.trim() === "") return oids;
+      text.trim().split("\n").map((oid) => oids.add(oid));
+    });
+    return oids;
+  }
+  static async write({ fs, gitdir, oids }) {
+    if (lock$2 === null) lock$2 = new import_async_lock.default();
+    const filepath = join(gitdir, "shallow");
+    if (oids.size > 0) {
+      const text = [...oids].join("\n") + "\n";
+      await lock$2.acquire(filepath, async function() {
+        await fs.write(filepath, text, {
+          encoding: "utf8"
+        });
+      });
+    } else {
+      await lock$2.acquire(filepath, async function() {
+        await fs.rm(filepath);
+      });
+    }
+  }
+};
+async function hasObjectLoose({ fs, gitdir, oid }) {
+  const source = `objects/${oid.slice(0, 2)}/${oid.slice(2)}`;
+  return fs.exists(`${gitdir}/${source}`);
+}
+async function hasObjectPacked({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  getExternalRefDelta
+}) {
+  let list = await fs.readdir(join(gitdir, "objects/pack"));
+  list = list.filter((x) => x.endsWith(".idx"));
+  for (const filename of list) {
+    const indexFile = `${gitdir}/objects/pack/${filename}`;
+    const p = await readPackIndex({
+      fs,
+      cache,
+      filename: indexFile,
+      getExternalRefDelta
+    });
+    if (p.error) throw new InternalError(p.error);
+    if (p.offsets.has(oid)) {
+      return true;
+    }
+  }
+  return false;
+}
+async function hasObject({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  format = "content"
+}) {
+  const getExternalRefDelta = (oid2) => _readObject({ fs, cache, gitdir, oid: oid2 });
+  let result = await hasObjectLoose({ fs, gitdir, oid });
+  if (!result) {
+    result = await hasObjectPacked({
+      fs,
+      cache,
+      gitdir,
+      oid,
+      getExternalRefDelta
+    });
+  }
+  return result;
+}
+function emptyPackfile(pack) {
+  const pheader = "5041434b";
+  const version2 = "00000002";
+  const obCount = "00000000";
+  const header = pheader + version2 + obCount;
+  return pack.slice(0, 12).toString("hex") === header;
+}
+function filterCapabilities(server, client) {
+  const serverNames = server.map((cap) => cap.split("=", 1)[0]);
+  return client.filter((cap) => {
+    const name = cap.split("=", 1)[0];
+    return serverNames.includes(name);
+  });
+}
+var pkg = {
+  name: "isomorphic-git",
+  version: "1.27.1",
+  agent: "git/isomorphic-git@1.27.1"
+};
+var FIFO = class {
+  constructor() {
+    this._queue = [];
+  }
+  write(chunk) {
+    if (this._ended) {
+      throw Error("You cannot write to a FIFO that has already been ended!");
+    }
+    if (this._waiting) {
+      const resolve = this._waiting;
+      this._waiting = null;
+      resolve({ value: chunk });
+    } else {
+      this._queue.push(chunk);
+    }
+  }
+  end() {
+    this._ended = true;
+    if (this._waiting) {
+      const resolve = this._waiting;
+      this._waiting = null;
+      resolve({ done: true });
+    }
+  }
+  destroy(err) {
+    this.error = err;
+    this.end();
+  }
+  async next() {
+    if (this._queue.length > 0) {
+      return { value: this._queue.shift() };
+    }
+    if (this._ended) {
+      return { done: true };
+    }
+    if (this._waiting) {
+      throw Error(
+        "You cannot call read until the previous call to read has returned!"
+      );
+    }
+    return new Promise((resolve) => {
+      this._waiting = resolve;
+    });
+  }
+};
+function findSplit(str) {
+  const r = str.indexOf("\r");
+  const n = str.indexOf("\n");
+  if (r === -1 && n === -1) return -1;
+  if (r === -1) return n + 1;
+  if (n === -1) return r + 1;
+  if (n === r + 1) return n + 1;
+  return Math.min(r, n) + 1;
+}
+function splitLines(input) {
+  const output = new FIFO();
+  let tmp = "";
+  (async () => {
+    await forAwait(input, (chunk) => {
+      chunk = chunk.toString("utf8");
+      tmp += chunk;
+      while (true) {
+        const i = findSplit(tmp);
+        if (i === -1) break;
+        output.write(tmp.slice(0, i));
+        tmp = tmp.slice(i);
+      }
+    });
+    if (tmp.length > 0) {
+      output.write(tmp);
+    }
+    output.end();
+  })();
+  return output;
+}
+var GitSideBand = class {
+  static demux(input) {
+    const read = GitPktLine.streamReader(input);
+    const packetlines = new FIFO();
+    const packfile = new FIFO();
+    const progress = new FIFO();
+    const nextBit = async function() {
+      const line = await read();
+      if (line === null) return nextBit();
+      if (line === true) {
+        packetlines.end();
+        progress.end();
+        input.error ? packfile.destroy(input.error) : packfile.end();
+        return;
+      }
+      switch (line[0]) {
+        case 1: {
+          packfile.write(line.slice(1));
+          break;
+        }
+        case 2: {
+          progress.write(line.slice(1));
+          break;
+        }
+        case 3: {
+          const error = line.slice(1);
+          progress.write(error);
+          packetlines.end();
+          progress.end();
+          packfile.destroy(new Error(error.toString("utf8")));
+          return;
+        }
+        default: {
+          packetlines.write(line);
+        }
+      }
+      nextBit();
+    };
+    nextBit();
+    return {
+      packetlines,
+      packfile,
+      progress
+    };
+  }
+  // static mux ({
+  //   protocol, // 'side-band' or 'side-band-64k'
+  //   packetlines,
+  //   packfile,
+  //   progress,
+  //   error
+  // }) {
+  //   const MAX_PACKET_LENGTH = protocol === 'side-band-64k' ? 999 : 65519
+  //   let output = new PassThrough()
+  //   packetlines.on('data', data => {
+  //     if (data === null) {
+  //       output.write(GitPktLine.flush())
+  //     } else {
+  //       output.write(GitPktLine.encode(data))
+  //     }
+  //   })
+  //   let packfileWasEmpty = true
+  //   let packfileEnded = false
+  //   let progressEnded = false
+  //   let errorEnded = false
+  //   let goodbye = Buffer.concat([
+  //     GitPktLine.encode(Buffer.from('010A', 'hex')),
+  //     GitPktLine.flush()
+  //   ])
+  //   packfile
+  //     .on('data', data => {
+  //       packfileWasEmpty = false
+  //       const buffers = splitBuffer(data, MAX_PACKET_LENGTH)
+  //       for (const buffer of buffers) {
+  //         output.write(
+  //           GitPktLine.encode(Buffer.concat([Buffer.from('01', 'hex'), buffer]))
+  //         )
+  //       }
+  //     })
+  //     .on('end', () => {
+  //       packfileEnded = true
+  //       if (!packfileWasEmpty) output.write(goodbye)
+  //       if (progressEnded && errorEnded) output.end()
+  //     })
+  //   progress
+  //     .on('data', data => {
+  //       const buffers = splitBuffer(data, MAX_PACKET_LENGTH)
+  //       for (const buffer of buffers) {
+  //         output.write(
+  //           GitPktLine.encode(Buffer.concat([Buffer.from('02', 'hex'), buffer]))
+  //         )
+  //       }
+  //     })
+  //     .on('end', () => {
+  //       progressEnded = true
+  //       if (packfileEnded && errorEnded) output.end()
+  //     })
+  //   error
+  //     .on('data', data => {
+  //       const buffers = splitBuffer(data, MAX_PACKET_LENGTH)
+  //       for (const buffer of buffers) {
+  //         output.write(
+  //           GitPktLine.encode(Buffer.concat([Buffer.from('03', 'hex'), buffer]))
+  //         )
+  //       }
+  //     })
+  //     .on('end', () => {
+  //       errorEnded = true
+  //       if (progressEnded && packfileEnded) output.end()
+  //     })
+  //   return output
+  // }
+};
+async function parseUploadPackResponse(stream) {
+  const { packetlines, packfile, progress } = GitSideBand.demux(stream);
+  const shallows = [];
+  const unshallows = [];
+  const acks = [];
+  let nak = false;
+  let done = false;
+  return new Promise((resolve, reject) => {
+    forAwait(packetlines, (data) => {
+      const line = data.toString("utf8").trim();
+      if (line.startsWith("shallow")) {
+        const oid = line.slice(-41).trim();
+        if (oid.length !== 40) {
+          reject(new InvalidOidError(oid));
+        }
+        shallows.push(oid);
+      } else if (line.startsWith("unshallow")) {
+        const oid = line.slice(-41).trim();
+        if (oid.length !== 40) {
+          reject(new InvalidOidError(oid));
+        }
+        unshallows.push(oid);
+      } else if (line.startsWith("ACK")) {
+        const [, oid, status2] = line.split(" ");
+        acks.push({ oid, status: status2 });
+        if (!status2) done = true;
+      } else if (line.startsWith("NAK")) {
+        nak = true;
+        done = true;
+      } else {
+        done = true;
+        nak = true;
+      }
+      if (done) {
+        stream.error ? reject(stream.error) : resolve({ shallows, unshallows, acks, nak, packfile, progress });
+      }
+    }).finally(() => {
+      if (!done) {
+        stream.error ? reject(stream.error) : resolve({ shallows, unshallows, acks, nak, packfile, progress });
+      }
+    });
+  });
+}
+function writeUploadPackRequest({
+  capabilities = [],
+  wants = [],
+  haves = [],
+  shallows = [],
+  depth = null,
+  since = null,
+  exclude = []
+}) {
+  const packstream = [];
+  wants = [...new Set(wants)];
+  let firstLineCapabilities = ` ${capabilities.join(" ")}`;
+  for (const oid of wants) {
+    packstream.push(GitPktLine.encode(`want ${oid}${firstLineCapabilities}
+`));
+    firstLineCapabilities = "";
+  }
+  for (const oid of shallows) {
+    packstream.push(GitPktLine.encode(`shallow ${oid}
+`));
+  }
+  if (depth !== null) {
+    packstream.push(GitPktLine.encode(`deepen ${depth}
+`));
+  }
+  if (since !== null) {
+    packstream.push(
+      GitPktLine.encode(`deepen-since ${Math.floor(since.valueOf() / 1e3)}
+`)
+    );
+  }
+  for (const oid of exclude) {
+    packstream.push(GitPktLine.encode(`deepen-not ${oid}
+`));
+  }
+  packstream.push(GitPktLine.flush());
+  for (const oid of haves) {
+    packstream.push(GitPktLine.encode(`have ${oid}
+`));
+  }
+  packstream.push(GitPktLine.encode(`done
+`));
+  return packstream;
+}
+async function _fetch({
+  fs,
+  cache,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  gitdir,
+  ref: _ref,
+  remoteRef: _remoteRef,
+  remote: _remote,
+  url: _url,
+  corsProxy,
+  depth = null,
+  since = null,
+  exclude = [],
+  relative = false,
+  tags = false,
+  singleBranch = false,
+  headers = {},
+  prune = false,
+  pruneTags = false
+}) {
+  const ref = _ref || await _currentBranch({ fs, gitdir, test: true });
+  const config = await GitConfigManager.get({ fs, gitdir });
+  const remote = _remote || ref && await config.get(`branch.${ref}.remote`) || "origin";
+  const url = _url || await config.get(`remote.${remote}.url`);
+  if (typeof url === "undefined") {
+    throw new MissingParameterError("remote OR url");
+  }
+  const remoteRef = _remoteRef || ref && await config.get(`branch.${ref}.merge`) || _ref || "HEAD";
+  if (corsProxy === void 0) {
+    corsProxy = await config.get("http.corsProxy");
+  }
+  const GitRemoteHTTP2 = GitRemoteManager.getRemoteHelperFor({ url });
+  const remoteHTTP = await GitRemoteHTTP2.discover({
+    http,
+    onAuth,
+    onAuthSuccess,
+    onAuthFailure,
+    corsProxy,
+    service: "git-upload-pack",
+    url,
+    headers,
+    protocolVersion: 1
+  });
+  const auth = remoteHTTP.auth;
+  const remoteRefs = remoteHTTP.refs;
+  if (remoteRefs.size === 0) {
+    return {
+      defaultBranch: null,
+      fetchHead: null,
+      fetchHeadDescription: null
+    };
+  }
+  if (depth !== null && !remoteHTTP.capabilities.has("shallow")) {
+    throw new RemoteCapabilityError("shallow", "depth");
+  }
+  if (since !== null && !remoteHTTP.capabilities.has("deepen-since")) {
+    throw new RemoteCapabilityError("deepen-since", "since");
+  }
+  if (exclude.length > 0 && !remoteHTTP.capabilities.has("deepen-not")) {
+    throw new RemoteCapabilityError("deepen-not", "exclude");
+  }
+  if (relative === true && !remoteHTTP.capabilities.has("deepen-relative")) {
+    throw new RemoteCapabilityError("deepen-relative", "relative");
+  }
+  const { oid, fullref } = GitRefManager.resolveAgainstMap({
+    ref: remoteRef,
+    map: remoteRefs
+  });
+  for (const remoteRef2 of remoteRefs.keys()) {
+    if (remoteRef2 === fullref || remoteRef2 === "HEAD" || remoteRef2.startsWith("refs/heads/") || tags && remoteRef2.startsWith("refs/tags/")) {
+      continue;
+    }
+    remoteRefs.delete(remoteRef2);
+  }
+  const capabilities = filterCapabilities(
+    [...remoteHTTP.capabilities],
+    [
+      "multi_ack_detailed",
+      "no-done",
+      "side-band-64k",
+      // Note: I removed 'thin-pack' option since our code doesn't "fatten" packfiles,
+      // which is necessary for compatibility with git. It was the cause of mysterious
+      // 'fatal: pack has [x] unresolved deltas' errors that plagued us for some time.
+      // isomorphic-git is perfectly happy with thin packfiles in .git/objects/pack but
+      // canonical git it turns out is NOT.
+      "ofs-delta",
+      `agent=${pkg.agent}`
+    ]
+  );
+  if (relative) capabilities.push("deepen-relative");
+  const wants = singleBranch ? [oid] : remoteRefs.values();
+  const haveRefs = singleBranch ? [ref] : await GitRefManager.listRefs({
+    fs,
+    gitdir,
+    filepath: `refs`
+  });
+  let haves = [];
+  for (let ref2 of haveRefs) {
+    try {
+      ref2 = await GitRefManager.expand({ fs, gitdir, ref: ref2 });
+      const oid2 = await GitRefManager.resolve({ fs, gitdir, ref: ref2 });
+      if (await hasObject({ fs, cache, gitdir, oid: oid2 })) {
+        haves.push(oid2);
+      }
+    } catch (err) {
+    }
+  }
+  haves = [...new Set(haves)];
+  const oids = await GitShallowManager.read({ fs, gitdir });
+  const shallows = remoteHTTP.capabilities.has("shallow") ? [...oids] : [];
+  const packstream = writeUploadPackRequest({
+    capabilities,
+    wants,
+    haves,
+    shallows,
+    depth,
+    since,
+    exclude
+  });
+  const packbuffer = import_buffer.Buffer.from(await collect(packstream));
+  const raw = await GitRemoteHTTP2.connect({
+    http,
+    onProgress,
+    corsProxy,
+    service: "git-upload-pack",
+    url,
+    auth,
+    body: [packbuffer],
+    headers
+  });
+  const response = await parseUploadPackResponse(raw.body);
+  if (raw.headers) {
+    response.headers = raw.headers;
+  }
+  for (const oid2 of response.shallows) {
+    if (!oids.has(oid2)) {
+      try {
+        const { object } = await _readObject({ fs, cache, gitdir, oid: oid2 });
+        const commit2 = new GitCommit(object);
+        const hasParents = await Promise.all(
+          commit2.headers().parent.map((oid3) => hasObject({ fs, cache, gitdir, oid: oid3 }))
+        );
+        const haveAllParents = hasParents.length === 0 || hasParents.every((has) => has);
+        if (!haveAllParents) {
+          oids.add(oid2);
+        }
+      } catch (err) {
+        oids.add(oid2);
+      }
+    }
+  }
+  for (const oid2 of response.unshallows) {
+    oids.delete(oid2);
+  }
+  await GitShallowManager.write({ fs, gitdir, oids });
+  if (singleBranch) {
+    const refs = /* @__PURE__ */ new Map([[fullref, oid]]);
+    const symrefs = /* @__PURE__ */ new Map();
+    let bail = 10;
+    let key = fullref;
+    while (bail--) {
+      const value = remoteHTTP.symrefs.get(key);
+      if (value === void 0) break;
+      symrefs.set(key, value);
+      key = value;
+    }
+    const realRef = remoteRefs.get(key);
+    if (realRef) {
+      refs.set(key, realRef);
+    }
+    const { pruned } = await GitRefManager.updateRemoteRefs({
+      fs,
+      gitdir,
+      remote,
+      refs,
+      symrefs,
+      tags,
+      prune
+    });
+    if (prune) {
+      response.pruned = pruned;
+    }
+  } else {
+    const { pruned } = await GitRefManager.updateRemoteRefs({
+      fs,
+      gitdir,
+      remote,
+      refs: remoteRefs,
+      symrefs: remoteHTTP.symrefs,
+      tags,
+      prune,
+      pruneTags
+    });
+    if (prune) {
+      response.pruned = pruned;
+    }
+  }
+  response.HEAD = remoteHTTP.symrefs.get("HEAD");
+  if (response.HEAD === void 0) {
+    const { oid: oid2 } = GitRefManager.resolveAgainstMap({
+      ref: "HEAD",
+      map: remoteRefs
+    });
+    for (const [key, value] of remoteRefs.entries()) {
+      if (key !== "HEAD" && value === oid2) {
+        response.HEAD = key;
+        break;
+      }
+    }
+  }
+  const noun = fullref.startsWith("refs/tags") ? "tag" : "branch";
+  response.FETCH_HEAD = {
+    oid,
+    description: `${noun} '${abbreviateRef(fullref)}' of ${url}`
+  };
+  if (onProgress || onMessage) {
+    const lines = splitLines(response.progress);
+    forAwait(lines, async (line) => {
+      if (onMessage) await onMessage(line);
+      if (onProgress) {
+        const matches = line.match(/([^:]*).*\((\d+?)\/(\d+?)\)/);
+        if (matches) {
+          await onProgress({
+            phase: matches[1].trim(),
+            loaded: parseInt(matches[2], 10),
+            total: parseInt(matches[3], 10)
+          });
+        }
+      }
+    });
+  }
+  const packfile = import_buffer.Buffer.from(await collect(response.packfile));
+  if (raw.body.error) throw raw.body.error;
+  const packfileSha = packfile.slice(-20).toString("hex");
+  const res = {
+    defaultBranch: response.HEAD,
+    fetchHead: response.FETCH_HEAD.oid,
+    fetchHeadDescription: response.FETCH_HEAD.description
+  };
+  if (response.headers) {
+    res.headers = response.headers;
+  }
+  if (prune) {
+    res.pruned = response.pruned;
+  }
+  if (packfileSha !== "" && !emptyPackfile(packfile)) {
+    res.packfile = `objects/pack/pack-${packfileSha}.pack`;
+    const fullpath = join(gitdir, res.packfile);
+    await fs.write(fullpath, packfile);
+    const getExternalRefDelta = (oid2) => _readObject({ fs, cache, gitdir, oid: oid2 });
+    const idx = await GitPackIndex.fromPack({
+      pack: packfile,
+      getExternalRefDelta,
+      onProgress
+    });
+    await fs.write(fullpath.replace(/\.pack$/, ".idx"), await idx.toBuffer());
+  }
+  return res;
+}
+async function _init({
+  fs,
+  bare = false,
+  dir,
+  gitdir = bare ? dir : join(dir, ".git"),
+  defaultBranch = "master"
+}) {
+  if (await fs.exists(gitdir + "/config")) return;
+  let folders = [
+    "hooks",
+    "info",
+    "objects/info",
+    "objects/pack",
+    "refs/heads",
+    "refs/tags"
+  ];
+  folders = folders.map((dir2) => gitdir + "/" + dir2);
+  for (const folder of folders) {
+    await fs.mkdir(folder);
+  }
+  await fs.write(
+    gitdir + "/config",
+    `[core]
+	repositoryformatversion = 0
+	filemode = false
+	bare = ${bare}
+` + (bare ? "" : "	logallrefupdates = true\n") + "	symlinks = false\n	ignorecase = true\n"
+  );
+  await fs.write(gitdir + "/HEAD", `ref: refs/heads/${defaultBranch}
+`);
+}
+async function _clone({
+  fs,
+  cache,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  onPostCheckout,
+  dir,
+  gitdir,
+  url,
+  corsProxy,
+  ref,
+  remote,
+  depth,
+  since,
+  exclude,
+  relative,
+  singleBranch,
+  noCheckout,
+  noTags,
+  headers
+}) {
+  try {
+    await _init({ fs, gitdir });
+    await _addRemote({ fs, gitdir, remote, url, force: false });
+    if (corsProxy) {
+      const config = await GitConfigManager.get({ fs, gitdir });
+      await config.set(`http.corsProxy`, corsProxy);
+      await GitConfigManager.save({ fs, gitdir, config });
+    }
+    const { defaultBranch, fetchHead } = await _fetch({
+      fs,
+      cache,
+      http,
+      onProgress,
+      onMessage,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      gitdir,
+      ref,
+      remote,
+      corsProxy,
+      depth,
+      since,
+      exclude,
+      relative,
+      singleBranch,
+      headers,
+      tags: !noTags
+    });
+    if (fetchHead === null) return;
+    ref = ref || defaultBranch;
+    ref = ref.replace("refs/heads/", "");
+    await _checkout({
+      fs,
+      cache,
+      onProgress,
+      onPostCheckout,
+      dir,
+      gitdir,
+      ref,
+      remote,
+      noCheckout
+    });
+  } catch (err) {
+    await fs.rmdir(gitdir, { recursive: true, maxRetries: 10 }).catch(() => void 0);
+    throw err;
+  }
+}
+async function clone({
+  fs,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  onPostCheckout,
+  dir,
+  gitdir = join(dir, ".git"),
+  url,
+  corsProxy = void 0,
+  ref = void 0,
+  remote = "origin",
+  depth = void 0,
+  since = void 0,
+  exclude = [],
+  relative = false,
+  singleBranch = false,
+  noCheckout = false,
+  noTags = false,
+  headers = {},
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("http", http);
+    assertParameter("gitdir", gitdir);
+    if (!noCheckout) {
+      assertParameter("dir", dir);
+    }
+    assertParameter("url", url);
+    return await _clone({
+      fs: new FileSystem(fs),
+      cache,
+      http,
+      onProgress,
+      onMessage,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      onPostCheckout,
+      dir,
+      gitdir,
+      url,
+      corsProxy,
+      ref,
+      remote,
+      depth,
+      since,
+      exclude,
+      relative,
+      singleBranch,
+      noCheckout,
+      noTags,
+      headers
+    });
+  } catch (err) {
+    err.caller = "git.clone";
+    throw err;
+  }
+}
+async function commit({
+  fs: _fs,
+  onSign,
+  dir,
+  gitdir = join(dir, ".git"),
+  message,
+  author,
+  committer,
+  signingKey,
+  amend = false,
+  dryRun = false,
+  noUpdateBranch = false,
+  ref,
+  parent,
+  tree,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    if (!amend) {
+      assertParameter("message", message);
+    }
+    if (signingKey) {
+      assertParameter("onSign", onSign);
+    }
+    const fs = new FileSystem(_fs);
+    return await _commit({
+      fs,
+      cache,
+      onSign,
+      gitdir,
+      message,
+      author,
+      committer,
+      signingKey,
+      amend,
+      dryRun,
+      noUpdateBranch,
+      ref,
+      parent,
+      tree
+    });
+  } catch (err) {
+    err.caller = "git.commit";
+    throw err;
+  }
+}
+async function currentBranch({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  fullname = false,
+  test = false
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    return await _currentBranch({
+      fs: new FileSystem(fs),
+      gitdir,
+      fullname,
+      test
+    });
+  } catch (err) {
+    err.caller = "git.currentBranch";
+    throw err;
+  }
+}
+async function _deleteBranch({ fs, gitdir, ref }) {
+  ref = ref.startsWith("refs/heads/") ? ref : `refs/heads/${ref}`;
+  const exist = await GitRefManager.exists({ fs, gitdir, ref });
+  if (!exist) {
+    throw new NotFoundError(ref);
+  }
+  const fullRef = await GitRefManager.expand({ fs, gitdir, ref });
+  const currentRef = await _currentBranch({ fs, gitdir, fullname: true });
+  if (fullRef === currentRef) {
+    const value = await GitRefManager.resolve({ fs, gitdir, ref: fullRef });
+    await GitRefManager.writeRef({ fs, gitdir, ref: "HEAD", value });
+  }
+  await GitRefManager.deleteRef({ fs, gitdir, ref: fullRef });
+  const abbrevRef = abbreviateRef(ref);
+  const config = await GitConfigManager.get({ fs, gitdir });
+  await config.deleteSection("branch", abbrevRef);
+  await GitConfigManager.save({ fs, gitdir, config });
+}
+async function deleteBranch({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("ref", ref);
+    return await _deleteBranch({
+      fs: new FileSystem(fs),
+      gitdir,
+      ref
+    });
+  } catch (err) {
+    err.caller = "git.deleteBranch";
+    throw err;
+  }
+}
+async function deleteRef({ fs, dir, gitdir = join(dir, ".git"), ref }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("ref", ref);
+    await GitRefManager.deleteRef({ fs: new FileSystem(fs), gitdir, ref });
+  } catch (err) {
+    err.caller = "git.deleteRef";
+    throw err;
+  }
+}
+async function _deleteRemote({ fs, gitdir, remote }) {
+  const config = await GitConfigManager.get({ fs, gitdir });
+  await config.deleteSection("remote", remote);
+  await GitConfigManager.save({ fs, gitdir, config });
+}
+async function deleteRemote({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  remote
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("remote", remote);
+    return await _deleteRemote({
+      fs: new FileSystem(fs),
+      gitdir,
+      remote
+    });
+  } catch (err) {
+    err.caller = "git.deleteRemote";
+    throw err;
+  }
+}
+async function _deleteTag({ fs, gitdir, ref }) {
+  ref = ref.startsWith("refs/tags/") ? ref : `refs/tags/${ref}`;
+  await GitRefManager.deleteRef({ fs, gitdir, ref });
+}
+async function deleteTag({ fs, dir, gitdir = join(dir, ".git"), ref }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("ref", ref);
+    return await _deleteTag({
+      fs: new FileSystem(fs),
+      gitdir,
+      ref
+    });
+  } catch (err) {
+    err.caller = "git.deleteTag";
+    throw err;
+  }
+}
+async function expandOidLoose({ fs, gitdir, oid: short }) {
+  const prefix = short.slice(0, 2);
+  const objectsSuffixes = await fs.readdir(`${gitdir}/objects/${prefix}`);
+  return objectsSuffixes.map((suffix) => `${prefix}${suffix}`).filter((_oid) => _oid.startsWith(short));
+}
+async function expandOidPacked({
+  fs,
+  cache,
+  gitdir,
+  oid: short,
+  getExternalRefDelta
+}) {
+  const results = [];
+  let list = await fs.readdir(join(gitdir, "objects/pack"));
+  list = list.filter((x) => x.endsWith(".idx"));
+  for (const filename of list) {
+    const indexFile = `${gitdir}/objects/pack/${filename}`;
+    const p = await readPackIndex({
+      fs,
+      cache,
+      filename: indexFile,
+      getExternalRefDelta
+    });
+    if (p.error) throw new InternalError(p.error);
+    for (const oid of p.offsets.keys()) {
+      if (oid.startsWith(short)) results.push(oid);
+    }
+  }
+  return results;
+}
+async function _expandOid({ fs, cache, gitdir, oid: short }) {
+  const getExternalRefDelta = (oid) => _readObject({ fs, cache, gitdir, oid });
+  const results = await expandOidLoose({ fs, gitdir, oid: short });
+  const packedOids = await expandOidPacked({
+    fs,
+    cache,
+    gitdir,
+    oid: short,
+    getExternalRefDelta
+  });
+  for (const packedOid of packedOids) {
+    if (results.indexOf(packedOid) === -1) {
+      results.push(packedOid);
+    }
+  }
+  if (results.length === 1) {
+    return results[0];
+  }
+  if (results.length > 1) {
+    throw new AmbiguousError("oids", short, results);
+  }
+  throw new NotFoundError(`an object matching "${short}"`);
+}
+async function expandOid({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oid,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    return await _expandOid({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oid
+    });
+  } catch (err) {
+    err.caller = "git.expandOid";
+    throw err;
+  }
+}
+async function expandRef({ fs, dir, gitdir = join(dir, ".git"), ref }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    return await GitRefManager.expand({
+      fs: new FileSystem(fs),
+      gitdir,
+      ref
+    });
+  } catch (err) {
+    err.caller = "git.expandRef";
+    throw err;
+  }
+}
+async function _findMergeBase({ fs, cache, gitdir, oids }) {
+  const visits = {};
+  const passes = oids.length;
+  let heads = oids.map((oid, index3) => ({ index: index3, oid }));
+  while (heads.length) {
+    const result = /* @__PURE__ */ new Set();
+    for (const { oid, index: index3 } of heads) {
+      if (!visits[oid]) visits[oid] = /* @__PURE__ */ new Set();
+      visits[oid].add(index3);
+      if (visits[oid].size === passes) {
+        result.add(oid);
+      }
+    }
+    if (result.size > 0) {
+      return [...result];
+    }
+    const newheads = /* @__PURE__ */ new Map();
+    for (const { oid, index: index3 } of heads) {
+      try {
+        const { object } = await _readObject({ fs, cache, gitdir, oid });
+        const commit2 = GitCommit.from(object);
+        const { parent } = commit2.parseHeaders();
+        for (const oid2 of parent) {
+          if (!visits[oid2] || !visits[oid2].has(index3)) {
+            newheads.set(oid2 + ":" + index3, { oid: oid2, index: index3 });
+          }
+        }
+      } catch (err) {
+      }
+    }
+    heads = Array.from(newheads.values());
+  }
+  return [];
+}
+var LINEBREAKS = /^.*(\r?\n|$)/gm;
+function mergeFile({ branches, contents }) {
+  const ourName = branches[1];
+  const theirName = branches[2];
+  const baseContent = contents[0];
+  const ourContent = contents[1];
+  const theirContent = contents[2];
+  const ours = ourContent.match(LINEBREAKS);
+  const base = baseContent.match(LINEBREAKS);
+  const theirs = theirContent.match(LINEBREAKS);
+  const result = (0, import_diff3.default)(ours, base, theirs);
+  const markerSize = 7;
+  let mergedText = "";
+  let cleanMerge = true;
+  for (const item of result) {
+    if (item.ok) {
+      mergedText += item.ok.join("");
+    }
+    if (item.conflict) {
+      cleanMerge = false;
+      mergedText += `${"<".repeat(markerSize)} ${ourName}
+`;
+      mergedText += item.conflict.a.join("");
+      mergedText += `${"=".repeat(markerSize)}
+`;
+      mergedText += item.conflict.b.join("");
+      mergedText += `${">".repeat(markerSize)} ${theirName}
+`;
+    }
+  }
+  return { cleanMerge, mergedText };
+}
+async function mergeTree({
+  fs,
+  cache,
+  dir,
+  gitdir = join(dir, ".git"),
+  index: index3,
+  ourOid,
+  baseOid,
+  theirOid,
+  ourName = "ours",
+  baseName = "base",
+  theirName = "theirs",
+  dryRun = false,
+  abortOnConflict = true,
+  mergeDriver
+}) {
+  const ourTree = TREE({ ref: ourOid });
+  const baseTree = TREE({ ref: baseOid });
+  const theirTree = TREE({ ref: theirOid });
+  const unmergedFiles = [];
+  const bothModified = [];
+  const deleteByUs = [];
+  const deleteByTheirs = [];
+  const results = await _walk({
+    fs,
+    cache,
+    dir,
+    gitdir,
+    trees: [ourTree, baseTree, theirTree],
+    map: async function(filepath, [ours, base, theirs]) {
+      const path = basename(filepath);
+      const ourChange = await modified(ours, base);
+      const theirChange = await modified(theirs, base);
+      switch (`${ourChange}-${theirChange}`) {
+        case "false-false": {
+          return {
+            mode: await base.mode(),
+            path,
+            oid: await base.oid(),
+            type: await base.type()
+          };
+        }
+        case "false-true": {
+          return theirs ? {
+            mode: await theirs.mode(),
+            path,
+            oid: await theirs.oid(),
+            type: await theirs.type()
+          } : void 0;
+        }
+        case "true-false": {
+          return ours ? {
+            mode: await ours.mode(),
+            path,
+            oid: await ours.oid(),
+            type: await ours.type()
+          } : void 0;
+        }
+        case "true-true": {
+          if (ours && base && theirs && await ours.type() === "blob" && await base.type() === "blob" && await theirs.type() === "blob") {
+            return mergeBlobs({
+              fs,
+              gitdir,
+              path,
+              ours,
+              base,
+              theirs,
+              ourName,
+              baseName,
+              theirName,
+              mergeDriver
+            }).then(async (r) => {
+              if (!r.cleanMerge) {
+                unmergedFiles.push(filepath);
+                bothModified.push(filepath);
+                if (!abortOnConflict) {
+                  const baseOid2 = await base.oid();
+                  const ourOid2 = await ours.oid();
+                  const theirOid2 = await theirs.oid();
+                  index3.delete({ filepath });
+                  index3.insert({ filepath, oid: baseOid2, stage: 1 });
+                  index3.insert({ filepath, oid: ourOid2, stage: 2 });
+                  index3.insert({ filepath, oid: theirOid2, stage: 3 });
+                }
+              } else if (!abortOnConflict) {
+                index3.insert({ filepath, oid: r.mergeResult.oid, stage: 0 });
+              }
+              return r.mergeResult;
+            });
+          }
+          if (base && !ours && theirs && await base.type() === "blob" && await theirs.type() === "blob") {
+            unmergedFiles.push(filepath);
+            deleteByUs.push(filepath);
+            if (!abortOnConflict) {
+              const baseOid2 = await base.oid();
+              const theirOid2 = await theirs.oid();
+              index3.delete({ filepath });
+              index3.insert({ filepath, oid: baseOid2, stage: 1 });
+              index3.insert({ filepath, oid: theirOid2, stage: 3 });
+            }
+            return {
+              mode: await theirs.mode(),
+              oid: await theirs.oid(),
+              type: "blob",
+              path
+            };
+          }
+          if (base && ours && !theirs && await base.type() === "blob" && await ours.type() === "blob") {
+            unmergedFiles.push(filepath);
+            deleteByTheirs.push(filepath);
+            if (!abortOnConflict) {
+              const baseOid2 = await base.oid();
+              const ourOid2 = await ours.oid();
+              index3.delete({ filepath });
+              index3.insert({ filepath, oid: baseOid2, stage: 1 });
+              index3.insert({ filepath, oid: ourOid2, stage: 2 });
+            }
+            return {
+              mode: await ours.mode(),
+              oid: await ours.oid(),
+              type: "blob",
+              path
+            };
+          }
+          if (base && !ours && !theirs && await base.type() === "blob") {
+            return void 0;
+          }
+          throw new MergeNotSupportedError();
+        }
+      }
+    },
+    /**
+     * @param {TreeEntry} [parent]
+     * @param {Array<TreeEntry>} children
+     */
+    reduce: unmergedFiles.length !== 0 && (!dir || abortOnConflict) ? void 0 : async (parent, children) => {
+      const entries = children.filter(Boolean);
+      if (!parent) return;
+      if (parent && parent.type === "tree" && entries.length === 0) return;
+      if (entries.length > 0) {
+        const tree = new GitTree(entries);
+        const object = tree.toObject();
+        const oid = await _writeObject({
+          fs,
+          gitdir,
+          type: "tree",
+          object,
+          dryRun
+        });
+        parent.oid = oid;
+      }
+      return parent;
+    }
+  });
+  if (unmergedFiles.length !== 0) {
+    if (dir && !abortOnConflict) {
+      await _walk({
+        fs,
+        cache,
+        dir,
+        gitdir,
+        trees: [TREE({ ref: results.oid })],
+        map: async function(filepath, [entry]) {
+          const path = `${dir}/${filepath}`;
+          if (await entry.type() === "blob") {
+            const mode = await entry.mode();
+            const content = new TextDecoder().decode(await entry.content());
+            await fs.write(path, content, { mode });
+          }
+          return true;
+        }
+      });
+    }
+    return new MergeConflictError(
+      unmergedFiles,
+      bothModified,
+      deleteByUs,
+      deleteByTheirs
+    );
+  }
+  return results.oid;
+}
+async function mergeBlobs({
+  fs,
+  gitdir,
+  path,
+  ours,
+  base,
+  theirs,
+  ourName,
+  theirName,
+  baseName,
+  dryRun,
+  mergeDriver = mergeFile
+}) {
+  const type = "blob";
+  const mode = await base.mode() === await ours.mode() ? await theirs.mode() : await ours.mode();
+  if (await ours.oid() === await theirs.oid()) {
+    return {
+      cleanMerge: true,
+      mergeResult: { mode, path, oid: await ours.oid(), type }
+    };
+  }
+  if (await ours.oid() === await base.oid()) {
+    return {
+      cleanMerge: true,
+      mergeResult: { mode, path, oid: await theirs.oid(), type }
+    };
+  }
+  if (await theirs.oid() === await base.oid()) {
+    return {
+      cleanMerge: true,
+      mergeResult: { mode, path, oid: await ours.oid(), type }
+    };
+  }
+  const ourContent = import_buffer.Buffer.from(await ours.content()).toString("utf8");
+  const baseContent = import_buffer.Buffer.from(await base.content()).toString("utf8");
+  const theirContent = import_buffer.Buffer.from(await theirs.content()).toString("utf8");
+  const { mergedText, cleanMerge } = await mergeDriver({
+    branches: [baseName, ourName, theirName],
+    contents: [baseContent, ourContent, theirContent],
+    path
+  });
+  const oid = await _writeObject({
+    fs,
+    gitdir,
+    type: "blob",
+    object: import_buffer.Buffer.from(mergedText, "utf8"),
+    dryRun
+  });
+  return { cleanMerge, mergeResult: { mode, path, oid, type } };
+}
+async function _merge({
+  fs,
+  cache,
+  dir,
+  gitdir,
+  ours,
+  theirs,
+  fastForward: fastForward2 = true,
+  fastForwardOnly = false,
+  dryRun = false,
+  noUpdateBranch = false,
+  abortOnConflict = true,
+  message,
+  author,
+  committer,
+  signingKey,
+  onSign,
+  mergeDriver
+}) {
+  if (ours === void 0) {
+    ours = await _currentBranch({ fs, gitdir, fullname: true });
+  }
+  ours = await GitRefManager.expand({
+    fs,
+    gitdir,
+    ref: ours
+  });
+  theirs = await GitRefManager.expand({
+    fs,
+    gitdir,
+    ref: theirs
+  });
+  const ourOid = await GitRefManager.resolve({
+    fs,
+    gitdir,
+    ref: ours
+  });
+  const theirOid = await GitRefManager.resolve({
+    fs,
+    gitdir,
+    ref: theirs
+  });
+  const baseOids = await _findMergeBase({
+    fs,
+    cache,
+    gitdir,
+    oids: [ourOid, theirOid]
+  });
+  if (baseOids.length !== 1) {
+    throw new MergeNotSupportedError();
+  }
+  const baseOid = baseOids[0];
+  if (baseOid === theirOid) {
+    return {
+      oid: ourOid,
+      alreadyMerged: true
+    };
+  }
+  if (fastForward2 && baseOid === ourOid) {
+    if (!dryRun && !noUpdateBranch) {
+      await GitRefManager.writeRef({ fs, gitdir, ref: ours, value: theirOid });
+    }
+    return {
+      oid: theirOid,
+      fastForward: true
+    };
+  } else {
+    if (fastForwardOnly) {
+      throw new FastForwardError();
+    }
+    const tree = await GitIndexManager.acquire(
+      { fs, gitdir, cache, allowUnmerged: false },
+      async (index3) => {
+        return mergeTree({
+          fs,
+          cache,
+          dir,
+          gitdir,
+          index: index3,
+          ourOid,
+          theirOid,
+          baseOid,
+          ourName: abbreviateRef(ours),
+          baseName: "base",
+          theirName: abbreviateRef(theirs),
+          dryRun,
+          abortOnConflict,
+          mergeDriver
+        });
+      }
+    );
+    if (tree instanceof MergeConflictError) throw tree;
+    if (!message) {
+      message = `Merge branch '${abbreviateRef(theirs)}' into ${abbreviateRef(
+        ours
+      )}`;
+    }
+    const oid = await _commit({
+      fs,
+      cache,
+      gitdir,
+      message,
+      ref: ours,
+      tree,
+      parent: [ourOid, theirOid],
+      author,
+      committer,
+      signingKey,
+      onSign,
+      dryRun,
+      noUpdateBranch
+    });
+    return {
+      oid,
+      tree,
+      mergeCommit: true
+    };
+  }
+}
+async function _pull({
+  fs,
+  cache,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  dir,
+  gitdir,
+  ref,
+  url,
+  remote,
+  remoteRef,
+  prune,
+  pruneTags,
+  fastForward: fastForward2,
+  fastForwardOnly,
+  corsProxy,
+  singleBranch,
+  headers,
+  author,
+  committer,
+  signingKey
+}) {
+  try {
+    if (!ref) {
+      const head = await _currentBranch({ fs, gitdir });
+      if (!head) {
+        throw new MissingParameterError("ref");
+      }
+      ref = head;
+    }
+    const { fetchHead, fetchHeadDescription } = await _fetch({
+      fs,
+      cache,
+      http,
+      onProgress,
+      onMessage,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      gitdir,
+      corsProxy,
+      ref,
+      url,
+      remote,
+      remoteRef,
+      singleBranch,
+      headers,
+      prune,
+      pruneTags
+    });
+    await _merge({
+      fs,
+      cache,
+      gitdir,
+      ours: ref,
+      theirs: fetchHead,
+      fastForward: fastForward2,
+      fastForwardOnly,
+      message: `Merge ${fetchHeadDescription}`,
+      author,
+      committer,
+      signingKey,
+      dryRun: false,
+      noUpdateBranch: false
+    });
+    await _checkout({
+      fs,
+      cache,
+      onProgress,
+      dir,
+      gitdir,
+      ref,
+      remote,
+      noCheckout: false
+    });
+  } catch (err) {
+    err.caller = "git.pull";
+    throw err;
+  }
+}
+async function fastForward({
+  fs,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  url,
+  remote,
+  remoteRef,
+  corsProxy,
+  singleBranch,
+  headers = {},
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("http", http);
+    assertParameter("gitdir", gitdir);
+    const thisWillNotBeUsed = {
+      name: "",
+      email: "",
+      timestamp: Date.now(),
+      timezoneOffset: 0
+    };
+    return await _pull({
+      fs: new FileSystem(fs),
+      cache,
+      http,
+      onProgress,
+      onMessage,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      dir,
+      gitdir,
+      ref,
+      url,
+      remote,
+      remoteRef,
+      fastForwardOnly: true,
+      corsProxy,
+      singleBranch,
+      headers,
+      author: thisWillNotBeUsed,
+      committer: thisWillNotBeUsed
+    });
+  } catch (err) {
+    err.caller = "git.fastForward";
+    throw err;
+  }
+}
+async function fetch2({
+  fs,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  remote,
+  remoteRef,
+  url,
+  corsProxy,
+  depth = null,
+  since = null,
+  exclude = [],
+  relative = false,
+  tags = false,
+  singleBranch = false,
+  headers = {},
+  prune = false,
+  pruneTags = false,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("http", http);
+    assertParameter("gitdir", gitdir);
+    return await _fetch({
+      fs: new FileSystem(fs),
+      cache,
+      http,
+      onProgress,
+      onMessage,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      gitdir,
+      ref,
+      remote,
+      remoteRef,
+      url,
+      corsProxy,
+      depth,
+      since,
+      exclude,
+      relative,
+      tags,
+      singleBranch,
+      headers,
+      prune,
+      pruneTags
+    });
+  } catch (err) {
+    err.caller = "git.fetch";
+    throw err;
+  }
+}
+async function findMergeBase({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oids,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oids", oids);
+    return await _findMergeBase({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oids
+    });
+  } catch (err) {
+    err.caller = "git.findMergeBase";
+    throw err;
+  }
+}
+async function _findRoot({ fs, filepath }) {
+  if (await fs.exists(join(filepath, ".git"))) {
+    return filepath;
+  } else {
+    const parent = dirname(filepath);
+    if (parent === filepath) {
+      throw new NotFoundError(`git root for ${filepath}`);
+    }
+    return _findRoot({ fs, filepath: parent });
+  }
+}
+async function findRoot({ fs, filepath }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("filepath", filepath);
+    return await _findRoot({ fs: new FileSystem(fs), filepath });
+  } catch (err) {
+    err.caller = "git.findRoot";
+    throw err;
+  }
+}
+async function getConfig({ fs, dir, gitdir = join(dir, ".git"), path }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("path", path);
+    return await _getConfig({
+      fs: new FileSystem(fs),
+      gitdir,
+      path
+    });
+  } catch (err) {
+    err.caller = "git.getConfig";
+    throw err;
+  }
+}
+async function _getConfigAll({ fs, gitdir, path }) {
+  const config = await GitConfigManager.get({ fs, gitdir });
+  return config.getall(path);
+}
+async function getConfigAll({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  path
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("path", path);
+    return await _getConfigAll({
+      fs: new FileSystem(fs),
+      gitdir,
+      path
+    });
+  } catch (err) {
+    err.caller = "git.getConfigAll";
+    throw err;
+  }
+}
+async function getRemoteInfo({
+  http,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  corsProxy,
+  url,
+  headers = {},
+  forPush = false
+}) {
+  try {
+    assertParameter("http", http);
+    assertParameter("url", url);
+    const GitRemoteHTTP2 = GitRemoteManager.getRemoteHelperFor({ url });
+    const remote = await GitRemoteHTTP2.discover({
+      http,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      corsProxy,
+      service: forPush ? "git-receive-pack" : "git-upload-pack",
+      url,
+      headers,
+      protocolVersion: 1
+    });
+    const result = {
+      capabilities: [...remote.capabilities]
+    };
+    for (const [ref, oid] of remote.refs) {
+      const parts = ref.split("/");
+      const last = parts.pop();
+      let o = result;
+      for (const part of parts) {
+        o[part] = o[part] || {};
+        o = o[part];
+      }
+      o[last] = oid;
+    }
+    for (const [symref, ref] of remote.symrefs) {
+      const parts = symref.split("/");
+      const last = parts.pop();
+      let o = result;
+      for (const part of parts) {
+        o[part] = o[part] || {};
+        o = o[part];
+      }
+      o[last] = ref;
+    }
+    return result;
+  } catch (err) {
+    err.caller = "git.getRemoteInfo";
+    throw err;
+  }
+}
+function formatInfoRefs(remote, prefix, symrefs, peelTags) {
+  const refs = [];
+  for (const [key, value] of remote.refs) {
+    if (prefix && !key.startsWith(prefix)) continue;
+    if (key.endsWith("^{}")) {
+      if (peelTags) {
+        const _key = key.replace("^{}", "");
+        const last = refs[refs.length - 1];
+        const r = last.ref === _key ? last : refs.find((x) => x.ref === _key);
+        if (r === void 0) {
+          throw new Error("I did not expect this to happen");
+        }
+        r.peeled = value;
+      }
+      continue;
+    }
+    const ref = { ref: key, oid: value };
+    if (symrefs) {
+      if (remote.symrefs.has(key)) {
+        ref.target = remote.symrefs.get(key);
+      }
+    }
+    refs.push(ref);
+  }
+  return refs;
+}
+async function getRemoteInfo2({
+  http,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  corsProxy,
+  url,
+  headers = {},
+  forPush = false,
+  protocolVersion = 2
+}) {
+  try {
+    assertParameter("http", http);
+    assertParameter("url", url);
+    const GitRemoteHTTP2 = GitRemoteManager.getRemoteHelperFor({ url });
+    const remote = await GitRemoteHTTP2.discover({
+      http,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      corsProxy,
+      service: forPush ? "git-receive-pack" : "git-upload-pack",
+      url,
+      headers,
+      protocolVersion
+    });
+    if (remote.protocolVersion === 2) {
+      return {
+        protocolVersion: remote.protocolVersion,
+        capabilities: remote.capabilities2
+      };
+    }
+    const capabilities = {};
+    for (const cap of remote.capabilities) {
+      const [key, value] = cap.split("=");
+      if (value) {
+        capabilities[key] = value;
+      } else {
+        capabilities[key] = true;
+      }
+    }
+    return {
+      protocolVersion: 1,
+      capabilities,
+      refs: formatInfoRefs(remote, void 0, true, true)
+    };
+  } catch (err) {
+    err.caller = "git.getRemoteInfo2";
+    throw err;
+  }
+}
+async function hashObject({
+  type,
+  object,
+  format = "content",
+  oid = void 0
+}) {
+  if (format !== "deflated") {
+    if (format !== "wrapped") {
+      object = GitObject.wrap({ type, object });
+    }
+    oid = await shasum(object);
+  }
+  return { oid, object };
+}
+async function hashBlob({ object }) {
+  try {
+    assertParameter("object", object);
+    if (typeof object === "string") {
+      object = import_buffer.Buffer.from(object, "utf8");
+    } else {
+      object = import_buffer.Buffer.from(object);
+    }
+    const type = "blob";
+    const { oid, object: _object } = await hashObject({
+      type: "blob",
+      format: "content",
+      object
+    });
+    return { oid, type, object: new Uint8Array(_object), format: "wrapped" };
+  } catch (err) {
+    err.caller = "git.hashBlob";
+    throw err;
+  }
+}
+async function _indexPack({
+  fs,
+  cache,
+  onProgress,
+  dir,
+  gitdir,
+  filepath
+}) {
+  try {
+    filepath = join(dir, filepath);
+    const pack = await fs.read(filepath);
+    const getExternalRefDelta = (oid) => _readObject({ fs, cache, gitdir, oid });
+    const idx = await GitPackIndex.fromPack({
+      pack,
+      getExternalRefDelta,
+      onProgress
+    });
+    await fs.write(filepath.replace(/\.pack$/, ".idx"), await idx.toBuffer());
+    return {
+      oids: [...idx.hashes]
+    };
+  } catch (err) {
+    err.caller = "git.indexPack";
+    throw err;
+  }
+}
+async function indexPack({
+  fs,
+  onProgress,
+  dir,
+  gitdir = join(dir, ".git"),
+  filepath,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("dir", dir);
+    assertParameter("gitdir", dir);
+    assertParameter("filepath", filepath);
+    return await _indexPack({
+      fs: new FileSystem(fs),
+      cache,
+      onProgress,
+      dir,
+      gitdir,
+      filepath
+    });
+  } catch (err) {
+    err.caller = "git.indexPack";
+    throw err;
+  }
+}
+async function init({
+  fs,
+  bare = false,
+  dir,
+  gitdir = bare ? dir : join(dir, ".git"),
+  defaultBranch = "master"
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    if (!bare) {
+      assertParameter("dir", dir);
+    }
+    return await _init({
+      fs: new FileSystem(fs),
+      bare,
+      dir,
+      gitdir,
+      defaultBranch
+    });
+  } catch (err) {
+    err.caller = "git.init";
+    throw err;
+  }
+}
+async function _isDescendent({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  ancestor,
+  depth
+}) {
+  const shallows = await GitShallowManager.read({ fs, gitdir });
+  if (!oid) {
+    throw new MissingParameterError("oid");
+  }
+  if (!ancestor) {
+    throw new MissingParameterError("ancestor");
+  }
+  if (oid === ancestor) return false;
+  const queue = [oid];
+  const visited = /* @__PURE__ */ new Set();
+  let searchdepth = 0;
+  while (queue.length) {
+    if (searchdepth++ === depth) {
+      throw new MaxDepthError(depth);
+    }
+    const oid2 = queue.shift();
+    const { type, object } = await _readObject({
+      fs,
+      cache,
+      gitdir,
+      oid: oid2
+    });
+    if (type !== "commit") {
+      throw new ObjectTypeError(oid2, type, "commit");
+    }
+    const commit2 = GitCommit.from(object).parse();
+    for (const parent of commit2.parent) {
+      if (parent === ancestor) return true;
+    }
+    if (!shallows.has(oid2)) {
+      for (const parent of commit2.parent) {
+        if (!visited.has(parent)) {
+          queue.push(parent);
+          visited.add(parent);
+        }
+      }
+    }
+  }
+  return false;
+}
+async function isDescendent({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oid,
+  ancestor,
+  depth = -1,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    assertParameter("ancestor", ancestor);
+    return await _isDescendent({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oid,
+      ancestor,
+      depth
+    });
+  } catch (err) {
+    err.caller = "git.isDescendent";
+    throw err;
+  }
+}
+async function isIgnored({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  filepath
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("dir", dir);
+    assertParameter("gitdir", gitdir);
+    assertParameter("filepath", filepath);
+    return GitIgnoreManager.isIgnored({
+      fs: new FileSystem(fs),
+      dir,
+      gitdir,
+      filepath
+    });
+  } catch (err) {
+    err.caller = "git.isIgnored";
+    throw err;
+  }
+}
+async function listBranches({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  remote
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    return GitRefManager.listBranches({
+      fs: new FileSystem(fs),
+      gitdir,
+      remote
+    });
+  } catch (err) {
+    err.caller = "git.listBranches";
+    throw err;
+  }
+}
+async function _listFiles({ fs, gitdir, ref, cache }) {
+  if (ref) {
+    const oid = await GitRefManager.resolve({ gitdir, fs, ref });
+    const filenames = [];
+    await accumulateFilesFromOid({
+      fs,
+      cache,
+      gitdir,
+      oid,
+      filenames,
+      prefix: ""
+    });
+    return filenames;
+  } else {
+    return GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      return index3.entries.map((x) => x.path);
+    });
+  }
+}
+async function accumulateFilesFromOid({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  filenames,
+  prefix
+}) {
+  const { tree } = await _readTree({ fs, cache, gitdir, oid });
+  for (const entry of tree) {
+    if (entry.type === "tree") {
+      await accumulateFilesFromOid({
+        fs,
+        cache,
+        gitdir,
+        oid: entry.oid,
+        filenames,
+        prefix: join(prefix, entry.path)
+      });
+    } else {
+      filenames.push(join(prefix, entry.path));
+    }
+  }
+}
+async function listFiles({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    return await _listFiles({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      ref
+    });
+  } catch (err) {
+    err.caller = "git.listFiles";
+    throw err;
+  }
+}
+async function _listNotes({ fs, cache, gitdir, ref }) {
+  let parent;
+  try {
+    parent = await GitRefManager.resolve({ gitdir, fs, ref });
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return [];
+    }
+  }
+  const result = await _readTree({
+    fs,
+    cache,
+    gitdir,
+    oid: parent
+  });
+  const notes = result.tree.map((entry) => ({
+    target: entry.path,
+    note: entry.oid
+  }));
+  return notes;
+}
+async function listNotes({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref = "refs/notes/commits",
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    return await _listNotes({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      ref
+    });
+  } catch (err) {
+    err.caller = "git.listNotes";
+    throw err;
+  }
+}
+async function _listRemotes({ fs, gitdir }) {
+  const config = await GitConfigManager.get({ fs, gitdir });
+  const remoteNames = await config.getSubsections("remote");
+  const remotes = Promise.all(
+    remoteNames.map(async (remote) => {
+      const url = await config.get(`remote.${remote}.url`);
+      return { remote, url };
+    })
+  );
+  return remotes;
+}
+async function listRemotes({ fs, dir, gitdir = join(dir, ".git") }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    return await _listRemotes({
+      fs: new FileSystem(fs),
+      gitdir
+    });
+  } catch (err) {
+    err.caller = "git.listRemotes";
+    throw err;
+  }
+}
+async function parseListRefsResponse(stream) {
+  const read = GitPktLine.streamReader(stream);
+  const refs = [];
+  let line;
+  while (true) {
+    line = await read();
+    if (line === true) break;
+    if (line === null) continue;
+    line = line.toString("utf8").replace(/\n$/, "");
+    const [oid, ref, ...attrs] = line.split(" ");
+    const r = { ref, oid };
+    for (const attr of attrs) {
+      const [name, value] = attr.split(":");
+      if (name === "symref-target") {
+        r.target = value;
+      } else if (name === "peeled") {
+        r.peeled = value;
+      }
+    }
+    refs.push(r);
+  }
+  return refs;
+}
+async function writeListRefsRequest({ prefix, symrefs, peelTags }) {
+  const packstream = [];
+  packstream.push(GitPktLine.encode("command=ls-refs\n"));
+  packstream.push(GitPktLine.encode(`agent=${pkg.agent}
+`));
+  if (peelTags || symrefs || prefix) {
+    packstream.push(GitPktLine.delim());
+  }
+  if (peelTags) packstream.push(GitPktLine.encode("peel"));
+  if (symrefs) packstream.push(GitPktLine.encode("symrefs"));
+  if (prefix) packstream.push(GitPktLine.encode(`ref-prefix ${prefix}`));
+  packstream.push(GitPktLine.flush());
+  return packstream;
+}
+async function listServerRefs({
+  http,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  corsProxy,
+  url,
+  headers = {},
+  forPush = false,
+  protocolVersion = 2,
+  prefix,
+  symrefs,
+  peelTags
+}) {
+  try {
+    assertParameter("http", http);
+    assertParameter("url", url);
+    const remote = await GitRemoteHTTP.discover({
+      http,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      corsProxy,
+      service: forPush ? "git-receive-pack" : "git-upload-pack",
+      url,
+      headers,
+      protocolVersion
+    });
+    if (remote.protocolVersion === 1) {
+      return formatInfoRefs(remote, prefix, symrefs, peelTags);
+    }
+    const body = await writeListRefsRequest({ prefix, symrefs, peelTags });
+    const res = await GitRemoteHTTP.connect({
+      http,
+      auth: remote.auth,
+      headers,
+      corsProxy,
+      service: forPush ? "git-receive-pack" : "git-upload-pack",
+      url,
+      body
+    });
+    return parseListRefsResponse(res.body);
+  } catch (err) {
+    err.caller = "git.listServerRefs";
+    throw err;
+  }
+}
+async function listTags({ fs, dir, gitdir = join(dir, ".git") }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    return GitRefManager.listTags({ fs: new FileSystem(fs), gitdir });
+  } catch (err) {
+    err.caller = "git.listTags";
+    throw err;
+  }
+}
+function compareAge(a, b) {
+  return a.committer.timestamp - b.committer.timestamp;
+}
+var EMPTY_OID = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
+async function resolveFileIdInTree({ fs, cache, gitdir, oid, fileId }) {
+  if (fileId === EMPTY_OID) return;
+  const _oid = oid;
+  let filepath;
+  const result = await resolveTree({ fs, cache, gitdir, oid });
+  const tree = result.tree;
+  if (fileId === result.oid) {
+    filepath = result.path;
+  } else {
+    filepath = await _resolveFileId({
+      fs,
+      cache,
+      gitdir,
+      tree,
+      fileId,
+      oid: _oid
+    });
+    if (Array.isArray(filepath)) {
+      if (filepath.length === 0) filepath = void 0;
+      else if (filepath.length === 1) filepath = filepath[0];
+    }
+  }
+  return filepath;
+}
+async function _resolveFileId({
+  fs,
+  cache,
+  gitdir,
+  tree,
+  fileId,
+  oid,
+  filepaths = [],
+  parentPath = ""
+}) {
+  const walks = tree.entries().map(function(entry) {
+    let result;
+    if (entry.oid === fileId) {
+      result = join(parentPath, entry.path);
+      filepaths.push(result);
+    } else if (entry.type === "tree") {
+      result = _readObject({
+        fs,
+        cache,
+        gitdir,
+        oid: entry.oid
+      }).then(function({ object }) {
+        return _resolveFileId({
+          fs,
+          cache,
+          gitdir,
+          tree: GitTree.from(object),
+          fileId,
+          oid,
+          filepaths,
+          parentPath: join(parentPath, entry.path)
+        });
+      });
+    }
+    return result;
+  });
+  await Promise.all(walks);
+  return filepaths;
+}
+async function _log({
+  fs,
+  cache,
+  gitdir,
+  filepath,
+  ref,
+  depth,
+  since,
+  force,
+  follow
+}) {
+  const sinceTimestamp = typeof since === "undefined" ? void 0 : Math.floor(since.valueOf() / 1e3);
+  const commits = [];
+  const shallowCommits = await GitShallowManager.read({ fs, gitdir });
+  const oid = await GitRefManager.resolve({ fs, gitdir, ref });
+  const tips = [await _readCommit({ fs, cache, gitdir, oid })];
+  let lastFileOid;
+  let lastCommit;
+  let isOk;
+  function endCommit(commit2) {
+    if (isOk && filepath) commits.push(commit2);
+  }
+  while (tips.length > 0) {
+    const commit2 = tips.pop();
+    if (sinceTimestamp !== void 0 && commit2.commit.committer.timestamp <= sinceTimestamp) {
+      break;
+    }
+    if (filepath) {
+      let vFileOid;
+      try {
+        vFileOid = await resolveFilepath({
+          fs,
+          cache,
+          gitdir,
+          oid: commit2.commit.tree,
+          filepath
+        });
+        if (lastCommit && lastFileOid !== vFileOid) {
+          commits.push(lastCommit);
+        }
+        lastFileOid = vFileOid;
+        lastCommit = commit2;
+        isOk = true;
+      } catch (e) {
+        if (e instanceof NotFoundError) {
+          let found = follow && lastFileOid;
+          if (found) {
+            found = await resolveFileIdInTree({
+              fs,
+              cache,
+              gitdir,
+              oid: commit2.commit.tree,
+              fileId: lastFileOid
+            });
+            if (found) {
+              if (Array.isArray(found)) {
+                if (lastCommit) {
+                  const lastFound = await resolveFileIdInTree({
+                    fs,
+                    cache,
+                    gitdir,
+                    oid: lastCommit.commit.tree,
+                    fileId: lastFileOid
+                  });
+                  if (Array.isArray(lastFound)) {
+                    found = found.filter((p) => lastFound.indexOf(p) === -1);
+                    if (found.length === 1) {
+                      found = found[0];
+                      filepath = found;
+                      if (lastCommit) commits.push(lastCommit);
+                    } else {
+                      found = false;
+                      if (lastCommit) commits.push(lastCommit);
+                      break;
+                    }
+                  }
+                }
+              } else {
+                filepath = found;
+                if (lastCommit) commits.push(lastCommit);
+              }
+            }
+          }
+          if (!found) {
+            if (isOk && lastFileOid) {
+              commits.push(lastCommit);
+              if (!force) break;
+            }
+            if (!force && !follow) throw e;
+          }
+          lastCommit = commit2;
+          isOk = false;
+        } else throw e;
+      }
+    } else {
+      commits.push(commit2);
+    }
+    if (depth !== void 0 && commits.length === depth) {
+      endCommit(commit2);
+      break;
+    }
+    if (!shallowCommits.has(commit2.oid)) {
+      for (const oid2 of commit2.commit.parent) {
+        const commit3 = await _readCommit({ fs, cache, gitdir, oid: oid2 });
+        if (!tips.map((commit4) => commit4.oid).includes(commit3.oid)) {
+          tips.push(commit3);
+        }
+      }
+    }
+    if (tips.length === 0) {
+      endCommit(commit2);
+    }
+    tips.sort((a, b) => compareAge(a.commit, b.commit));
+  }
+  return commits;
+}
+async function log({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  filepath,
+  ref = "HEAD",
+  depth,
+  since,
+  // Date
+  force,
+  follow,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    return await _log({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      filepath,
+      ref,
+      depth,
+      since,
+      force,
+      follow
+    });
+  } catch (err) {
+    err.caller = "git.log";
+    throw err;
+  }
+}
+async function merge({
+  fs: _fs,
+  onSign,
+  dir,
+  gitdir = join(dir, ".git"),
+  ours,
+  theirs,
+  fastForward: fastForward2 = true,
+  fastForwardOnly = false,
+  dryRun = false,
+  noUpdateBranch = false,
+  abortOnConflict = true,
+  message,
+  author: _author,
+  committer: _committer,
+  signingKey,
+  cache = {},
+  mergeDriver
+}) {
+  try {
+    assertParameter("fs", _fs);
+    if (signingKey) {
+      assertParameter("onSign", onSign);
+    }
+    const fs = new FileSystem(_fs);
+    const author = await normalizeAuthorObject({ fs, gitdir, author: _author });
+    if (!author && (!fastForwardOnly || !fastForward2)) {
+      throw new MissingNameError("author");
+    }
+    const committer = await normalizeCommitterObject({
+      fs,
+      gitdir,
+      author,
+      committer: _committer
+    });
+    if (!committer && (!fastForwardOnly || !fastForward2)) {
+      throw new MissingNameError("committer");
+    }
+    return await _merge({
+      fs,
+      cache,
+      dir,
+      gitdir,
+      ours,
+      theirs,
+      fastForward: fastForward2,
+      fastForwardOnly,
+      dryRun,
+      noUpdateBranch,
+      abortOnConflict,
+      message,
+      author,
+      committer,
+      signingKey,
+      onSign,
+      mergeDriver
+    });
+  } catch (err) {
+    err.caller = "git.merge";
+    throw err;
+  }
+}
+var types = {
+  commit: 16,
+  tree: 32,
+  blob: 48,
+  tag: 64,
+  ofs_delta: 96,
+  ref_delta: 112
+};
+async function _pack({
+  fs,
+  cache,
+  dir,
+  gitdir = join(dir, ".git"),
+  oids
+}) {
+  const hash = new import_sha1.default();
+  const outputStream = [];
+  function write(chunk, enc) {
+    const buff = import_buffer.Buffer.from(chunk, enc);
+    outputStream.push(buff);
+    hash.update(buff);
+  }
+  async function writeObject2({ stype, object }) {
+    const type = types[stype];
+    let length = object.length;
+    let multibyte = length > 15 ? 128 : 0;
+    const lastFour = length & 15;
+    length = length >>> 4;
+    let byte = (multibyte | type | lastFour).toString(16);
+    write(byte, "hex");
+    while (multibyte) {
+      multibyte = length > 127 ? 128 : 0;
+      byte = multibyte | length & 127;
+      write(padHex(2, byte), "hex");
+      length = length >>> 7;
+    }
+    write(import_buffer.Buffer.from(await deflate(object)));
+  }
+  write("PACK");
+  write("00000002", "hex");
+  write(padHex(8, oids.length), "hex");
+  for (const oid of oids) {
+    const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+    await writeObject2({ write, object, stype: type });
+  }
+  const digest = hash.digest();
+  outputStream.push(digest);
+  return outputStream;
+}
+async function _packObjects({ fs, cache, gitdir, oids, write }) {
+  const buffers = await _pack({ fs, cache, gitdir, oids });
+  const packfile = import_buffer.Buffer.from(await collect(buffers));
+  const packfileSha = packfile.slice(-20).toString("hex");
+  const filename = `pack-${packfileSha}.pack`;
+  if (write) {
+    await fs.write(join(gitdir, `objects/pack/${filename}`), packfile);
+    return { filename };
+  }
+  return {
+    filename,
+    packfile: new Uint8Array(packfile)
+  };
+}
+async function packObjects({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oids,
+  write = false,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oids", oids);
+    return await _packObjects({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oids,
+      write
+    });
+  } catch (err) {
+    err.caller = "git.packObjects";
+    throw err;
+  }
+}
+async function pull({
+  fs: _fs,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  url,
+  remote,
+  remoteRef,
+  prune = false,
+  pruneTags = false,
+  fastForward: fastForward2 = true,
+  fastForwardOnly = false,
+  corsProxy,
+  singleBranch,
+  headers = {},
+  author: _author,
+  committer: _committer,
+  signingKey,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    const fs = new FileSystem(_fs);
+    const author = await normalizeAuthorObject({ fs, gitdir, author: _author });
+    if (!author) throw new MissingNameError("author");
+    const committer = await normalizeCommitterObject({
+      fs,
+      gitdir,
+      author,
+      committer: _committer
+    });
+    if (!committer) throw new MissingNameError("committer");
+    return await _pull({
+      fs,
+      cache,
+      http,
+      onProgress,
+      onMessage,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      dir,
+      gitdir,
+      ref,
+      url,
+      remote,
+      remoteRef,
+      fastForward: fastForward2,
+      fastForwardOnly,
+      corsProxy,
+      singleBranch,
+      headers,
+      author,
+      committer,
+      signingKey,
+      prune,
+      pruneTags
+    });
+  } catch (err) {
+    err.caller = "git.pull";
+    throw err;
+  }
+}
+async function listCommitsAndTags({
+  fs,
+  cache,
+  dir,
+  gitdir = join(dir, ".git"),
+  start,
+  finish
+}) {
+  const shallows = await GitShallowManager.read({ fs, gitdir });
+  const startingSet = /* @__PURE__ */ new Set();
+  const finishingSet = /* @__PURE__ */ new Set();
+  for (const ref of start) {
+    startingSet.add(await GitRefManager.resolve({ fs, gitdir, ref }));
+  }
+  for (const ref of finish) {
+    try {
+      const oid = await GitRefManager.resolve({ fs, gitdir, ref });
+      finishingSet.add(oid);
+    } catch (err) {
+    }
+  }
+  const visited = /* @__PURE__ */ new Set();
+  async function walk2(oid) {
+    visited.add(oid);
+    const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+    if (type === "tag") {
+      const tag2 = GitAnnotatedTag.from(object);
+      const commit2 = tag2.headers().object;
+      return walk2(commit2);
+    }
+    if (type !== "commit") {
+      throw new ObjectTypeError(oid, type, "commit");
+    }
+    if (!shallows.has(oid)) {
+      const commit2 = GitCommit.from(object);
+      const parents = commit2.headers().parent;
+      for (oid of parents) {
+        if (!finishingSet.has(oid) && !visited.has(oid)) {
+          await walk2(oid);
+        }
+      }
+    }
+  }
+  for (const oid of startingSet) {
+    await walk2(oid);
+  }
+  return visited;
+}
+async function listObjects({
+  fs,
+  cache,
+  dir,
+  gitdir = join(dir, ".git"),
+  oids
+}) {
+  const visited = /* @__PURE__ */ new Set();
+  async function walk2(oid) {
+    if (visited.has(oid)) return;
+    visited.add(oid);
+    const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+    if (type === "tag") {
+      const tag2 = GitAnnotatedTag.from(object);
+      const obj = tag2.headers().object;
+      await walk2(obj);
+    } else if (type === "commit") {
+      const commit2 = GitCommit.from(object);
+      const tree = commit2.headers().tree;
+      await walk2(tree);
+    } else if (type === "tree") {
+      const tree = GitTree.from(object);
+      for (const entry of tree) {
+        if (entry.type === "blob") {
+          visited.add(entry.oid);
+        }
+        if (entry.type === "tree") {
+          await walk2(entry.oid);
+        }
+      }
+    }
+  }
+  for (const oid of oids) {
+    await walk2(oid);
+  }
+  return visited;
+}
+async function parseReceivePackResponse(packfile) {
+  const result = {};
+  let response = "";
+  const read = GitPktLine.streamReader(packfile);
+  let line = await read();
+  while (line !== true) {
+    if (line !== null) response += line.toString("utf8") + "\n";
+    line = await read();
+  }
+  const lines = response.toString("utf8").split("\n");
+  line = lines.shift();
+  if (!line.startsWith("unpack ")) {
+    throw new ParseError('unpack ok" or "unpack [error message]', line);
+  }
+  result.ok = line === "unpack ok";
+  if (!result.ok) {
+    result.error = line.slice("unpack ".length);
+  }
+  result.refs = {};
+  for (const line2 of lines) {
+    if (line2.trim() === "") continue;
+    const status2 = line2.slice(0, 2);
+    const refAndMessage = line2.slice(3);
+    let space = refAndMessage.indexOf(" ");
+    if (space === -1) space = refAndMessage.length;
+    const ref = refAndMessage.slice(0, space);
+    const error = refAndMessage.slice(space + 1);
+    result.refs[ref] = {
+      ok: status2 === "ok",
+      error
+    };
+  }
+  return result;
+}
+async function writeReceivePackRequest({
+  capabilities = [],
+  triplets = []
+}) {
+  const packstream = [];
+  let capsFirstLine = `\0 ${capabilities.join(" ")}`;
+  for (const trip of triplets) {
+    packstream.push(
+      GitPktLine.encode(
+        `${trip.oldoid} ${trip.oid} ${trip.fullRef}${capsFirstLine}
+`
+      )
+    );
+    capsFirstLine = "";
+  }
+  packstream.push(GitPktLine.flush());
+  return packstream;
+}
+async function _push({
+  fs,
+  cache,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  onPrePush,
+  gitdir,
+  ref: _ref,
+  remoteRef: _remoteRef,
+  remote,
+  url: _url,
+  force = false,
+  delete: _delete = false,
+  corsProxy,
+  headers = {}
+}) {
+  const ref = _ref || await _currentBranch({ fs, gitdir });
+  if (typeof ref === "undefined") {
+    throw new MissingParameterError("ref");
+  }
+  const config = await GitConfigManager.get({ fs, gitdir });
+  remote = remote || await config.get(`branch.${ref}.pushRemote`) || await config.get("remote.pushDefault") || await config.get(`branch.${ref}.remote`) || "origin";
+  const url = _url || await config.get(`remote.${remote}.pushurl`) || await config.get(`remote.${remote}.url`);
+  if (typeof url === "undefined") {
+    throw new MissingParameterError("remote OR url");
+  }
+  const remoteRef = _remoteRef || await config.get(`branch.${ref}.merge`);
+  if (typeof url === "undefined") {
+    throw new MissingParameterError("remoteRef");
+  }
+  if (corsProxy === void 0) {
+    corsProxy = await config.get("http.corsProxy");
+  }
+  const fullRef = await GitRefManager.expand({ fs, gitdir, ref });
+  const oid = _delete ? "0000000000000000000000000000000000000000" : await GitRefManager.resolve({ fs, gitdir, ref: fullRef });
+  const GitRemoteHTTP2 = GitRemoteManager.getRemoteHelperFor({ url });
+  const httpRemote = await GitRemoteHTTP2.discover({
+    http,
+    onAuth,
+    onAuthSuccess,
+    onAuthFailure,
+    corsProxy,
+    service: "git-receive-pack",
+    url,
+    headers,
+    protocolVersion: 1
+  });
+  const auth = httpRemote.auth;
+  let fullRemoteRef;
+  if (!remoteRef) {
+    fullRemoteRef = fullRef;
+  } else {
+    try {
+      fullRemoteRef = await GitRefManager.expandAgainstMap({
+        ref: remoteRef,
+        map: httpRemote.refs
+      });
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        fullRemoteRef = remoteRef.startsWith("refs/") ? remoteRef : `refs/heads/${remoteRef}`;
+      } else {
+        throw err;
+      }
+    }
+  }
+  const oldoid = httpRemote.refs.get(fullRemoteRef) || "0000000000000000000000000000000000000000";
+  if (onPrePush) {
+    const hookCancel = await onPrePush({
+      remote,
+      url,
+      localRef: { ref: _delete ? "(delete)" : fullRef, oid },
+      remoteRef: { ref: fullRemoteRef, oid: oldoid }
+    });
+    if (!hookCancel) throw new UserCanceledError();
+  }
+  const thinPack = !httpRemote.capabilities.has("no-thin");
+  let objects = /* @__PURE__ */ new Set();
+  if (!_delete) {
+    const finish = [...httpRemote.refs.values()];
+    let skipObjects = /* @__PURE__ */ new Set();
+    if (oldoid !== "0000000000000000000000000000000000000000") {
+      const mergebase = await _findMergeBase({
+        fs,
+        cache,
+        gitdir,
+        oids: [oid, oldoid]
+      });
+      for (const oid2 of mergebase) finish.push(oid2);
+      if (thinPack) {
+        skipObjects = await listObjects({ fs, cache, gitdir, oids: mergebase });
+      }
+    }
+    if (!finish.includes(oid)) {
+      const commits = await listCommitsAndTags({
+        fs,
+        cache,
+        gitdir,
+        start: [oid],
+        finish
+      });
+      objects = await listObjects({ fs, cache, gitdir, oids: commits });
+    }
+    if (thinPack) {
+      try {
+        const ref2 = await GitRefManager.resolve({
+          fs,
+          gitdir,
+          ref: `refs/remotes/${remote}/HEAD`,
+          depth: 2
+        });
+        const { oid: oid2 } = await GitRefManager.resolveAgainstMap({
+          ref: ref2.replace(`refs/remotes/${remote}/`, ""),
+          fullref: ref2,
+          map: httpRemote.refs
+        });
+        const oids = [oid2];
+        for (const oid3 of await listObjects({ fs, cache, gitdir, oids })) {
+          skipObjects.add(oid3);
+        }
+      } catch (e) {
+      }
+      for (const oid2 of skipObjects) {
+        objects.delete(oid2);
+      }
+    }
+    if (oid === oldoid) force = true;
+    if (!force) {
+      if (fullRef.startsWith("refs/tags") && oldoid !== "0000000000000000000000000000000000000000") {
+        throw new PushRejectedError("tag-exists");
+      }
+      if (oid !== "0000000000000000000000000000000000000000" && oldoid !== "0000000000000000000000000000000000000000" && !await _isDescendent({
+        fs,
+        cache,
+        gitdir,
+        oid,
+        ancestor: oldoid,
+        depth: -1
+      })) {
+        throw new PushRejectedError("not-fast-forward");
+      }
+    }
+  }
+  const capabilities = filterCapabilities(
+    [...httpRemote.capabilities],
+    ["report-status", "side-band-64k", `agent=${pkg.agent}`]
+  );
+  const packstream1 = await writeReceivePackRequest({
+    capabilities,
+    triplets: [{ oldoid, oid, fullRef: fullRemoteRef }]
+  });
+  const packstream2 = _delete ? [] : await _pack({
+    fs,
+    cache,
+    gitdir,
+    oids: [...objects]
+  });
+  const res = await GitRemoteHTTP2.connect({
+    http,
+    onProgress,
+    corsProxy,
+    service: "git-receive-pack",
+    url,
+    auth,
+    headers,
+    body: [...packstream1, ...packstream2]
+  });
+  const { packfile, progress } = await GitSideBand.demux(res.body);
+  if (onMessage) {
+    const lines = splitLines(progress);
+    forAwait(lines, async (line) => {
+      await onMessage(line);
+    });
+  }
+  const result = await parseReceivePackResponse(packfile);
+  if (res.headers) {
+    result.headers = res.headers;
+  }
+  if (remote && result.ok && result.refs[fullRemoteRef].ok && !fullRef.startsWith("refs/tags")) {
+    const ref2 = `refs/remotes/${remote}/${fullRemoteRef.replace(
+      "refs/heads",
+      ""
+    )}`;
+    if (_delete) {
+      await GitRefManager.deleteRef({ fs, gitdir, ref: ref2 });
+    } else {
+      await GitRefManager.writeRef({ fs, gitdir, ref: ref2, value: oid });
+    }
+  }
+  if (result.ok && Object.values(result.refs).every((result2) => result2.ok)) {
+    return result;
+  } else {
+    const prettyDetails = Object.entries(result.refs).filter(([k, v]) => !v.ok).map(([k, v]) => `
+  - ${k}: ${v.error}`).join("");
+    throw new GitPushError(prettyDetails, result);
+  }
+}
+async function push({
+  fs,
+  http,
+  onProgress,
+  onMessage,
+  onAuth,
+  onAuthSuccess,
+  onAuthFailure,
+  onPrePush,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  remoteRef,
+  remote = "origin",
+  url,
+  force = false,
+  delete: _delete = false,
+  corsProxy,
+  headers = {},
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("http", http);
+    assertParameter("gitdir", gitdir);
+    return await _push({
+      fs: new FileSystem(fs),
+      cache,
+      http,
+      onProgress,
+      onMessage,
+      onAuth,
+      onAuthSuccess,
+      onAuthFailure,
+      onPrePush,
+      gitdir,
+      ref,
+      remoteRef,
+      remote,
+      url,
+      force,
+      delete: _delete,
+      corsProxy,
+      headers
+    });
+  } catch (err) {
+    err.caller = "git.push";
+    throw err;
+  }
+}
+async function resolveBlob({ fs, cache, gitdir, oid }) {
+  const { type, object } = await _readObject({ fs, cache, gitdir, oid });
+  if (type === "tag") {
+    oid = GitAnnotatedTag.from(object).parse().object;
+    return resolveBlob({ fs, cache, gitdir, oid });
+  }
+  if (type !== "blob") {
+    throw new ObjectTypeError(oid, type, "blob");
+  }
+  return { oid, blob: new Uint8Array(object) };
+}
+async function _readBlob({
+  fs,
+  cache,
+  gitdir,
+  oid,
+  filepath = void 0
+}) {
+  if (filepath !== void 0) {
+    oid = await resolveFilepath({ fs, cache, gitdir, oid, filepath });
+  }
+  const blob = await resolveBlob({
+    fs,
+    cache,
+    gitdir,
+    oid
+  });
+  return blob;
+}
+async function readBlob({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oid,
+  filepath,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    return await _readBlob({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oid,
+      filepath
+    });
+  } catch (err) {
+    err.caller = "git.readBlob";
+    throw err;
+  }
+}
+async function readCommit({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oid,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    return await _readCommit({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oid
+    });
+  } catch (err) {
+    err.caller = "git.readCommit";
+    throw err;
+  }
+}
+async function _readNote({
+  fs,
+  cache,
+  gitdir,
+  ref = "refs/notes/commits",
+  oid
+}) {
+  const parent = await GitRefManager.resolve({ gitdir, fs, ref });
+  const { blob } = await _readBlob({
+    fs,
+    cache,
+    gitdir,
+    oid: parent,
+    filepath: oid
+  });
+  return blob;
+}
+async function readNote({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref = "refs/notes/commits",
+  oid,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    assertParameter("oid", oid);
+    return await _readNote({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      ref,
+      oid
+    });
+  } catch (err) {
+    err.caller = "git.readNote";
+    throw err;
+  }
+}
+async function readObject({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oid,
+  format = "parsed",
+  filepath = void 0,
+  encoding = void 0,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    const fs = new FileSystem(_fs);
+    if (filepath !== void 0) {
+      oid = await resolveFilepath({
+        fs,
+        cache,
+        gitdir,
+        oid,
+        filepath
+      });
+    }
+    const _format = format === "parsed" ? "content" : format;
+    const result = await _readObject({
+      fs,
+      cache,
+      gitdir,
+      oid,
+      format: _format
+    });
+    result.oid = oid;
+    if (format === "parsed") {
+      result.format = "parsed";
+      switch (result.type) {
+        case "commit":
+          result.object = GitCommit.from(result.object).parse();
+          break;
+        case "tree":
+          result.object = GitTree.from(result.object).entries();
+          break;
+        case "blob":
+          if (encoding) {
+            result.object = result.object.toString(encoding);
+          } else {
+            result.object = new Uint8Array(result.object);
+            result.format = "content";
+          }
+          break;
+        case "tag":
+          result.object = GitAnnotatedTag.from(result.object).parse();
+          break;
+        default:
+          throw new ObjectTypeError(
+            result.oid,
+            result.type,
+            "blob|commit|tag|tree"
+          );
+      }
+    } else if (result.format === "deflated" || result.format === "wrapped") {
+      result.type = result.format;
+    }
+    return result;
+  } catch (err) {
+    err.caller = "git.readObject";
+    throw err;
+  }
+}
+async function _readTag({ fs, cache, gitdir, oid }) {
+  const { type, object } = await _readObject({
+    fs,
+    cache,
+    gitdir,
+    oid,
+    format: "content"
+  });
+  if (type !== "tag") {
+    throw new ObjectTypeError(oid, type, "tag");
+  }
+  const tag2 = GitAnnotatedTag.from(object);
+  const result = {
+    oid,
+    tag: tag2.parse(),
+    payload: tag2.payload()
+  };
+  return result;
+}
+async function readTag({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oid,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    return await _readTag({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oid
+    });
+  } catch (err) {
+    err.caller = "git.readTag";
+    throw err;
+  }
+}
+async function readTree({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  oid,
+  filepath = void 0,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    return await _readTree({
+      fs: new FileSystem(fs),
+      cache,
+      gitdir,
+      oid,
+      filepath
+    });
+  } catch (err) {
+    err.caller = "git.readTree";
+    throw err;
+  }
+}
+async function remove({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  filepath,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("filepath", filepath);
+    await GitIndexManager.acquire(
+      { fs: new FileSystem(_fs), gitdir, cache },
+      async function(index3) {
+        index3.delete({ filepath });
+      }
+    );
+  } catch (err) {
+    err.caller = "git.remove";
+    throw err;
+  }
+}
+async function _removeNote({
+  fs,
+  cache,
+  onSign,
+  gitdir,
+  ref = "refs/notes/commits",
+  oid,
+  author,
+  committer,
+  signingKey
+}) {
+  let parent;
+  try {
+    parent = await GitRefManager.resolve({ gitdir, fs, ref });
+  } catch (err) {
+    if (!(err instanceof NotFoundError)) {
+      throw err;
+    }
+  }
+  const result = await _readTree({
+    fs,
+    gitdir,
+    oid: parent || "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+  });
+  let tree = result.tree;
+  tree = tree.filter((entry) => entry.path !== oid);
+  const treeOid = await _writeTree({
+    fs,
+    gitdir,
+    tree
+  });
+  const commitOid = await _commit({
+    fs,
+    cache,
+    onSign,
+    gitdir,
+    ref,
+    tree: treeOid,
+    parent: parent && [parent],
+    message: `Note removed by 'isomorphic-git removeNote'
+`,
+    author,
+    committer,
+    signingKey
+  });
+  return commitOid;
+}
+async function removeNote({
+  fs: _fs,
+  onSign,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref = "refs/notes/commits",
+  oid,
+  author: _author,
+  committer: _committer,
+  signingKey,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("oid", oid);
+    const fs = new FileSystem(_fs);
+    const author = await normalizeAuthorObject({ fs, gitdir, author: _author });
+    if (!author) throw new MissingNameError("author");
+    const committer = await normalizeCommitterObject({
+      fs,
+      gitdir,
+      author,
+      committer: _committer
+    });
+    if (!committer) throw new MissingNameError("committer");
+    return await _removeNote({
+      fs,
+      cache,
+      onSign,
+      gitdir,
+      ref,
+      oid,
+      author,
+      committer,
+      signingKey
+    });
+  } catch (err) {
+    err.caller = "git.removeNote";
+    throw err;
+  }
+}
+async function _renameBranch({
+  fs,
+  gitdir,
+  oldref,
+  ref,
+  checkout: checkout2 = false
+}) {
+  if (ref !== import_clean_git_ref.default.clean(ref)) {
+    throw new InvalidRefNameError(ref, import_clean_git_ref.default.clean(ref));
+  }
+  if (oldref !== import_clean_git_ref.default.clean(oldref)) {
+    throw new InvalidRefNameError(oldref, import_clean_git_ref.default.clean(oldref));
+  }
+  const fulloldref = `refs/heads/${oldref}`;
+  const fullnewref = `refs/heads/${ref}`;
+  const newexist = await GitRefManager.exists({ fs, gitdir, ref: fullnewref });
+  if (newexist) {
+    throw new AlreadyExistsError("branch", ref, false);
+  }
+  const value = await GitRefManager.resolve({
+    fs,
+    gitdir,
+    ref: fulloldref,
+    depth: 1
+  });
+  await GitRefManager.writeRef({ fs, gitdir, ref: fullnewref, value });
+  await GitRefManager.deleteRef({ fs, gitdir, ref: fulloldref });
+  const fullCurrentBranchRef = await _currentBranch({
+    fs,
+    gitdir,
+    fullname: true
+  });
+  const isCurrentBranch = fullCurrentBranchRef === fulloldref;
+  if (checkout2 || isCurrentBranch) {
+    await GitRefManager.writeSymbolicRef({
+      fs,
+      gitdir,
+      ref: "HEAD",
+      value: fullnewref
+    });
+  }
+}
+async function renameBranch({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  oldref,
+  checkout: checkout2 = false
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    assertParameter("oldref", oldref);
+    return await _renameBranch({
+      fs: new FileSystem(fs),
+      gitdir,
+      ref,
+      oldref,
+      checkout: checkout2
+    });
+  } catch (err) {
+    err.caller = "git.renameBranch";
+    throw err;
+  }
+}
+async function hashObject$1({ gitdir, type, object }) {
+  return shasum(GitObject.wrap({ type, object }));
+}
+async function resetIndex({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  filepath,
+  ref,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("filepath", filepath);
+    const fs = new FileSystem(_fs);
+    let oid;
+    let workdirOid;
+    try {
+      oid = await GitRefManager.resolve({ fs, gitdir, ref: ref || "HEAD" });
+    } catch (e) {
+      if (ref) {
+        throw e;
+      }
+    }
+    if (oid) {
+      try {
+        oid = await resolveFilepath({
+          fs,
+          cache,
+          gitdir,
+          oid,
+          filepath
+        });
+      } catch (e) {
+        oid = null;
+      }
+    }
+    let stats = {
+      ctime: /* @__PURE__ */ new Date(0),
+      mtime: /* @__PURE__ */ new Date(0),
+      dev: 0,
+      ino: 0,
+      mode: 0,
+      uid: 0,
+      gid: 0,
+      size: 0
+    };
+    const object = dir && await fs.read(join(dir, filepath));
+    if (object) {
+      workdirOid = await hashObject$1({
+        gitdir,
+        type: "blob",
+        object
+      });
+      if (oid === workdirOid) {
+        stats = await fs.lstat(join(dir, filepath));
+      }
+    }
+    await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      index3.delete({ filepath });
+      if (oid) {
+        index3.insert({ filepath, stats, oid });
+      }
+    });
+  } catch (err) {
+    err.caller = "git.reset";
+    throw err;
+  }
+}
+async function resolveRef({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  depth
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    const oid = await GitRefManager.resolve({
+      fs: new FileSystem(fs),
+      gitdir,
+      ref,
+      depth
+    });
+    return oid;
+  } catch (err) {
+    err.caller = "git.resolveRef";
+    throw err;
+  }
+}
+async function setConfig({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  path,
+  value,
+  append = false
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("path", path);
+    const fs = new FileSystem(_fs);
+    const config = await GitConfigManager.get({ fs, gitdir });
+    if (append) {
+      await config.append(path, value);
+    } else {
+      await config.set(path, value);
+    }
+    await GitConfigManager.save({ fs, gitdir, config });
+  } catch (err) {
+    err.caller = "git.setConfig";
+    throw err;
+  }
+}
+async function status({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  filepath,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("filepath", filepath);
+    const fs = new FileSystem(_fs);
+    const ignored = await GitIgnoreManager.isIgnored({
+      fs,
+      gitdir,
+      dir,
+      filepath
+    });
+    if (ignored) {
+      return "ignored";
+    }
+    const headTree = await getHeadTree({ fs, cache, gitdir });
+    const treeOid = await getOidAtPath({
+      fs,
+      cache,
+      gitdir,
+      tree: headTree,
+      path: filepath
+    });
+    const indexEntry = await GitIndexManager.acquire(
+      { fs, gitdir, cache },
+      async function(index3) {
+        for (const entry of index3) {
+          if (entry.path === filepath) return entry;
+        }
+        return null;
+      }
+    );
+    const stats = await fs.lstat(join(dir, filepath));
+    const H = treeOid !== null;
+    const I = indexEntry !== null;
+    const W = stats !== null;
+    const getWorkdirOid = async () => {
+      if (I && !compareStats(indexEntry, stats)) {
+        return indexEntry.oid;
+      } else {
+        const object = await fs.read(join(dir, filepath));
+        const workdirOid = await hashObject$1({
+          gitdir,
+          type: "blob",
+          object
+        });
+        if (I && indexEntry.oid === workdirOid) {
+          if (stats.size !== -1) {
+            GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+              index3.insert({ filepath, stats, oid: workdirOid });
+            });
+          }
+        }
+        return workdirOid;
+      }
+    };
+    if (!H && !W && !I) return "absent";
+    if (!H && !W && I) return "*absent";
+    if (!H && W && !I) return "*added";
+    if (!H && W && I) {
+      const workdirOid = await getWorkdirOid();
+      return workdirOid === indexEntry.oid ? "added" : "*added";
+    }
+    if (H && !W && !I) return "deleted";
+    if (H && !W && I) {
+      return treeOid === indexEntry.oid ? "*deleted" : "*deleted";
+    }
+    if (H && W && !I) {
+      const workdirOid = await getWorkdirOid();
+      return workdirOid === treeOid ? "*undeleted" : "*undeletemodified";
+    }
+    if (H && W && I) {
+      const workdirOid = await getWorkdirOid();
+      if (workdirOid === treeOid) {
+        return workdirOid === indexEntry.oid ? "unmodified" : "*unmodified";
+      } else {
+        return workdirOid === indexEntry.oid ? "modified" : "*modified";
+      }
+    }
+  } catch (err) {
+    err.caller = "git.status";
+    throw err;
+  }
+}
+async function getOidAtPath({ fs, cache, gitdir, tree, path }) {
+  if (typeof path === "string") path = path.split("/");
+  const dirname2 = path.shift();
+  for (const entry of tree) {
+    if (entry.path === dirname2) {
+      if (path.length === 0) {
+        return entry.oid;
+      }
+      const { type, object } = await _readObject({
+        fs,
+        cache,
+        gitdir,
+        oid: entry.oid
+      });
+      if (type === "tree") {
+        const tree2 = GitTree.from(object);
+        return getOidAtPath({ fs, cache, gitdir, tree: tree2, path });
+      }
+      if (type === "blob") {
+        throw new ObjectTypeError(entry.oid, type, "blob", path.join("/"));
+      }
+    }
+  }
+  return null;
+}
+async function getHeadTree({ fs, cache, gitdir }) {
+  let oid;
+  try {
+    oid = await GitRefManager.resolve({ fs, gitdir, ref: "HEAD" });
+  } catch (e) {
+    if (e instanceof NotFoundError) {
+      return [];
+    }
+  }
+  const { tree } = await _readTree({ fs, cache, gitdir, oid });
+  return tree;
+}
+async function statusMatrix({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref = "HEAD",
+  filepaths = ["."],
+  filter,
+  cache = {},
+  ignored: shouldIgnore = false
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    const fs = new FileSystem(_fs);
+    return await _walk({
+      fs,
+      cache,
+      dir,
+      gitdir,
+      trees: [TREE({ ref }), WORKDIR(), STAGE()],
+      map: async function(filepath, [head, workdir, stage]) {
+        if (!head && !stage && workdir) {
+          if (!shouldIgnore) {
+            const isIgnored2 = await GitIgnoreManager.isIgnored({
+              fs,
+              dir,
+              filepath
+            });
+            if (isIgnored2) {
+              return null;
+            }
+          }
+        }
+        if (!filepaths.some((base) => worthWalking(filepath, base))) {
+          return null;
+        }
+        if (filter) {
+          if (!filter(filepath)) return;
+        }
+        const [headType, workdirType, stageType] = await Promise.all([
+          head && head.type(),
+          workdir && workdir.type(),
+          stage && stage.type()
+        ]);
+        const isBlob = [headType, workdirType, stageType].includes("blob");
+        if ((headType === "tree" || headType === "special") && !isBlob) return;
+        if (headType === "commit") return null;
+        if ((workdirType === "tree" || workdirType === "special") && !isBlob)
+          return;
+        if (stageType === "commit") return null;
+        if ((stageType === "tree" || stageType === "special") && !isBlob) return;
+        const headOid = headType === "blob" ? await head.oid() : void 0;
+        const stageOid = stageType === "blob" ? await stage.oid() : void 0;
+        let workdirOid;
+        if (headType !== "blob" && workdirType === "blob" && stageType !== "blob") {
+          workdirOid = "42";
+        } else if (workdirType === "blob") {
+          workdirOid = await workdir.oid();
+        }
+        const entry = [void 0, headOid, workdirOid, stageOid];
+        const result = entry.map((value) => entry.indexOf(value));
+        result.shift();
+        return [filepath, ...result];
+      }
+    });
+  } catch (err) {
+    err.caller = "git.statusMatrix";
+    throw err;
+  }
+}
+async function tag({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  object,
+  force = false
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    const fs = new FileSystem(_fs);
+    if (ref === void 0) {
+      throw new MissingParameterError("ref");
+    }
+    ref = ref.startsWith("refs/tags/") ? ref : `refs/tags/${ref}`;
+    const value = await GitRefManager.resolve({
+      fs,
+      gitdir,
+      ref: object || "HEAD"
+    });
+    if (!force && await GitRefManager.exists({ fs, gitdir, ref })) {
+      throw new AlreadyExistsError("tag", ref);
+    }
+    await GitRefManager.writeRef({ fs, gitdir, ref, value });
+  } catch (err) {
+    err.caller = "git.tag";
+    throw err;
+  }
+}
+async function updateIndex({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  cache = {},
+  filepath,
+  oid,
+  mode,
+  add: add2,
+  remove: remove2,
+  force
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("filepath", filepath);
+    const fs = new FileSystem(_fs);
+    if (remove2) {
+      return await GitIndexManager.acquire(
+        { fs, gitdir, cache },
+        async function(index3) {
+          let fileStats2;
+          if (!force) {
+            fileStats2 = await fs.lstat(join(dir, filepath));
+            if (fileStats2) {
+              if (fileStats2.isDirectory()) {
+                throw new InvalidFilepathError("directory");
+              }
+              return;
+            }
+          }
+          if (index3.has({ filepath })) {
+            index3.delete({
+              filepath
+            });
+          }
+        }
+      );
+    }
+    let fileStats;
+    if (!oid) {
+      fileStats = await fs.lstat(join(dir, filepath));
+      if (!fileStats) {
+        throw new NotFoundError(
+          `file at "${filepath}" on disk and "remove" not set`
+        );
+      }
+      if (fileStats.isDirectory()) {
+        throw new InvalidFilepathError("directory");
+      }
+    }
+    return await GitIndexManager.acquire({ fs, gitdir, cache }, async function(index3) {
+      if (!add2 && !index3.has({ filepath })) {
+        throw new NotFoundError(
+          `file at "${filepath}" in index and "add" not set`
+        );
+      }
+      let stats = {
+        ctime: /* @__PURE__ */ new Date(0),
+        mtime: /* @__PURE__ */ new Date(0),
+        dev: 0,
+        ino: 0,
+        mode,
+        uid: 0,
+        gid: 0,
+        size: 0
+      };
+      if (!oid) {
+        stats = fileStats;
+        const object = stats.isSymbolicLink() ? await fs.readlink(join(dir, filepath)) : await fs.read(join(dir, filepath));
+        oid = await _writeObject({
+          fs,
+          gitdir,
+          type: "blob",
+          format: "content",
+          object
+        });
+      }
+      index3.insert({
+        filepath,
+        oid,
+        stats
+      });
+      return oid;
+    });
+  } catch (err) {
+    err.caller = "git.updateIndex";
+    throw err;
+  }
+}
+function version() {
+  try {
+    return pkg.version;
+  } catch (err) {
+    err.caller = "git.version";
+    throw err;
+  }
+}
+async function walk({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  trees,
+  map,
+  reduce,
+  iterate,
+  cache = {}
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("trees", trees);
+    return await _walk({
+      fs: new FileSystem(fs),
+      cache,
+      dir,
+      gitdir,
+      trees,
+      map,
+      reduce,
+      iterate
+    });
+  } catch (err) {
+    err.caller = "git.walk";
+    throw err;
+  }
+}
+async function writeBlob({ fs, dir, gitdir = join(dir, ".git"), blob }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("blob", blob);
+    return await _writeObject({
+      fs: new FileSystem(fs),
+      gitdir,
+      type: "blob",
+      object: blob,
+      format: "content"
+    });
+  } catch (err) {
+    err.caller = "git.writeBlob";
+    throw err;
+  }
+}
+async function _writeCommit({ fs, gitdir, commit: commit2 }) {
+  const object = GitCommit.from(commit2).toObject();
+  const oid = await _writeObject({
+    fs,
+    gitdir,
+    type: "commit",
+    object,
+    format: "content"
+  });
+  return oid;
+}
+async function writeCommit({
+  fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  commit: commit2
+}) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("commit", commit2);
+    return await _writeCommit({
+      fs: new FileSystem(fs),
+      gitdir,
+      commit: commit2
+    });
+  } catch (err) {
+    err.caller = "git.writeCommit";
+    throw err;
+  }
+}
+async function writeObject({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  type,
+  object,
+  format = "parsed",
+  oid,
+  encoding = void 0
+}) {
+  try {
+    const fs = new FileSystem(_fs);
+    if (format === "parsed") {
+      switch (type) {
+        case "commit":
+          object = GitCommit.from(object).toObject();
+          break;
+        case "tree":
+          object = GitTree.from(object).toObject();
+          break;
+        case "blob":
+          object = import_buffer.Buffer.from(object, encoding);
+          break;
+        case "tag":
+          object = GitAnnotatedTag.from(object).toObject();
+          break;
+        default:
+          throw new ObjectTypeError(oid || "", type, "blob|commit|tag|tree");
+      }
+      format = "content";
+    }
+    oid = await _writeObject({
+      fs,
+      gitdir,
+      type,
+      object,
+      oid,
+      format
+    });
+    return oid;
+  } catch (err) {
+    err.caller = "git.writeObject";
+    throw err;
+  }
+}
+async function writeRef({
+  fs: _fs,
+  dir,
+  gitdir = join(dir, ".git"),
+  ref,
+  value,
+  force = false,
+  symbolic = false
+}) {
+  try {
+    assertParameter("fs", _fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("ref", ref);
+    assertParameter("value", value);
+    const fs = new FileSystem(_fs);
+    if (ref !== import_clean_git_ref.default.clean(ref)) {
+      throw new InvalidRefNameError(ref, import_clean_git_ref.default.clean(ref));
+    }
+    if (!force && await GitRefManager.exists({ fs, gitdir, ref })) {
+      throw new AlreadyExistsError("ref", ref);
+    }
+    if (symbolic) {
+      await GitRefManager.writeSymbolicRef({
+        fs,
+        gitdir,
+        ref,
+        value
+      });
+    } else {
+      value = await GitRefManager.resolve({
+        fs,
+        gitdir,
+        ref: value
+      });
+      await GitRefManager.writeRef({
+        fs,
+        gitdir,
+        ref,
+        value
+      });
+    }
+  } catch (err) {
+    err.caller = "git.writeRef";
+    throw err;
+  }
+}
+async function _writeTag({ fs, gitdir, tag: tag2 }) {
+  const object = GitAnnotatedTag.from(tag2).toObject();
+  const oid = await _writeObject({
+    fs,
+    gitdir,
+    type: "tag",
+    object,
+    format: "content"
+  });
+  return oid;
+}
+async function writeTag({ fs, dir, gitdir = join(dir, ".git"), tag: tag2 }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("tag", tag2);
+    return await _writeTag({
+      fs: new FileSystem(fs),
+      gitdir,
+      tag: tag2
+    });
+  } catch (err) {
+    err.caller = "git.writeTag";
+    throw err;
+  }
+}
+async function writeTree({ fs, dir, gitdir = join(dir, ".git"), tree }) {
+  try {
+    assertParameter("fs", fs);
+    assertParameter("gitdir", gitdir);
+    assertParameter("tree", tree);
+    return await _writeTree({
+      fs: new FileSystem(fs),
+      gitdir,
+      tree
+    });
+  } catch (err) {
+    err.caller = "git.writeTree";
+    throw err;
+  }
+}
+var index = {
+  Errors,
+  STAGE,
+  TREE,
+  WORKDIR,
+  add,
+  abortMerge,
+  addNote,
+  addRemote,
+  annotatedTag,
+  branch,
+  checkout,
+  clone,
+  commit,
+  getConfig,
+  getConfigAll,
+  setConfig,
+  currentBranch,
+  deleteBranch,
+  deleteRef,
+  deleteRemote,
+  deleteTag,
+  expandOid,
+  expandRef,
+  fastForward,
+  fetch: fetch2,
+  findMergeBase,
+  findRoot,
+  getRemoteInfo,
+  getRemoteInfo2,
+  hashBlob,
+  indexPack,
+  init,
+  isDescendent,
+  isIgnored,
+  listBranches,
+  listFiles,
+  listNotes,
+  listRemotes,
+  listServerRefs,
+  listTags,
+  log,
+  merge,
+  packObjects,
+  pull,
+  push,
+  readBlob,
+  readCommit,
+  readNote,
+  readObject,
+  readTag,
+  readTree,
+  remove,
+  removeNote,
+  renameBranch,
+  resetIndex,
+  updateIndex,
+  resolveRef,
+  status,
+  statusMatrix,
+  tag,
+  version,
+  walk,
+  writeBlob,
+  writeCommit,
+  writeObject,
+  writeRef,
+  writeTag,
+  writeTree
+};
+var isomorphic_git_default = index;
+
+// node_modules/isomorphic-git/http/web/index.js
+init_bufinject();
+function fromValue2(value) {
+  let queue = [value];
+  return {
+    next() {
+      return Promise.resolve({ done: queue.length === 0, value: queue.pop() });
+    },
+    return() {
+      queue = [];
+      return {};
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    }
+  };
+}
+function getIterator2(iterable) {
+  if (iterable[Symbol.asyncIterator]) {
+    return iterable[Symbol.asyncIterator]();
+  }
+  if (iterable[Symbol.iterator]) {
+    return iterable[Symbol.iterator]();
+  }
+  if (iterable.next) {
+    return iterable;
+  }
+  return fromValue2(iterable);
+}
+async function forAwait2(iterable, cb) {
+  const iter = getIterator2(iterable);
+  while (true) {
+    const { value, done } = await iter.next();
+    if (value) await cb(value);
+    if (done) break;
+  }
+  if (iter.return) iter.return();
+}
+async function collect2(iterable) {
+  let size = 0;
+  const buffers = [];
+  await forAwait2(iterable, (value) => {
+    buffers.push(value);
+    size += value.byteLength;
+  });
+  const result = new Uint8Array(size);
+  let nextIndex = 0;
+  for (const buffer of buffers) {
+    result.set(buffer, nextIndex);
+    nextIndex += buffer.byteLength;
+  }
+  return result;
+}
+function fromStream(stream) {
+  if (stream[Symbol.asyncIterator]) return stream;
+  const reader = stream.getReader();
+  return {
+    next() {
+      return reader.read();
+    },
+    return() {
+      reader.releaseLock();
+      return {};
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    }
+  };
+}
+async function request({
+  onProgress,
+  url,
+  method = "GET",
+  headers = {},
+  body
+}) {
+  if (body) {
+    body = await collect2(body);
+  }
+  const res = await fetch(url, { method, headers, body });
+  const iter = res.body && res.body.getReader ? fromStream(res.body) : [new Uint8Array(await res.arrayBuffer())];
+  headers = {};
+  for (const [key, value] of res.headers.entries()) {
+    headers[key] = value;
+  }
+  return {
+    url: res.url,
+    method: res.method,
+    statusCode: res.status,
+    statusMessage: res.statusText,
+    body: iter,
+    headers
+  };
+}
+var index2 = { request };
+var web_default = index2;
+export {
+  isomorphic_git_default as git,
+  web_default as http
+};
+/*! Bundled license information:
+
+ieee754/index.js:
+  (*! ieee754. BSD-3-Clause License. Feross Aboukhadijeh <https://feross.org/opensource> *)
+
+buffer/index.js:
+  (*!
+   * The buffer module from node.js, for the browser.
+   *
+   * @author   Feross Aboukhadijeh <https://feross.org>
+   * @license  MIT
+   *)
+
+safe-buffer/index.js:
+  (*! safe-buffer. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> *)
+
+crc-32/crc32.js:
+  (*! crc32.js (C) 2014-present SheetJS -- http://sheetjs.com *)
+*/


### PR DESCRIPTION
## Summary

This PR adds Node.js filesystem API compatibility to the sandbox `fs` object, enabling libraries like `isomorphic-git` that expect a Node `fs`/`fs.promises` interface to work directly with the sandbox filesystem.

## Key Changes

- **New filesystem operations:**
  - `fs.lstat(path)` — stat without following final symlinks
  - `fs.readlink(path)` — read symlink targets
  - `fs.symlink(target, path)` — create symbolic links (Unix only)

- **Node.js compatibility surface:**
  - Added `fs.promises` as an enumerable own property exposing all async methods (`readFile`, `writeFile`, `mkdir`, `rmdir`, `unlink`, `stat`, `lstat`, `readdir`, `readlink`, `symlink`, etc.)
  - `fs.promises.readFile` now follows Node semantics: returns `Uint8Array` by default, string only when a text encoding is given
  - `fs.stat` and `fs.lstat` now return a Node `fs.Stats`-like object with `isFile()`, `isDirectory()`, `isSymbolicLink()` predicate methods (changed from boolean properties)
  - Error rejections now carry a Node-style `code` field (e.g., `ENOENT`, `EEXIST`, `EACCES`) extracted from error messages

- **Error handling improvements:**
  - Introduced `io_err()` and `io_err2()` helper functions to standardize error message formatting with embedded error codes
  - Error codes are parsed from Rust I/O errors and embedded in messages for JavaScript extraction

- **Overlay/mount support:**
  - Extended `SessionMount` with `symlink()` and `readlink()` methods for snapshot filesystem operations
  - Symlinks stored as entries with `mode: 0o120777` and target path in content

- **Documentation:**
  - Updated API reference with new methods and Node compatibility details
  - Added comprehensive test suite (`fs_node_compat.rs`) validating Node-style behavior
  - Updated README and how-to guides with symlink examples

## Implementation Details

- The JavaScript wrapper now uses a centralized `call()` function that tags errors with Node-style codes by regex-matching known error tokens (`ENOENT`, `EEXIST`, etc.)
- `Stats` objects are constructed with both data fields and predicate methods to match Node's `fs.Stats` interface
- Symlink support is platform-conditional: Unix systems use `tokio::fs::symlink`, other platforms return `ENOSYS`
- The `fs.promises` namespace is created as a non-enumerable-by-default object that becomes enumerable through property descriptor manipulation, ensuring library detection works
- Full hardening (frozen `Deno.core.ops`) is compatible with the new surface since frozen objects remain callable

https://claude.ai/code/session_01AyTiBDGVi7e2KU2DNUvtwt