### PR TITLE
feat: add Streamable HTTP client transport for downstream MCP servers

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -333,15 +333,17 @@ pub struct Cli {
 
     /// Connect to an external MCP server as a module. JS code can call its tools
     /// via the `mcp` global object (mcp.callTool, mcp.listTools, mcp.servers).
-    /// Format for stdio: name=stdio:command:arg1:arg2
-    /// Format for SSE:   name=sse:url
+    /// Format for stdio:          name=stdio:command:arg1:arg2
+    /// Format for SSE:            name=sse:url
+    /// Format for Streamable HTTP: name=http:url
     /// Can be specified multiple times for multiple servers.
     #[arg(long = "mcp-server", value_name = "NAME=TRANSPORT:...", help_heading = "MCP Server Module")]
     pub mcp_servers: Vec<String>,
 
     /// Path to a JSON config file for MCP server modules.
     /// Format: [{"name": "srv", "transport": "stdio", "command": "cmd", "args": ["a"]},
-    ///          {"name": "srv2", "transport": "sse", "url": "http://..."}]
+    ///          {"name": "srv2", "transport": "sse", "url": "http://..."},
+    ///          {"name": "srv3", "transport": "http", "url": "https://..."}]
     #[arg(long = "mcp-config", env = "MCP_V8_MCP_CONFIG", value_name = "PATH", help_heading = "MCP Server Module")]
     pub mcp_config: Option<String>,
 

--- a/server/src/engine/mcp_client.rs
+++ b/server/src/engine/mcp_client.rs
@@ -44,6 +44,9 @@ pub enum McpServerTransport {
     Sse {
         url: String,
     },
+    Http {
+        url: String,
+    },
 }
 
 /// Configuration for a single named MCP server.
@@ -560,6 +563,33 @@ async fn connect_one(config: &McpServerConfig) -> Result<ConnectedMcpServer, Str
             // The standalone SSE client transport was removed in rmcp 1.x; the
             // Streamable HTTP client transport is its replacement and speaks to
             // the same `/mcp`-style endpoints modern MCP servers expose.
+            let transport = rmcp::transport::StreamableHttpClientTransport::from_uri(url.clone());
+
+            let service: rmcp::service::RunningService<RoleClient, ()> =
+                ().serve(transport)
+                    .await
+                    .map_err(|e| format!("MCP client handshake with '{}' failed: {}", config.name, e))?;
+
+            let peer = service.peer().clone();
+            let tools = peer
+                .list_all_tools()
+                .await
+                .map_err(|e| format!("Failed to list tools from '{}': {}", config.name, e))?;
+
+            let keep_alive = tokio::spawn(async move {
+                let _ = service.waiting().await;
+            });
+
+            Ok(ConnectedMcpServer {
+                peer,
+                tools,
+                _keep_alive: keep_alive.abort_handle(),
+            })
+        }
+        McpServerTransport::Http { url } => {
+            // Streamable HTTP transport (MCP spec 2025-03-26+). Uses the same
+            // rmcp StreamableHttpClientTransport as the legacy `sse` variant but
+            // with a name that matches the current MCP specification terminology.
             let transport = rmcp::transport::StreamableHttpClientTransport::from_uri(url.clone());
 
             let service: rmcp::service::RunningService<RoleClient, ()> =

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1211,9 +1211,16 @@ fn load_mcp_server_configs(
                     url: url.to_string(),
                 },
             });
+        } else if let Some(url) = rest.strip_prefix("http:") {
+            configs.push(McpServerConfig {
+                name,
+                transport: McpServerTransport::Http {
+                    url: url.to_string(),
+                },
+            });
         } else {
             anyhow::bail!(
-                "Invalid --mcp-server transport for '{}': must start with 'stdio:' or 'sse:'. Got: '{}'",
+                "Invalid --mcp-server transport for '{}': must start with 'stdio:', 'sse:', or 'http:'. Got: '{}'",
                 name, rest
             );
         }


### PR DESCRIPTION
## Summary

- Adds `Http { url }` variant to the `McpServerTransport` enum alongside existing `Stdio` and `Sse`
- Implements the `connect_one()` match arm using `rmcp::transport::StreamableHttpClientTransport::from_uri()` — the same underlying client the `sse` variant already uses, but with proper naming per the MCP 2025-03-26 specification
- Adds CLI parsing for `--mcp-server name=http:https://example.com/mcp` format
- Adds serde deserialization support for JSON config: `{"name": "srv", "transport": "http", "url": "https://..."}`
- Fully backwards compatible: the existing `sse` transport continues to work unchanged

## Context

The MCP specification (2025-03-26+) defines "Streamable HTTP" as the standard HTTP-based transport. The existing `sse` variant in MCPJS already uses rmcp's `StreamableHttpClientTransport` internally, but is confusingly named after the deprecated SSE transport. This PR adds a properly-named `http` variant so users can use the canonical transport name going forward, while `sse` remains as a backwards-compatible alias.

## Test plan

- [ ] Verify `cargo check` passes (enum variant exhaustiveness, serde derive)
- [ ] Test CLI parsing: `--mcp-server test=http:http://localhost:9000/mcp`
- [ ] Test JSON config: `[{"name": "test", "transport": "http", "url": "http://localhost:9000/mcp"}]`
- [ ] Verify existing `sse` transport still works unchanged
- [ ] Verify error message includes `http:` in the list of valid transports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Rys6MZbgtzFrz7X6mZtwn